### PR TITLE
feat: add native GitHub reactions

### DIFF
--- a/.cairn/items/github-web-parity.md
+++ b/.cairn/items/github-web-parity.md
@@ -361,19 +361,43 @@ SHA confirmation. The focused `GitHubCodeMutationClient` owns normalization, per
 repository guards, conflict mapping, Git transport, response verification, and tests. The Code UI
 reuses the existing overview, Markdown editor, Shiki preview, shadcn dialogs, toasts, and query roots;
 workflow-file scope requirements and protected/default-branch failures remain explicit.
+Issues, pull requests, review summaries, inline review comments, Discussions, nested Discussion
+replies, and Releases now share one native GitHub Reactions workflow. The focused
+`GitHubReactionClient` uses GitHub's `Reactable` GraphQL contract, keeps global node IDs opaque,
+verifies exact subject kind and repository ownership, batches reads at 100 nodes, and applies
+idempotent desired-state writes with authoritative response checks. Release choices are limited to
+their documented six values while other supported subjects expose all eight. The shared TanStack
+Query provider batches each visible conversation, serializes mutations, cancels stale reads before
+optimistic updates, rolls back on failure, and replaces every cached copy with GitHub's returned
+groups. Discussion upvotes remain a separate GitHub capability instead of being conflated with
+thumbs-up reactions.
 The workspace shell is responsive, starts at 1600x1000, and remains usable down to 900x620.
 
 ## Next action
 
-Complete the remaining deterministic desktop checks for repository file rename, file deletion, and
-the 900x620 layout, then audit the next missing personal-developer GitHub Web workflow. Keep
-organization administration, Enterprise controls, and advanced organization security out of scope.
+Complete the remaining deterministic desktop checks for repository file rename and deletion, then
+audit and implement the next missing personal-developer GitHub Web workflow. Keep organization
+administration, Enterprise controls, and advanced organization security out of scope.
 
 ## Verification
 
 Each GitHub parity slice must use real API data, cover loading/empty/error/permission states, preserve
 repository context and navigation, and complete its primary path without forcing a browser fallback.
 Run `pnpm check`, the Rust check suite when Rust changes, and a focused desktop interaction check.
+
+GitHub Reactions verification covers current official GraphQL schema fields, eight supported
+Reactable kinds, opaque node IDs, selected-repository guards, Release vocabulary restrictions,
+nullable and sparse groups, duplicate and inconsistent response rejection, saved-credential
+delegation, desired-state IPC arguments, 100-node batching, canonical cache replacement, optimistic
+add/remove, rollback support, and mutation serialization. `pnpm check` passes with 129 frontend
+tests; 228 Rust tests pass with one external DeepWiki test ignored by design; `cargo fmt`, `cargo
+check`, the production build, `git diff --check`, and Clippy pass with the same 11 pre-existing
+warnings and no new warning. A deterministic Playwright fixture verified Issue and pull request
+bodies, conversation comments, review summaries, inline review comments, Discussions, nested
+replies, Releases, separate Discussion upvotes, exact batch and mutation arguments, and six-versus-
+eight choice menus. At 900x620 and 1600x1000 the document dimensions equal the viewport; the browser
+console reports zero errors and zero warnings. Screenshots and the reusable fixture stay ignored
+under `output/playwright/`.
 
 Repository Code mutation verification covers exact Tauri contracts, atomic rename payloads, stale
 file and branch guards, Git-compatible branch validation, empty-repository initialization, stable
@@ -864,6 +888,11 @@ page-level overflow, and the browser reports zero errors and zero warnings.
   administration, Enterprise identity and policy, organization billing, and organization advanced
   security. Keep an explicit GitHub Web fallback for sensitive or browser-only account operations
   that GitHub does not expose to an OAuth desktop client; do not fake them with local state.
+- Keep reactions behind one `GitHubReactionClient` and GitHub's shared `Reactable` GraphQL contract.
+  Require the caller's exact closed subject kind, compare every node to the selected repository ID,
+  and use read-before-write desired state so retries are idempotent. Batch visible subjects through
+  `nodes(ids:)`, use `reactors.totalCount`, retain Discussion upvotes separately, and restrict
+  Releases to their documented six reaction values.
 - Keep discovery behind `GitHubDiscoveryClient`. Preserve raw GitHub search syntax as GitHub CLI
   does, but own tab result discriminators, kind-valid sorts, and the 1,000-result boundary. Surface
   `incomplete_results` rather than implying the result set is complete. Use authenticated

--- a/.cairn/items/github-web-parity.md
+++ b/.cairn/items/github-web-parity.md
@@ -371,6 +371,8 @@ Query provider batches each visible conversation, serializes mutations, cancels 
 optimistic updates, rolls back on failure, and replaces every cached copy with GitHub's returned
 groups. Discussion upvotes remain a separate GitHub capability instead of being conflated with
 thumbs-up reactions.
+The completed Reactions slice is open and mergeable in
+[PR #4](https://github.com/Excelius-Wang/harbor/pull/4) from `feat/github-reactions`.
 The workspace shell is responsive, starts at 1600x1000, and remains usable down to 900x620.
 
 ## Next action

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ node_modules
 dist
 dist-ssr
 *.local
+*.tsbuildinfo
+vite.config.js
+vite.config.d.ts
 
 # Editor directories and files
 .vscode/*
@@ -25,3 +28,7 @@ dist-ssr
 
 # Claude AI
 .claude/
+
+# Local browser QA artifacts
+.playwright-cli/
+output/playwright/

--- a/docs/GITHUB_REACTIONS_RESEARCH.md
+++ b/docs/GITHUB_REACTIONS_RESEARCH.md
@@ -1,0 +1,503 @@
+# GitHub Reactions Research
+
+Research date: 2026-08-29. This note uses only current GitHub documentation and first-party
+`github/cli` source. It covers Harbor's existing personal-developer surfaces: Issues, pull request
+conversation and review comments, Discussions, and Releases. Commit comments, Team discussions,
+organization administration, and Enterprise administration are intentionally out of scope.
+
+## Recommendation
+
+Implement one native GraphQL reaction boundary around GitHub's `Reactable` interface. It is the only
+documented API surface that covers every Harbor target, including pull request review summaries and
+repository Discussions. It also returns the two pieces REST summaries cannot provide directly:
+`viewerCanReact` and `viewerHasReacted`. The interface currently covers `Issue`, `IssueComment`,
+`PullRequest`, `PullRequestReview`, `PullRequestReviewComment`, `Discussion`, `DiscussionComment`,
+`Release`, and `CommitComment`; Harbor should accept the first eight and explicitly reject
+`CommitComment` until it has a native commit-comment surface. The complete schema contract is in the
+[official GraphQL Reactions reference](https://docs.github.com/en/graphql/reference/reactions).
+
+Use a read-before-write, desired-state operation rather than a blind toggle:
+
+1. Resolve the selected repository and reaction subject in one query.
+2. Verify repository node ID, exact `__typename`, `viewerCanReact`, and current viewer state.
+3. Return immediately if the requested state is already authoritative.
+4. Otherwise call `addReaction` or `removeReaction` and verify the returned subject ID, type, and
+   requested `viewerHasReacted` state.
+5. Replace optimistic data with the mutation's complete authoritative `reactionGroups` result.
+
+This keeps the WebView from choosing API routes, prevents a global node ID from escaping the selected
+repository, makes retries idempotent at Harbor's Service boundary, and fits the project's existing
+Tauri, GitHub client, TanStack Query, and shadcn architecture.
+
+## Exact subject map
+
+| Harbor surface                                      | GraphQL subject            | Repository-scope field             | REST alternative                                                                          |
+| --------------------------------------------------- | -------------------------- | ---------------------------------- | ----------------------------------------------------------------------------------------- |
+| Issue body                                          | `Issue`                    | `repository { id }`                | `/repos/{owner}/{repo}/issues/{issue_number}/reactions`                                   |
+| Pull request body                                   | `PullRequest`              | `repository { id }`                | The same Issues route; GitHub models every pull request as an issue for shared operations |
+| Issue or ordinary pull request conversation comment | `IssueComment`             | `repository { id }`                | `/repos/{owner}/{repo}/issues/comments/{comment_id}/reactions`                            |
+| Submitted pull request review summary               | `PullRequestReview`        | `repository { id }`                | None documented                                                                           |
+| Inline pull request review comment or reply         | `PullRequestReviewComment` | `repository { id }`                | `/repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions`                             |
+| Discussion body                                     | `Discussion`               | `repository { id }`                | None documented                                                                           |
+| Discussion top-level comment or nested reply        | `DiscussionComment`        | `discussion { repository { id } }` | None documented                                                                           |
+| Release body                                        | `Release`                  | `repository { id }`                | `/repos/{owner}/{repo}/releases/{release_id}/reactions`                                   |
+
+The GraphQL reference lists all of these concrete types as implementations of `Reactable`.
+`IssueComment` exposes both `issue` and a nullable `pullRequest`, so the same type correctly represents
+ordinary comments in either conversation. `DiscussionComment` is the exception to the direct
+repository-field pattern: its `discussion` is nullable, so a missing discussion or repository must
+fail closed. See the official object references for
+[Issues](https://docs.github.com/en/graphql/reference/issues#issuecomment),
+[Pull requests](https://docs.github.com/en/graphql/reference/pulls),
+[Discussions](https://docs.github.com/en/graphql/reference/discussions#discussioncomment), and
+[Releases](https://docs.github.com/en/graphql/reference/releases).
+
+GitHub documents ordinary Issue and pull request comments together, while distinguishing pull request
+review comments, in its [REST Issue comments reference](https://docs.github.com/en/rest/issues/comments).
+The REST reaction catalog contains routes for Issues, Issue comments, pull request review comments,
+and Releases, but no routes for `PullRequestReview`, `Discussion`, or `DiscussionComment`.
+[GitHub's REST Reactions reference](https://docs.github.com/en/rest/reactions/reactions?apiVersion=2026-03-10)
+is therefore useful as a compatibility and error-semantics reference, not as Harbor's shared
+implementation boundary.
+
+### Review and Discussion distinctions
+
+- A pull request body is `PullRequest`, an ordinary conversation comment is `IssueComment`, a review
+  summary is `PullRequestReview`, and an inline thread entry is `PullRequestReviewComment`. A review
+  thread itself is not `Reactable`; render controls on each comment in the thread.
+- Pending inline comments still have `PullRequestReviewComment` nodes. Do not infer that a pending,
+  outdated, resolved, minimized, locked, open, or closed object can accept reactions; render the
+  authoritative `viewerCanReact` state.
+- A Discussion upvote is not a thumbs-up reaction. `Discussion` and `DiscussionComment` independently
+  implement `Votable` and `Reactable`; retain Harbor's existing `addUpvote`/`removeUpvote` control and
+  add a separate reaction bar. The distinct mutations and interfaces are documented in the
+  [GraphQL Discussions reference](https://docs.github.com/en/graphql/reference/discussions).
+
+## Vocabulary and wire mapping
+
+For Issues, pull requests, reviews, and comments, GitHub supports eight values. REST and GraphQL use
+different spellings; the emoji mapping below also matches the first-party GitHub CLI implementation
+in [`api/reaction_groups.go`](https://github.com/cli/cli/blob/40b742f76d68e6b1f472942a6368db4b5d765641/api/reaction_groups.go#L33-L59).
+
+| Harbor enum  | GraphQL `ReactionContent` | REST `content` | UI glyph |
+| ------------ | ------------------------- | -------------- | -------- |
+| `ThumbsUp`   | `THUMBS_UP`               | `+1`           | 👍       |
+| `ThumbsDown` | `THUMBS_DOWN`             | `-1`           | 👎       |
+| `Laugh`      | `LAUGH`                   | `laugh`        | 😄       |
+| `Hooray`     | `HOORAY`                  | `hooray`       | 🎉       |
+| `Confused`   | `CONFUSED`                | `confused`     | 😕       |
+| `Heart`      | `HEART`                   | `heart`        | ❤️       |
+| `Rocket`     | `ROCKET`                  | `rocket`       | 🚀       |
+| `Eyes`       | `EYES`                    | `eyes`         | 👀       |
+
+`Release` is a deliberate exception. Its official REST contract accepts only `+1`, `laugh`, `heart`,
+`hooray`, `rocket`, and `eyes`; `-1` and `confused` are not allowed. Although GraphQL uses the shared
+`ReactionContent` enum, the enum cannot express this subject-specific restriction. Harbor should
+therefore expose six choices for `Release` and reject the other two in Rust before making a mutation.
+The per-route vocabulary is documented in the
+[REST Reactions reference](https://docs.github.com/en/rest/reactions/reactions?apiVersion=2026-03-10).
+
+Treat the order above as Harbor presentation policy, not an API invariant. Map groups by enum value,
+accept a nullable or sparse `reactionGroups` list, and treat a missing content as count zero with
+`viewerHasReacted = false`. Do not parse a node ID prefix to derive its type. GitHub explicitly says
+global node IDs are opaque, supports more than one ID format, and warns that prefix decoding will
+break; use `__typename` instead.
+[GitHub's node ID migration guide](https://docs.github.com/en/graphql/guides/migrating-graphql-global-node-ids)
+owns that guarantee.
+
+## Counts, viewer state, and identities
+
+The minimal authoritative group selection is:
+
+```graphql
+reactionGroups {
+  content
+  viewerHasReacted
+  reactors { totalCount }
+}
+```
+
+`ReactionGroup.viewerHasReacted` is the authenticated viewer's membership in that content group.
+`reactors.totalCount` is the complete count for the group. Use `reactors`, not the deprecated
+`users`: a reactor can be a `User`, `Bot`, `Mannequin`, or `Organization`, whereas `users` excludes
+those additional actor kinds. `Reactable.viewerCanReact` is the authoritative write capability.
+The schema also exposes a paginated `reactions(content:, orderBy:)` connection and individual
+`Reaction` nodes with `id`, nullable `databaseId`, `content`, `createdAt`, and `user`, but Harbor does
+not need them for a count-and-toggle UI. These semantics and nullabilities are in the
+[GraphQL Reactions reference](https://docs.github.com/en/graphql/reference/reactions).
+
+The first-party GitHub CLI currently reads reaction groups on Issue comments and review summaries,
+then renders nonzero groups. See
+[`api/query_builder.go`](https://github.com/cli/cli/blob/40b742f76d68e6b1f472942a6368db4b5d765641/api/query_builder.go#L42-L59),
+[`api/queries_pr_review.go`](https://github.com/cli/cli/blob/40b742f76d68e6b1f472942a6368db4b5d765641/api/queries_pr_review.go#L38-L46), and
+[`pkg/cmd/pr/shared/reaction_groups.go`](https://github.com/cli/cli/blob/40b742f76d68e6b1f472942a6368db4b5d765641/pkg/cmd/pr/shared/reaction_groups.go#L10-L32).
+Its current query still selects deprecated `users.totalCount` and does not select viewer state, so it
+is evidence for surface coverage and emoji presentation, not a contract Harbor should copy. The CLI's
+Discussion client likewise maps reaction groups on the post, comments, and replies in
+[`pkg/cmd/discussion/client/client.go`](https://github.com/cli/cli/blob/40b742f76d68e6b1f472942a6368db4b5d765641/pkg/cmd/discussion/client/client.go#L447-L523).
+
+### Delete identity
+
+REST delete routes require the numeric `reaction_id` in addition to repository and subject identity.
+A count summary is insufficient: Harbor would have to list reactions, paginate, find the current
+viewer and content, retain that exact reaction ID, and then call `DELETE .../reactions/{reaction_id}`.
+The REST create response returns the reaction object; a duplicate create returns the existing one.
+These route and response requirements are specified in the
+[REST Reactions reference](https://docs.github.com/en/rest/reactions/reactions?apiVersion=2026-03-10).
+
+GraphQL removal instead takes exactly `subjectId: ID!` and `content: ReactionContent!`. Because the
+input contains no actor or reaction ID, it operates on the authenticated viewer's reaction for that
+subject and content; this is the only possible actor identity represented by the contract. The
+mutation returns the removed `reaction`, updated `reactionGroups`, and `subject`. This follows from
+the official [`RemoveReactionInput` and payload](https://docs.github.com/en/graphql/reference/reactions#removereaction).
+Harbor should still read first and skip removal when `viewerHasReacted` is already false, because the
+reference does not promise a special idempotent response for an absent reaction.
+
+## Read and mutation contracts
+
+### Scoped batch read
+
+Existing Harbor REST models already preserve global `node_id` values for Issue bodies, pull request
+bodies, ordinary comments, and review timeline events; review-thread comments and Discussions already
+use GraphQL IDs. Release and review models should preserve their GraphQL node IDs as well. GitHub
+documents that a REST `node_id` and GraphQL `id` identify the same object and recommends persisting
+the global ID for API interoperability in
+[Using global node IDs](https://docs.github.com/en/graphql/guides/using-global-node-ids).
+
+Hydrate the subjects already present on one parent page in a single bounded `nodes(ids:)` query. The
+query shape below was checked against GitHub's current API schema; GitHub publishes that schema and
+supports direct introspection from the API on its
+[Public schema page](https://docs.github.com/en/graphql/overview/public-schema). The query must also
+resolve the selected repository so the comparison uses node identity, not a mutable name:
+
+```graphql
+query HarborReactionSubjects($owner: String!, $repository: String!, $ids: [ID!]!) {
+  selected: repository(owner: $owner, name: $repository) {
+    id
+  }
+  nodes(ids: $ids) {
+    __typename
+    ... on Reactable {
+      id
+      viewerCanReact
+      reactionGroups {
+        content
+        viewerHasReacted
+        reactors {
+          totalCount
+        }
+      }
+    }
+    ... on Issue {
+      repository {
+        id
+      }
+    }
+    ... on IssueComment {
+      repository {
+        id
+      }
+    }
+    ... on PullRequest {
+      repository {
+        id
+      }
+    }
+    ... on PullRequestReview {
+      repository {
+        id
+      }
+    }
+    ... on PullRequestReviewComment {
+      repository {
+        id
+      }
+    }
+    ... on Discussion {
+      repository {
+        id
+      }
+    }
+    ... on DiscussionComment {
+      discussion {
+        repository {
+          id
+        }
+      }
+    }
+    ... on Release {
+      repository {
+        id
+      }
+    }
+  }
+}
+```
+
+For every requested subject, require all of the following before exposing it to a write command:
+
+- the returned node is non-null and implements `Reactable`;
+- `__typename` exactly matches the caller's closed `ReactionSubjectKind`;
+- the type is one of Harbor's eight supported kinds, not merely any `Reactable` implementation;
+- its repository node ID equals `selected.id`;
+- a `DiscussionComment` has a non-null `discussion.repository`;
+- the returned `id` is retained as an opaque string and matches the requested node ID.
+
+Reject the entire write preflight on a missing repository, missing subject, type mismatch, or
+repository mismatch. For a batch read, returning per-subject absence is acceptable for objects that
+were deleted between parent and reaction requests, but it must not silently authorize a mutation.
+
+### Desired-state mutation
+
+Use the official generic inputs and return the whole updated group snapshot:
+
+```graphql
+mutation HarborAddReaction($subjectId: ID!, $content: ReactionContent!) {
+  addReaction(input: { subjectId: $subjectId, content: $content }) {
+    subject {
+      __typename
+      id
+      viewerCanReact
+    }
+    reactionGroups {
+      content
+      viewerHasReacted
+      reactors {
+        totalCount
+      }
+    }
+  }
+}
+```
+
+`removeReaction` has the same shape with `RemoveReactionInput`. `addReaction` and `removeReaction`,
+their required inputs, and nullable payload fields are defined in the
+[GraphQL Reactions reference](https://docs.github.com/en/graphql/reference/reactions).
+
+After either mutation, reject a null payload or subject, GraphQL `errors`, a different subject ID or
+type, duplicate/unknown groups, an impossible `viewerHasReacted = true` with count zero, or a returned
+viewer state different from the requested desired state. Do not mistake HTTP 200 for GraphQL success:
+GitHub can return HTTP 200 with an error for primary and secondary rate limits, and resource-limited
+queries can return partial data plus errors.
+[GitHub's GraphQL rate and query limits](https://docs.github.com/en/graphql/overview/rate-limits-and-query-limits-for-the-graphql-api)
+document both behaviors.
+
+## Authentication, headers, and permissions
+
+Harbor's existing OAuth `repo` scope is sufficient for public and private repository reaction reads
+and writes, subject to the signed-in user's own repository access. A public-only client can request
+`public_repo`. Scopes limit a token but do not add permissions the user does not possess. GitHub's
+[OAuth scope reference](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/scopes-for-oauth-apps)
+documents those semantics, and its
+[Discussions GraphQL guide](https://docs.github.com/en/graphql/guides/using-the-graphql-api-for-discussions)
+explicitly requires `repo` for private repositories or `public_repo` for public repositories. No
+organization or administrative scope is needed for this slice.
+
+For GraphQL, send the OAuth token as `Authorization: Bearer TOKEN` to
+`https://api.github.com/graphql`; the GraphQL API is not selected with a REST version header. GitHub's
+[GraphQL client guide](https://docs.github.com/en/graphql/guides/using-graphql-clients) documents the
+endpoint and header. Always honor `viewerCanReact`; neither the OAuth scope nor a successful read
+proves that the current subject is writable.
+
+If Harbor ever uses the REST fallback with fine-grained tokens, the documented repository permissions
+are:
+
+| REST subject                                                                  | List                                                        | Create and delete                                           |
+| ----------------------------------------------------------------------------- | ----------------------------------------------------------- | ----------------------------------------------------------- |
+| Issue or Issue comment, including ordinary pull request conversation comments | Issues: read                                                | Issues: write                                               |
+| Pull request review comment                                                   | Pull requests: read                                         | Pull requests: write                                        |
+| Release                                                                       | No repository permission required by the fine-grained token | No repository permission required by the fine-grained token |
+
+Public list operations can be unauthenticated; create and delete operations need an authenticated
+actor. Send `Accept: application/vnd.github+json`, `Authorization: Bearer TOKEN`, and
+`X-GitHub-Api-Version: 2026-03-10`. The route-specific permission matrix and recommended media type
+are in the [REST Reactions reference](https://docs.github.com/en/rest/reactions/reactions?apiVersion=2026-03-10).
+GitHub currently supports REST versions `2026-03-10` and `2022-11-28`; an omitted version still
+defaults to `2022-11-28`, while an unsupported retired version returns 410. Pin the current version
+rather than relying on that default, as described in
+[GitHub REST API versions](https://docs.github.com/en/rest/about-the-rest-api/api-versions?apiVersion=2026-03-10).
+
+## Pagination, limits, and request policy
+
+- REST list routes use `page` and `per_page`, default to 30, and cap `per_page` at 100. Follow the
+  `Link` header until complete if individual reactors or a REST delete ID is ever needed.
+- `reactionGroups` is a small non-connection list, so the count-and-viewer query has no reaction
+  pagination. A future actor popover must paginate `reactors(first:, after:)`; GraphQL connections
+  require `first` or `last` from 1 through 100.
+- Bound a Harbor `nodes(ids:)` hydration batch to 100 opaque, deduplicated IDs. This is a local safety
+  limit aligned with current parent page sizes, not a claimed GitHub `nodes` argument maximum.
+  Do not load reactions for unmounted pages.
+- A GraphQL call cannot request more than 500,000 nodes, and GitHub warns specifically against
+  fetching all comments, reactions, and related Issues in a large nested query. Asking only for group
+  totals avoids reactor nodes. GraphQL pagination and node limits are documented in
+  [Using pagination](https://docs.github.com/en/graphql/guides/using-pagination-in-the-graphql-api)
+  and [Rate and query limits](https://docs.github.com/en/graphql/overview/rate-limits-and-query-limits-for-the-graphql-api).
+- An OAuth user has a primary GraphQL budget of 5,000 points per hour and a separate authenticated
+  REST budget of 5,000 requests per hour. Secondary limits are shared: at most 100 concurrent API
+  requests, 2,000 GraphQL points per minute, and generally no more than 80 content-generating
+  requests per minute or 500 per hour. A GraphQL request with a mutation costs five secondary-limit
+  points. GitHub recommends avoiding concurrent mutations and pausing at least one second between
+  mutative requests. These ceilings can change, so use response headers rather than hard-coded retry
+  timing. See the official [GraphQL limits](https://docs.github.com/en/graphql/overview/rate-limits-and-query-limits-for-the-graphql-api)
+  and [REST limits](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api).
+
+Serialize user reaction writes, never poll reaction state, and never retry a mutation in a hot loop.
+On a rate limit, honor `Retry-After`; otherwise use `x-ratelimit-reset` when remaining is zero, or wait
+at least one minute and then apply bounded exponential backoff. A user click after the wait is safer
+than a background retry that may surprise them.
+
+## Stable success and error behavior
+
+REST create is explicitly idempotent: 201 means a reaction was created and 200 means that viewer's
+same reaction already existed. Both are success. The documented create error is 422 for validation
+failure or spam detection; it is not a distinct conflict signal. List returns 200, with 404 for a
+missing subject and an additional 410 documented for the Issue route. Delete documents 204 and
+requires an exact reaction ID. These statuses are route-specific in the
+[REST Reactions reference](https://docs.github.com/en/rest/reactions/reactions?apiVersion=2026-03-10).
+
+GraphQL does not document equivalent duplicate or absent-removal status codes. Make Harbor's public
+operation stable instead:
+
+- `set_reaction(..., reacted: true)` returns the preflight snapshot without writing when already true;
+- `set_reaction(..., reacted: false)` returns it without writing when already false;
+- permission failure is based on `viewerCanReact` for addition and on any mutation error for removal;
+- `NOT_FOUND`, null node, unsupported type, expected-kind mismatch, and repository mismatch remain
+  distinct validation/not-found outcomes rather than generic permission errors;
+- rate-limit responses preserve retry metadata; a transport timeout after dispatch is ambiguous, so
+  refetch authoritative state before offering or attempting another write;
+- never accept partial GraphQL data when the response also contains errors for the reaction operation.
+
+For REST, primary exhaustion returns 403 or 429; GraphQL primary exhaustion can remain HTTP 200 with
+an error. Secondary exhaustion can return REST 403/429 or GraphQL 200/403. Keep Harbor's stable IPC
+codes based on the response body and rate headers, not HTTP status alone. The exact response rules are
+in GitHub's [REST](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api)
+and [GraphQL](https://docs.github.com/en/graphql/overview/rate-limits-and-query-limits-for-the-graphql-api)
+limit documentation.
+
+## Harbor module and cache design
+
+Add a focused deep module, for example `github/reaction.rs`, behind a two-method interface:
+
+```text
+reaction_subjects(token, repository, [(subject_id, expected_kind)]) -> [ReactionSubject]
+set_reaction(token, repository, subject_id, expected_kind, content, reacted) -> ReactionSubject
+```
+
+The module should own:
+
+- `ReactionContent`, `ReactionSubjectKind`, `ReactionGroup`, and `ReactionSubject` models;
+- the eight-kind allowlist and the six-value Release vocabulary;
+- opaque ID validation, a 100-subject batch bound, and deduplication;
+- the scoped batch query, desired-state mutations, and response verification;
+- Octocrab GraphQL transport, fake Adapter, and focused tests.
+
+Keep the public result compact: `subjectId`, `kind`, `viewerCanReact`, and nonzero groups containing
+`content`, `count`, and `viewerHasReacted`. Keep the picker vocabulary separately so dropping zero
+groups never removes available choices. The root GitHub module should only compose/re-export the
+Interface and the Tauri commands should take repository coordinates, opaque subject ID, exact kind,
+content, and desired boolean.
+
+Hydrate reactions with each existing parent detail page rather than issuing one Tauri call per card:
+
+- Issue detail: body plus the node IDs on the current 100-item timeline page.
+- Pull request conversation: body, ordinary comments, and review summaries on the current page.
+- Pull request files: inline comment IDs already loaded in the current review-thread page.
+- Discussion detail: post, current 30 top-level comments, and the replies already present.
+- Release detail: the Release node ID.
+
+The backend may batch REST-origin node IDs through `nodes(ids:)`; GraphQL-origin detail queries may
+select the same fragment inline when doing so does not create an excessive nested response. In either
+case, the frontend should receive the same `ReactionSubject` shape.
+
+Use one TanStack Query key family scoped by repository and node ID:
+
+```text
+["github", "repository", owner, repository, "reaction", subjectId]
+```
+
+Prime those entries from every parent detail response. A successful mutation replaces the canonical
+subject entry and patches any mounted parent snapshots containing that node: Issue detail timeline,
+pull request conversation/reviews, pull request review threads, Discussion detail/replies, and
+Release detail. Then invalidate only the relevant subject and parent root for authoritative
+reconciliation. Do not invalidate every Issue, pull request, Discussion, or Release list: this slice
+does not render reactions in those lists.
+
+## UI and reconciliation
+
+Use a single compact `GitHubReactionBar` on each supported body or comment. Existing nonzero groups
+are buttons; an add-reaction shadcn popover exposes all allowed choices. Give every button an
+accessible localized label such as “3 heart reactions; you reacted” rather than relying on emoji or
+color. Selected groups need icon-independent pressed state (`aria-pressed`), and the picker should be
+hidden or disabled with an explanation when `viewerCanReact` is false.
+
+Optimistic behavior should be immediate but bounded:
+
+1. Snapshot the canonical subject.
+2. Set the chosen `viewerHasReacted` to the requested state and adjust its count by exactly one,
+   clamped at zero.
+3. Disable or queue further writes for the same `(subjectId, content)`; coalesce rapid clicks to the
+   latest desired state instead of sending concurrent add/remove operations.
+4. On success, replace all optimistic groups with the mutation payload, including changes caused by
+   other users between read and write.
+5. On failure, restore the snapshot, retain retry context, show the existing Harbor permission/rate
+   feedback, and refetch that subject. After an ambiguous timeout, do not automatically replay until
+   the refetch resolves the actual viewer state.
+
+Different contents on the same subject should also be serialized through a small mutation queue to
+respect GitHub's no-concurrent-mutation guidance. A reaction action must never modify the separate
+Discussion upvote count. If a subject disappears from a later parent page or GraphQL returns null,
+remove its canonical reaction entry rather than displaying stale controls.
+
+## Focused verification
+
+### Rust contract and Service tests
+
+- Map all eight GraphQL enum values, REST spellings, stable display order, and glyphs.
+- Enforce the six-value Release subset and reject `ThumbsDown`/`Confused` before transport.
+- Deserialize `reactors.totalCount`, `viewerHasReacted`, and `viewerCanReact`; tolerate null/sparse
+  groups, drop zero groups from compact output, and reject duplicate or internally inconsistent
+  groups.
+- Preserve node IDs as opaque strings; trim, deduplicate, and cap a batch at 100 without parsing
+  prefixes.
+- Verify repository ID for all direct-repository types and the nested Discussion-comment path.
+- Reject null selected repository, null subject, missing Discussion parent, foreign repository,
+  `CommitComment`, any unsupported type, and expected-kind mismatch.
+- Confirm matching desired state skips transport for both add and remove.
+- Confirm add/remove send `subjectId` and GraphQL enum content, preserve GraphQL errors, and reject a
+  null payload, wrong returned ID/type, or unconfirmed desired state.
+- Confirm permission and rate-limit errors keep stable IPC codes and retry metadata.
+- Confirm a missing node in a batch cannot authorize a later write.
+
+### Frontend tests
+
+- Render counts and pressed state for every emoji with localized accessible names.
+- Show eight picker choices for Issue/PR/Discussion subjects and six for Release.
+- Keep Discussion upvote and thumbs-up reaction counts independent.
+- Hide or disable writes when `viewerCanReact` is false while retaining readable counts.
+- Cover optimistic add, optimistic remove, zero-count removal, rollback, authoritative replacement,
+  rapid-click coalescing, and no negative count.
+- Patch the correct cached subject across Issue body/comment, PR body/conversation review/inline
+  comment, Discussion body/comment/reply, and Release detail fixtures without invalidating unrelated
+  repositories or list filters.
+- Keep controls correct across existing timeline, thread, and Discussion pagination.
+
+### Commands
+
+```bash
+pnpm check
+pnpm test -- --run
+cargo test --manifest-path src-tauri/Cargo.toml reaction
+cargo check --manifest-path src-tauri/Cargo.toml
+```
+
+For signed-in desktop verification, exercise one public and one private repository: add and remove a
+reaction on every supported surface, revisit another tab/page to confirm cache reconciliation, test
+a locked or otherwise non-reactable subject, and confirm that a Release never offers 👎 or 😕.
+
+## Explicit non-goals
+
+- Commit-comment reactions until Harbor has a native commit-comment conversation.
+- Reactor identity drawers; counts and the current viewer state are sufficient for this slice.
+- Team discussion/comment REST endpoints or any organization/Enterprise administration.
+- Notification fan-out, webhook ingestion, bulk reacting, background polling, or reaction analytics.
+- Replacing Discussion upvotes with emoji reactions.

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -39,7 +39,8 @@ use crate::{
         GitHubPullRequestReviewTeamPage, GitHubPullRequestReviewThreadComment,
         GitHubPullRequestReviewThreadPage, GitHubPullRequestReviewThreadResolution,
         GitHubPullRequestReviewThreadState, GitHubPullRequestSort, GitHubPullRequestState,
-        GitHubRelease, GitHubReleaseArchiveFormat, GitHubReleaseAsset, GitHubReleaseMutationInput,
+        GitHubReactionContent, GitHubReactionSubject, GitHubReactionSubjectRef, GitHubRelease,
+        GitHubReleaseArchiveFormat, GitHubReleaseAsset, GitHubReleaseMutationInput,
         GitHubReleasePage, GitHubRepositoryCommitPage, GitHubRepositoryCreateInput,
         GitHubRepositoryCreationOptions, GitHubRepositoryFileCommit, GitHubRepositoryFileMutation,
         GitHubRepositoryPage, GitHubRepositoryRelationship, GitHubRepositorySettings,
@@ -1015,6 +1016,44 @@ pub async fn github_delete_repository_discussion_comment(
             repository.name(),
             validate_item_number(discussion_number, "discussion")?,
             &validate_graphql_node_id(comment_id, "discussion comment")?,
+        )
+        .await
+}
+
+#[tauri::command]
+pub async fn github_get_repository_reactions(
+    owner: String,
+    repository: String,
+    subjects: Vec<GitHubReactionSubjectRef>,
+    state: State<'_, AppState>,
+) -> Result<Vec<GitHubReactionSubject>, AppError> {
+    let repository = RepositoryRef::new(owner, repository)?;
+    let subjects = crate::github::reaction::normalize_reaction_subjects(subjects)?;
+    state
+        .github
+        .reaction_subjects(repository.owner(), repository.name(), &subjects)
+        .await
+}
+
+#[tauri::command]
+pub async fn github_update_repository_reaction(
+    owner: String,
+    repository: String,
+    subject: GitHubReactionSubjectRef,
+    content: GitHubReactionContent,
+    reacted: bool,
+    state: State<'_, AppState>,
+) -> Result<GitHubReactionSubject, AppError> {
+    let repository = RepositoryRef::new(owner, repository)?;
+    let subject = crate::github::reaction::normalize_reaction_subject(subject)?;
+    state
+        .github
+        .update_reaction(
+            repository.owner(),
+            repository.name(),
+            &subject,
+            content,
+            reacted,
         )
         .await
 }

--- a/src-tauri/src/github.rs
+++ b/src-tauri/src/github.rs
@@ -23,6 +23,7 @@ pub(crate) mod pending_review;
 pub(crate) mod profile;
 pub(crate) mod projects;
 pub(crate) mod pull_request;
+pub(crate) mod reaction;
 pub(crate) mod release;
 pub(crate) mod repository_relationships;
 pub(crate) mod repository_settings;
@@ -84,6 +85,10 @@ pub use pull_request::merge_queue::GitHubPullRequestMergeQueueStatus;
 pub use pull_request::reviewer::{GitHubPullRequestReviewTeam, GitHubPullRequestReviewTeamPage};
 pub use pull_request::update_branch::{
     GitHubPullRequestBranchUpdate, GitHubPullRequestBranchUpdateStatus,
+};
+pub use reaction::{
+    GitHubReactionContent, GitHubReactionSubject, GitHubReactionSubjectKind,
+    GitHubReactionSubjectRef,
 };
 pub use release::{
     GitHubRelease, GitHubReleaseArchiveFormat, GitHubReleaseAsset, GitHubReleaseMutationInput,
@@ -252,6 +257,7 @@ pub struct GitHubPullRequestPage {
 #[serde(rename_all = "camelCase")]
 pub struct GitHubPullRequest {
     pub id: u64,
+    pub reaction_subject: Option<GitHubReactionSubjectRef>,
     pub number: u64,
     pub title: String,
     pub body: Option<String>,
@@ -578,6 +584,7 @@ pub(crate) trait GitHubClient:
     + pull_request::merge_queue::GitHubPullRequestMergeQueueClient
     + pull_request::reviewer::GitHubPullRequestReviewerClient
     + pull_request::update_branch::GitHubPullRequestBranchClient
+    + reaction::GitHubReactionClient
     + release::GitHubReleaseClient
     + repository_relationships::GitHubRepositoryRelationshipsClient
     + repository_settings::GitHubRepositorySettingsClient
@@ -1798,6 +1805,10 @@ fn pull_request_from_octocrab(
 
     GitHubPullRequest {
         id: pull_request.id.into_inner(),
+        reaction_subject: pull_request.node_id.map(|id| GitHubReactionSubjectRef {
+            id,
+            kind: GitHubReactionSubjectKind::PullRequest,
+        }),
         number: pull_request.number,
         title: pull_request
             .title
@@ -2246,6 +2257,10 @@ mod tests {
             Ok(GitHubPullRequestDetailPage {
                 pull_request: GitHubPullRequest {
                     id: 3,
+                    reaction_subject: Some(GitHubReactionSubjectRef {
+                        id: "PR_3".to_string(),
+                        kind: GitHubReactionSubjectKind::PullRequest,
+                    }),
                     number: pull_request_number,
                     title: "Ship the PR workspace".to_string(),
                     body: Some("Pull request body".to_string()),
@@ -2639,6 +2654,28 @@ mod tests {
             .discussion_detail("octocat", "hello-world", 42, None)
             .await
             .expect("discussion detail");
+        let reaction_subject = GitHubReactionSubjectRef {
+            id: "I_kwDOA".to_string(),
+            kind: GitHubReactionSubjectKind::Issue,
+        };
+        let reactions = service
+            .reaction_subjects(
+                "octocat",
+                "hello-world",
+                std::slice::from_ref(&reaction_subject),
+            )
+            .await
+            .expect("reaction subjects");
+        let updated_reaction = service
+            .update_reaction(
+                "octocat",
+                "hello-world",
+                &reaction_subject,
+                GitHubReactionContent::Heart,
+                true,
+            )
+            .await
+            .expect("updated reaction");
         let releases = service
             .releases("octocat", "hello-world", 2)
             .await
@@ -2752,6 +2789,8 @@ mod tests {
         assert!(discussion_categories.enabled);
         assert_eq!(discussions.discussions[0].number, 42);
         assert_eq!(discussion.comments[0].body, "A focused answer.");
+        assert_eq!(reactions[0].id, reaction_subject.id);
+        assert!(updated_reaction.groups[0].viewer_has_reacted);
         assert_eq!(releases.page, 2);
         assert_eq!(release.tag_name, "v1.0.0");
         assert_eq!(release_asset.bytes, b"release-asset");
@@ -3554,6 +3593,13 @@ mod tests {
         assert_eq!(item.actor.as_deref(), Some("hubot"));
         assert_eq!(item.body.as_deref(), Some("Fixed by **#41**."));
         assert_eq!(item.author_association.as_deref(), Some("CONTRIBUTOR"));
+        assert_eq!(
+            item.reaction_subject,
+            Some(GitHubReactionSubjectRef {
+                id: "IC_42".to_string(),
+                kind: GitHubReactionSubjectKind::IssueComment,
+            })
+        );
     }
 
     #[test]
@@ -3580,6 +3626,13 @@ mod tests {
         assert_eq!(item.body.as_deref(), Some("Fixed in **#41**."));
         assert_eq!(item.author_association.as_deref(), Some("OWNER"));
         assert!(item.updated_at.is_some());
+        assert_eq!(
+            item.reaction_subject,
+            Some(GitHubReactionSubjectRef {
+                id: "IC_84".to_string(),
+                kind: GitHubReactionSubjectKind::IssueComment,
+            })
+        );
     }
 
     #[test]
@@ -3607,6 +3660,13 @@ mod tests {
         assert_eq!(item.actor.as_deref(), Some("reviewer"));
         assert!(item.created_at.is_some());
         assert_eq!(item.body.as_deref(), Some("Looks good."));
+        assert_eq!(
+            item.reaction_subject,
+            Some(GitHubReactionSubjectRef {
+                id: "PRR_43".to_string(),
+                kind: GitHubReactionSubjectKind::PullRequestReview,
+            })
+        );
     }
 
     #[test]

--- a/src-tauri/src/github/issue.rs
+++ b/src-tauri/src/github/issue.rs
@@ -4,7 +4,8 @@ use serde::{Deserialize, Serialize};
 use super::{
     authenticated_client, github_error, item_metadata, pull_request_review_state_from_octocrab,
     repository_coordinates_from_search_value, serialized_enum_name, GitHubPullRequestReviewState,
-    GitHubService, OctocrabGitHubClient, SearchParameters,
+    GitHubReactionSubjectKind, GitHubReactionSubjectRef, GitHubService, OctocrabGitHubClient,
+    SearchParameters,
 };
 use crate::error::AppError;
 
@@ -71,6 +72,7 @@ pub struct GitHubIssueInboxFilters {
 #[serde(rename_all = "camelCase")]
 pub struct GitHubIssue {
     pub id: u64,
+    pub reaction_subject: GitHubReactionSubjectRef,
     pub number: u64,
     pub title: String,
     pub body: Option<String>,
@@ -176,6 +178,7 @@ pub enum GitHubIssueTimelineKind {
 #[serde(rename_all = "camelCase")]
 pub struct GitHubIssueTimelineItem {
     pub id: String,
+    pub reaction_subject: Option<GitHubReactionSubjectRef>,
     pub kind: GitHubIssueTimelineKind,
     pub event: String,
     pub actor: Option<String>,
@@ -898,6 +901,10 @@ fn issue_from_octocrab(issue: octocrab::models::issues::Issue) -> GitHubIssue {
         .and_then(|milestone| u64::try_from(milestone.number).ok());
     GitHubIssue {
         id: issue.id.into_inner(),
+        reaction_subject: GitHubReactionSubjectRef {
+            id: issue.node_id,
+            kind: GitHubReactionSubjectKind::Issue,
+        },
         number: issue.number,
         title: issue.title,
         body: issue.body,
@@ -970,7 +977,11 @@ pub(super) fn timeline_item_from_issue_comment(
     comment: octocrab::models::issues::Comment,
 ) -> GitHubIssueTimelineItem {
     GitHubIssueTimelineItem {
-        id: comment.node_id,
+        id: comment.node_id.clone(),
+        reaction_subject: Some(GitHubReactionSubjectRef {
+            id: comment.node_id,
+            kind: GitHubReactionSubjectKind::IssueComment,
+        }),
         kind: GitHubIssueTimelineKind::Comment,
         event: "commented".to_string(),
         actor: Some(comment.user.login),
@@ -1042,12 +1053,21 @@ pub(super) fn timeline_item_from_octocrab(
 
     let review_state = event.state.map(pull_request_review_state_from_octocrab);
     let created_at = event.created_at.or(event.submitted_at);
+    let reaction_subject = event.node_id.clone().and_then(|id| {
+        let kind = match event_name.as_str() {
+            "commented" => GitHubReactionSubjectKind::IssueComment,
+            "reviewed" => GitHubReactionSubjectKind::PullRequestReview,
+            _ => return None,
+        };
+        Some(GitHubReactionSubjectRef { id, kind })
+    });
 
     GitHubIssueTimelineItem {
         id: event
             .node_id
             .clone()
             .unwrap_or_else(|| format!("{event_name}-{index}")),
+        reaction_subject,
         kind: if event_name == "commented" {
             GitHubIssueTimelineKind::Comment
         } else {

--- a/src-tauri/src/github/issue/tests.rs
+++ b/src-tauri/src/github/issue/tests.rs
@@ -16,6 +16,10 @@ impl GitHubIssueClient for super::super::tests::FakeGitHubClient {
         Ok(GitHubIssuePage {
             issues: vec![GitHubIssue {
                 id: 2,
+                reaction_subject: GitHubReactionSubjectRef {
+                    id: "I_2".to_string(),
+                    kind: GitHubReactionSubjectKind::Issue,
+                },
                 number: 7,
                 title: "Keep the example focused".to_string(),
                 body: Some("Issue body".to_string()),
@@ -256,6 +260,10 @@ impl GitHubIssueClient for super::super::tests::FakeGitHubClient {
         );
         Ok(GitHubIssueTimelineItem {
             id: "IC_84".to_string(),
+            reaction_subject: Some(GitHubReactionSubjectRef {
+                id: "IC_84".to_string(),
+                kind: GitHubReactionSubjectKind::IssueComment,
+            }),
             kind: GitHubIssueTimelineKind::Comment,
             event: "commented".to_string(),
             actor: Some("octocat".to_string()),

--- a/src-tauri/src/github/pull_request/mod.rs
+++ b/src-tauri/src/github/pull_request/mod.rs
@@ -558,6 +558,10 @@ impl GitHubPullRequestMutationClient for super::tests::FakeGitHubClient {
         );
         Ok(GitHubIssueTimelineItem {
             id: "IC_85".to_string(),
+            reaction_subject: Some(super::GitHubReactionSubjectRef {
+                id: "IC_85".to_string(),
+                kind: super::GitHubReactionSubjectKind::IssueComment,
+            }),
             kind: super::GitHubIssueTimelineKind::Comment,
             event: "commented".to_string(),
             actor: Some("octocat".to_string()),

--- a/src-tauri/src/github/reaction.rs
+++ b/src-tauri/src/github/reaction.rs
@@ -1,0 +1,567 @@
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+use super::{authenticated_client, github_error, GitHubService, OctocrabGitHubClient};
+use crate::error::AppError;
+
+const MAX_REACTION_SUBJECTS: usize = 100;
+const MAX_REACTION_SUBJECT_ID_BYTES: usize = 256;
+
+const REACTION_SUBJECTS_QUERY: &str = r#"
+query HarborReactionSubjects(
+  $owner: String!
+  $repository: String!
+  $ids: [ID!]!
+) {
+  repository(owner: $owner, name: $repository) { id }
+  nodes(ids: $ids) {
+    __typename
+    ... on Reactable {
+      id
+      viewerCanReact
+      reactionGroups { ...HarborReactionGroup }
+    }
+    ... on Issue { repository { id } }
+    ... on PullRequest { repository { id } }
+    ... on IssueComment { repository { id } }
+    ... on PullRequestReview { repository { id } }
+    ... on PullRequestReviewComment { repository { id } }
+    ... on Discussion { repository { id } }
+    ... on Release { repository { id } }
+    ... on DiscussionComment {
+      discussion { repository { id } }
+    }
+  }
+}
+
+fragment HarborReactionGroup on ReactionGroup {
+  content
+  viewerHasReacted
+  reactors { totalCount }
+}
+"#;
+
+const ADD_REACTION_MUTATION: &str = r#"
+mutation HarborAddReaction($subjectId: ID!, $content: ReactionContent!) {
+  addReaction(input: { subjectId: $subjectId, content: $content }) {
+    subject { __typename id viewerCanReact }
+    reactionGroups { ...HarborReactionGroup }
+  }
+}
+
+fragment HarborReactionGroup on ReactionGroup {
+  content
+  viewerHasReacted
+  reactors { totalCount }
+}
+"#;
+
+const REMOVE_REACTION_MUTATION: &str = r#"
+mutation HarborRemoveReaction($subjectId: ID!, $content: ReactionContent!) {
+  removeReaction(input: { subjectId: $subjectId, content: $content }) {
+    subject { __typename id viewerCanReact }
+    reactionGroups { ...HarborReactionGroup }
+  }
+}
+
+fragment HarborReactionGroup on ReactionGroup {
+  content
+  viewerHasReacted
+  reactors { totalCount }
+}
+"#;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum GitHubReactionSubjectKind {
+    Issue,
+    PullRequest,
+    IssueComment,
+    PullRequestReview,
+    PullRequestReviewComment,
+    Discussion,
+    DiscussionComment,
+    Release,
+}
+
+impl GitHubReactionSubjectKind {
+    fn as_graphql(self) -> &'static str {
+        match self {
+            Self::Issue => "Issue",
+            Self::PullRequest => "PullRequest",
+            Self::IssueComment => "IssueComment",
+            Self::PullRequestReview => "PullRequestReview",
+            Self::PullRequestReviewComment => "PullRequestReviewComment",
+            Self::Discussion => "Discussion",
+            Self::DiscussionComment => "DiscussionComment",
+            Self::Release => "Release",
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GitHubReactionSubjectRef {
+    pub id: String,
+    pub kind: GitHubReactionSubjectKind,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize)]
+pub enum GitHubReactionContent {
+    #[serde(rename = "thumbsUp", alias = "THUMBS_UP")]
+    ThumbsUp,
+    #[serde(rename = "thumbsDown", alias = "THUMBS_DOWN")]
+    ThumbsDown,
+    #[serde(rename = "laugh", alias = "LAUGH")]
+    Laugh,
+    #[serde(rename = "hooray", alias = "HOORAY")]
+    Hooray,
+    #[serde(rename = "confused", alias = "CONFUSED")]
+    Confused,
+    #[serde(rename = "heart", alias = "HEART")]
+    Heart,
+    #[serde(rename = "rocket", alias = "ROCKET")]
+    Rocket,
+    #[serde(rename = "eyes", alias = "EYES")]
+    Eyes,
+}
+
+impl GitHubReactionContent {
+    fn as_graphql(self) -> &'static str {
+        match self {
+            Self::ThumbsUp => "THUMBS_UP",
+            Self::ThumbsDown => "THUMBS_DOWN",
+            Self::Laugh => "LAUGH",
+            Self::Hooray => "HOORAY",
+            Self::Confused => "CONFUSED",
+            Self::Heart => "HEART",
+            Self::Rocket => "ROCKET",
+            Self::Eyes => "EYES",
+        }
+    }
+
+    fn sort_order(self) -> u8 {
+        match self {
+            Self::ThumbsUp => 0,
+            Self::ThumbsDown => 1,
+            Self::Laugh => 2,
+            Self::Hooray => 3,
+            Self::Confused => 4,
+            Self::Heart => 5,
+            Self::Rocket => 6,
+            Self::Eyes => 7,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GitHubReactionGroup {
+    pub content: GitHubReactionContent,
+    pub count: u64,
+    pub viewer_has_reacted: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GitHubReactionSubject {
+    pub id: String,
+    pub kind: GitHubReactionSubjectKind,
+    pub viewer_can_react: bool,
+    pub groups: Vec<GitHubReactionGroup>,
+}
+
+#[async_trait]
+pub(crate) trait GitHubReactionClient: Send + Sync {
+    async fn reaction_subjects(
+        &self,
+        token: &str,
+        owner: &str,
+        repository: &str,
+        subjects: &[GitHubReactionSubjectRef],
+    ) -> Result<Vec<GitHubReactionSubject>, AppError>;
+
+    #[allow(clippy::too_many_arguments)]
+    async fn update_reaction(
+        &self,
+        token: &str,
+        owner: &str,
+        repository: &str,
+        subject: &GitHubReactionSubjectRef,
+        content: GitHubReactionContent,
+        reacted: bool,
+    ) -> Result<GitHubReactionSubject, AppError>;
+}
+
+impl GitHubService {
+    pub async fn reaction_subjects(
+        &self,
+        owner: &str,
+        repository: &str,
+        subjects: &[GitHubReactionSubjectRef],
+    ) -> Result<Vec<GitHubReactionSubject>, AppError> {
+        let token = self.load_access_token().await?;
+        self.client
+            .reaction_subjects(&token, owner, repository, subjects)
+            .await
+    }
+
+    pub async fn update_reaction(
+        &self,
+        owner: &str,
+        repository: &str,
+        subject: &GitHubReactionSubjectRef,
+        content: GitHubReactionContent,
+        reacted: bool,
+    ) -> Result<GitHubReactionSubject, AppError> {
+        let token = self.load_access_token().await?;
+        self.client
+            .update_reaction(&token, owner, repository, subject, content, reacted)
+            .await
+    }
+}
+
+#[async_trait]
+impl GitHubReactionClient for OctocrabGitHubClient {
+    async fn reaction_subjects(
+        &self,
+        token: &str,
+        owner: &str,
+        repository: &str,
+        subjects: &[GitHubReactionSubjectRef],
+    ) -> Result<Vec<GitHubReactionSubject>, AppError> {
+        let subjects = normalize_reaction_subjects(subjects.to_vec())?;
+        reaction_subjects_with_client(token, owner, repository, &subjects).await
+    }
+
+    async fn update_reaction(
+        &self,
+        token: &str,
+        owner: &str,
+        repository: &str,
+        subject: &GitHubReactionSubjectRef,
+        content: GitHubReactionContent,
+        reacted: bool,
+    ) -> Result<GitHubReactionSubject, AppError> {
+        let requested_subject = normalize_reaction_subject(subject.clone())?;
+        ensure_reaction_content_supported(requested_subject.kind, content)?;
+        let current = reaction_subjects_with_client(
+            token,
+            owner,
+            repository,
+            std::slice::from_ref(&requested_subject),
+        )
+        .await?
+        .into_iter()
+        .find(|candidate| {
+            candidate.id == requested_subject.id && candidate.kind == requested_subject.kind
+        })
+        .ok_or_else(|| {
+            AppError::GitHub("GitHub did not return the requested reaction subject".to_string())
+        })?;
+        let viewer_has_reacted = current
+            .groups
+            .iter()
+            .find(|group| group.content == content)
+            .is_some_and(|group| group.viewer_has_reacted);
+        if viewer_has_reacted == reacted {
+            return Ok(current);
+        }
+        if reacted && !current.viewer_can_react {
+            return Err(AppError::GitHubPermission(
+                "GitHub does not allow the viewer to react to this subject".to_string(),
+            ));
+        }
+
+        let client = authenticated_client(token)?;
+        let query = if reacted {
+            ADD_REACTION_MUTATION
+        } else {
+            REMOVE_REACTION_MUTATION
+        };
+        let payload = serde_json::json!({
+            "query": query,
+            "variables": {
+                "subjectId": requested_subject.id,
+                "content": content.as_graphql(),
+            }
+        });
+        let response: UpdateReactionMutation =
+            client.graphql(&payload).await.map_err(github_error)?;
+        let mutation = if reacted {
+            response.add_reaction
+        } else {
+            response.remove_reaction
+        }
+        .ok_or_else(|| {
+            AppError::GitHub("GitHub did not return the reaction mutation".to_string())
+        })?;
+        let returned_subject = mutation.subject.ok_or_else(|| {
+            AppError::GitHub("GitHub did not return the updated reaction subject".to_string())
+        })?;
+        if returned_subject.id != current.id
+            || returned_subject.type_name != current.kind.as_graphql()
+        {
+            return Err(AppError::GitHub(
+                "GitHub returned a different reaction subject".to_string(),
+            ));
+        }
+        let reaction_groups = mutation.reaction_groups.ok_or_else(|| {
+            AppError::GitHub("GitHub did not return the updated reaction groups".to_string())
+        })?;
+        let result = GitHubReactionSubject {
+            id: returned_subject.id,
+            kind: current.kind,
+            viewer_can_react: returned_subject.viewer_can_react,
+            groups: reaction_groups_from_graphql(reaction_groups)?,
+        };
+        let returned_state = result
+            .groups
+            .iter()
+            .find(|group| group.content == content)
+            .is_some_and(|group| group.viewer_has_reacted);
+        if returned_state != reacted {
+            return Err(AppError::GitHub(
+                "GitHub did not apply the requested reaction state".to_string(),
+            ));
+        }
+        Ok(result)
+    }
+}
+
+pub(crate) fn normalize_reaction_subjects(
+    subjects: Vec<GitHubReactionSubjectRef>,
+) -> Result<Vec<GitHubReactionSubjectRef>, AppError> {
+    if subjects.is_empty() {
+        return Err(AppError::Validation(
+            "at least one reaction subject is required".to_string(),
+        ));
+    }
+    if subjects.len() > MAX_REACTION_SUBJECTS {
+        return Err(AppError::Validation(format!(
+            "at most {MAX_REACTION_SUBJECTS} reaction subjects may be loaded at once"
+        )));
+    }
+    let mut normalized = Vec::with_capacity(subjects.len());
+    for subject in subjects {
+        let subject = normalize_reaction_subject(subject)?;
+        if let Some(existing) = normalized
+            .iter()
+            .find(|existing: &&GitHubReactionSubjectRef| existing.id == subject.id)
+        {
+            if existing.kind != subject.kind {
+                return Err(AppError::Validation(
+                    "reaction subject ID was provided with conflicting kinds".to_string(),
+                ));
+            }
+        } else {
+            normalized.push(subject);
+        }
+    }
+    Ok(normalized)
+}
+
+pub(crate) fn normalize_reaction_subject(
+    mut subject: GitHubReactionSubjectRef,
+) -> Result<GitHubReactionSubjectRef, AppError> {
+    let subject_id = subject.id.trim();
+    if subject_id.is_empty()
+        || subject_id.len() > MAX_REACTION_SUBJECT_ID_BYTES
+        || subject_id.chars().any(char::is_whitespace)
+        || subject_id.chars().any(char::is_control)
+    {
+        return Err(AppError::Validation(
+            "reaction subject ID is invalid".to_string(),
+        ));
+    }
+    subject.id = subject_id.to_string();
+    Ok(subject)
+}
+
+fn ensure_reaction_content_supported(
+    kind: GitHubReactionSubjectKind,
+    content: GitHubReactionContent,
+) -> Result<(), AppError> {
+    if kind == GitHubReactionSubjectKind::Release
+        && matches!(
+            content,
+            GitHubReactionContent::ThumbsDown | GitHubReactionContent::Confused
+        )
+    {
+        return Err(AppError::Validation(
+            "GitHub Releases do not support this reaction".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+async fn reaction_subjects_with_client(
+    token: &str,
+    owner: &str,
+    repository: &str,
+    subjects: &[GitHubReactionSubjectRef],
+) -> Result<Vec<GitHubReactionSubject>, AppError> {
+    let client = authenticated_client(token)?;
+    let payload = serde_json::json!({
+        "query": REACTION_SUBJECTS_QUERY,
+        "variables": {
+            "owner": owner,
+            "repository": repository,
+            "ids": subjects.iter().map(|subject| &subject.id).collect::<Vec<_>>(),
+        },
+    });
+    let response: ReactionSubjectsQuery = client.graphql(&payload).await.map_err(github_error)?;
+    let repository_id = response
+        .repository
+        .map(|repository| repository.id)
+        .ok_or_else(|| {
+            AppError::GitHub("GitHub did not return the selected reaction repository".to_string())
+        })?;
+    if response.nodes.len() != subjects.len() {
+        return Err(AppError::GitHub(
+            "GitHub returned an incomplete reaction subject list".to_string(),
+        ));
+    }
+    response
+        .nodes
+        .into_iter()
+        .zip(subjects)
+        .filter_map(|(subject, expected)| {
+            subject.map(|subject| reaction_subject_from_graphql(subject, expected, &repository_id))
+        })
+        .collect()
+}
+
+fn reaction_subject_from_graphql(
+    subject: ReactionSubjectNode,
+    expected: &GitHubReactionSubjectRef,
+    repository_id: &str,
+) -> Result<GitHubReactionSubject, AppError> {
+    if subject.id != expected.id || subject.type_name != expected.kind.as_graphql() {
+        return Err(AppError::Validation(
+            "reaction subject kind does not match the requested subject".to_string(),
+        ));
+    }
+    let subject_repository_id = if expected.kind == GitHubReactionSubjectKind::DiscussionComment {
+        subject
+            .discussion
+            .and_then(|discussion| discussion.repository)
+            .map(|repository| repository.id)
+    } else {
+        subject.repository.map(|repository| repository.id)
+    }
+    .ok_or_else(|| {
+        AppError::GitHub("GitHub did not return the reaction subject repository".to_string())
+    })?;
+    if subject_repository_id != repository_id {
+        return Err(AppError::Validation(
+            "reaction subject does not belong to the selected repository".to_string(),
+        ));
+    }
+
+    Ok(GitHubReactionSubject {
+        id: subject.id,
+        kind: expected.kind,
+        viewer_can_react: subject.viewer_can_react,
+        groups: reaction_groups_from_graphql(subject.reaction_groups.unwrap_or_default())?,
+    })
+}
+
+fn reaction_groups_from_graphql(
+    groups: Vec<ReactionGroupNode>,
+) -> Result<Vec<GitHubReactionGroup>, AppError> {
+    let mut result = Vec::with_capacity(groups.len());
+    for group in groups {
+        if result
+            .iter()
+            .any(|existing: &GitHubReactionGroup| existing.content == group.content)
+        {
+            return Err(AppError::GitHub(
+                "GitHub returned duplicate reaction groups".to_string(),
+            ));
+        }
+        if group.viewer_has_reacted && group.reactors.total_count == 0 {
+            return Err(AppError::GitHub(
+                "GitHub returned an inconsistent reaction group".to_string(),
+            ));
+        }
+        if group.reactors.total_count > 0 || group.viewer_has_reacted {
+            result.push(GitHubReactionGroup {
+                content: group.content,
+                count: group.reactors.total_count,
+                viewer_has_reacted: group.viewer_has_reacted,
+            });
+        }
+    }
+    result.sort_by_key(|group| group.content.sort_order());
+    Ok(result)
+}
+
+#[derive(Deserialize)]
+struct ReactionSubjectsQuery {
+    repository: Option<ReactionRepositoryNode>,
+    nodes: Vec<Option<ReactionSubjectNode>>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ReactionSubjectNode {
+    #[serde(rename = "__typename")]
+    type_name: String,
+    id: String,
+    viewer_can_react: bool,
+    reaction_groups: Option<Vec<ReactionGroupNode>>,
+    repository: Option<ReactionRepositoryNode>,
+    discussion: Option<ReactionDiscussionNode>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ReactionRepositoryNode {
+    id: String,
+}
+
+#[derive(Deserialize)]
+struct ReactionDiscussionNode {
+    repository: Option<ReactionRepositoryNode>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ReactionGroupNode {
+    content: GitHubReactionContent,
+    viewer_has_reacted: bool,
+    reactors: ReactionReactorsNode,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ReactionReactorsNode {
+    total_count: u64,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct UpdateReactionMutation {
+    add_reaction: Option<UpdateReactionPayload>,
+    remove_reaction: Option<UpdateReactionPayload>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct UpdateReactionPayload {
+    subject: Option<UpdatedReactionSubjectNode>,
+    reaction_groups: Option<Vec<ReactionGroupNode>>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct UpdatedReactionSubjectNode {
+    #[serde(rename = "__typename")]
+    type_name: String,
+    id: String,
+    viewer_can_react: bool,
+}
+
+#[cfg(test)]
+mod tests;

--- a/src-tauri/src/github/reaction/tests.rs
+++ b/src-tauri/src/github/reaction/tests.rs
@@ -1,0 +1,241 @@
+use super::*;
+
+#[async_trait]
+impl GitHubReactionClient for super::super::tests::FakeGitHubClient {
+    async fn reaction_subjects(
+        &self,
+        token: &str,
+        owner: &str,
+        repository: &str,
+        subjects: &[GitHubReactionSubjectRef],
+    ) -> Result<Vec<GitHubReactionSubject>, AppError> {
+        assert_eq!(token, "github-user-access-token");
+        assert_eq!((owner, repository), ("octocat", "hello-world"));
+        Ok(subjects
+            .iter()
+            .map(|subject| GitHubReactionSubject {
+                id: subject.id.clone(),
+                kind: subject.kind,
+                viewer_can_react: true,
+                groups: vec![GitHubReactionGroup {
+                    content: GitHubReactionContent::ThumbsUp,
+                    count: 3,
+                    viewer_has_reacted: false,
+                }],
+            })
+            .collect())
+    }
+
+    async fn update_reaction(
+        &self,
+        token: &str,
+        owner: &str,
+        repository: &str,
+        subject: &GitHubReactionSubjectRef,
+        content: GitHubReactionContent,
+        reacted: bool,
+    ) -> Result<GitHubReactionSubject, AppError> {
+        assert_eq!(token, "github-user-access-token");
+        assert_eq!((owner, repository), ("octocat", "hello-world"));
+        Ok(GitHubReactionSubject {
+            id: subject.id.clone(),
+            kind: subject.kind,
+            viewer_can_react: true,
+            groups: vec![GitHubReactionGroup {
+                content,
+                count: if reacted { 4 } else { 3 },
+                viewer_has_reacted: reacted,
+            }],
+        })
+    }
+}
+
+fn group(
+    content: GitHubReactionContent,
+    count: u64,
+    viewer_has_reacted: bool,
+) -> ReactionGroupNode {
+    ReactionGroupNode {
+        content,
+        viewer_has_reacted,
+        reactors: ReactionReactorsNode { total_count: count },
+    }
+}
+
+#[test]
+fn reaction_subjects_are_bounded_deduplicated_and_opaque() {
+    assert_eq!(
+        normalize_reaction_subjects(vec![
+            GitHubReactionSubjectRef {
+                id: " I_kwDOexample ".to_string(),
+                kind: GitHubReactionSubjectKind::Issue,
+            },
+            GitHubReactionSubjectRef {
+                id: "IC_kwDOexample".to_string(),
+                kind: GitHubReactionSubjectKind::IssueComment,
+            },
+            GitHubReactionSubjectRef {
+                id: "I_kwDOexample".to_string(),
+                kind: GitHubReactionSubjectKind::Issue,
+            },
+        ])
+        .unwrap(),
+        [
+            GitHubReactionSubjectRef {
+                id: "I_kwDOexample".to_string(),
+                kind: GitHubReactionSubjectKind::Issue,
+            },
+            GitHubReactionSubjectRef {
+                id: "IC_kwDOexample".to_string(),
+                kind: GitHubReactionSubjectKind::IssueComment,
+            }
+        ]
+    );
+    assert!(normalize_reaction_subjects(Vec::new()).is_err());
+    assert!(normalize_reaction_subjects(vec![GitHubReactionSubjectRef {
+        id: "with whitespace".to_string(),
+        kind: GitHubReactionSubjectKind::Issue,
+    }])
+    .is_err());
+    assert!(normalize_reaction_subjects(vec![GitHubReactionSubjectRef {
+        id: "x".repeat(257),
+        kind: GitHubReactionSubjectKind::Issue,
+    }])
+    .is_err());
+    assert!(normalize_reaction_subjects(vec![
+        GitHubReactionSubjectRef {
+            id: "I_1".to_string(),
+            kind: GitHubReactionSubjectKind::Issue,
+        };
+        101
+    ])
+    .is_err());
+    assert!(normalize_reaction_subjects(vec![
+        GitHubReactionSubjectRef {
+            id: "I_1".to_string(),
+            kind: GitHubReactionSubjectKind::Issue,
+        },
+        GitHubReactionSubjectRef {
+            id: "I_1".to_string(),
+            kind: GitHubReactionSubjectKind::PullRequest,
+        },
+    ])
+    .is_err());
+}
+
+#[test]
+fn reaction_groups_keep_github_order_and_drop_empty_groups() {
+    let groups = reaction_groups_from_graphql(vec![
+        group(GitHubReactionContent::Rocket, 2, true),
+        group(GitHubReactionContent::ThumbsDown, 0, false),
+        group(GitHubReactionContent::ThumbsUp, 7, false),
+    ])
+    .unwrap();
+    assert_eq!(groups.len(), 2);
+    assert_eq!(groups[0].content, GitHubReactionContent::ThumbsUp);
+    assert_eq!(groups[1].content, GitHubReactionContent::Rocket);
+    assert!(groups[1].viewer_has_reacted);
+    assert!(reaction_groups_from_graphql(vec![
+        group(GitHubReactionContent::Heart, 1, false),
+        group(GitHubReactionContent::Heart, 2, true),
+    ])
+    .is_err());
+    assert!(
+        reaction_groups_from_graphql(vec![group(GitHubReactionContent::Eyes, 0, true,)]).is_err()
+    );
+}
+
+#[test]
+fn reaction_subjects_require_the_selected_repository_and_supported_types() {
+    let issue = ReactionSubjectNode {
+        type_name: "Issue".to_string(),
+        id: "I_1".to_string(),
+        viewer_can_react: true,
+        reaction_groups: Some(vec![group(GitHubReactionContent::Heart, 2, true)]),
+        repository: Some(ReactionRepositoryNode {
+            id: "R_1".to_string(),
+        }),
+        discussion: None,
+    };
+    let issue_ref = GitHubReactionSubjectRef {
+        id: "I_1".to_string(),
+        kind: GitHubReactionSubjectKind::Issue,
+    };
+    assert_eq!(
+        reaction_subject_from_graphql(issue, &issue_ref, "R_1")
+            .unwrap()
+            .id,
+        "I_1"
+    );
+
+    let discussion_comment = ReactionSubjectNode {
+        type_name: "DiscussionComment".to_string(),
+        id: "DC_1".to_string(),
+        viewer_can_react: true,
+        reaction_groups: None,
+        repository: None,
+        discussion: Some(ReactionDiscussionNode {
+            repository: Some(ReactionRepositoryNode {
+                id: "R_1".to_string(),
+            }),
+        }),
+    };
+    let discussion_comment_ref = GitHubReactionSubjectRef {
+        id: "DC_1".to_string(),
+        kind: GitHubReactionSubjectKind::DiscussionComment,
+    };
+    assert!(
+        reaction_subject_from_graphql(discussion_comment, &discussion_comment_ref, "R_1").is_ok()
+    );
+
+    let foreign = ReactionSubjectNode {
+        type_name: "IssueComment".to_string(),
+        id: "IC_1".to_string(),
+        viewer_can_react: true,
+        reaction_groups: None,
+        repository: Some(ReactionRepositoryNode {
+            id: "R_2".to_string(),
+        }),
+        discussion: None,
+    };
+    let comment_ref = GitHubReactionSubjectRef {
+        id: "IC_1".to_string(),
+        kind: GitHubReactionSubjectKind::IssueComment,
+    };
+    assert!(reaction_subject_from_graphql(foreign, &comment_ref, "R_1").is_err());
+
+    let commit_comment = ReactionSubjectNode {
+        type_name: "CommitComment".to_string(),
+        id: "CC_1".to_string(),
+        viewer_can_react: true,
+        reaction_groups: None,
+        repository: Some(ReactionRepositoryNode {
+            id: "R_1".to_string(),
+        }),
+        discussion: None,
+    };
+    assert!(reaction_subject_from_graphql(commit_comment, &comment_ref, "R_1").is_err());
+
+    assert!(ensure_reaction_content_supported(
+        GitHubReactionSubjectKind::Release,
+        GitHubReactionContent::ThumbsDown,
+    )
+    .is_err());
+    assert!(ensure_reaction_content_supported(
+        GitHubReactionSubjectKind::Release,
+        GitHubReactionContent::Rocket,
+    )
+    .is_ok());
+}
+
+#[test]
+fn reaction_operations_use_current_graphql_contracts() {
+    assert!(REACTION_SUBJECTS_QUERY.contains("nodes(ids: $ids)"));
+    assert!(REACTION_SUBJECTS_QUERY.contains("... on Reactable"));
+    assert!(REACTION_SUBJECTS_QUERY.contains("viewerCanReact"));
+    assert!(REACTION_SUBJECTS_QUERY.contains("reactors { totalCount }"));
+    assert!(ADD_REACTION_MUTATION.contains("addReaction"));
+    assert!(REMOVE_REACTION_MUTATION.contains("removeReaction"));
+    assert_eq!(GitHubReactionContent::ThumbsUp.as_graphql(), "THUMBS_UP");
+    assert_eq!(GitHubReactionContent::Hooray.as_graphql(), "HOORAY");
+}

--- a/src-tauri/src/github/release.rs
+++ b/src-tauri/src/github/release.rs
@@ -7,7 +7,8 @@ use tokio_util::io::ReaderStream;
 
 use super::{
     authenticated_client, download::safe_download_name, download::safe_download_name_with_suffix,
-    github_error, AppError, GitHubFileDownload, GitHubService, OctocrabGitHubClient,
+    github_error, AppError, GitHubFileDownload, GitHubReactionSubjectKind,
+    GitHubReactionSubjectRef, GitHubService, OctocrabGitHubClient,
 };
 
 const RELEASE_PAGE_SIZE: u8 = 30;
@@ -41,6 +42,7 @@ pub struct GitHubReleaseAsset {
 #[serde(rename_all = "camelCase")]
 pub struct GitHubRelease {
     pub id: u64,
+    pub reaction_subject: GitHubReactionSubjectRef,
     pub tag_name: String,
     pub target_commitish: String,
     pub name: Option<String>,
@@ -796,6 +798,10 @@ fn release_from_octocrab(release: Release) -> Result<GitHubRelease, AppError> {
         .map(|author| (author.login, Some(author.avatar_url.to_string())));
     Ok(GitHubRelease {
         id: release.id.into_inner(),
+        reaction_subject: GitHubReactionSubjectRef {
+            id: release.node_id,
+            kind: GitHubReactionSubjectKind::Release,
+        },
         tag_name: release.tag_name,
         target_commitish: release.target_commitish,
         name: release.name,

--- a/src-tauri/src/github/release/tests.rs
+++ b/src-tauri/src/github/release/tests.rs
@@ -235,6 +235,13 @@ fn release_mapping_keeps_status_notes_author_and_asset_integrity() {
     let mapped = release();
 
     assert_eq!(mapped.id, 88);
+    assert_eq!(
+        mapped.reaction_subject,
+        GitHubReactionSubjectRef {
+            id: "RE_kwDOA".to_string(),
+            kind: GitHubReactionSubjectKind::Release,
+        }
+    );
     assert_eq!(mapped.name, None);
     assert_eq!(mapped.tag_name, "v1.0.0");
     assert!(mapped.prerelease);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -98,6 +98,8 @@ pub fn run() {
             commands::github_add_repository_discussion_poll_vote,
             commands::github_delete_repository_discussion,
             commands::github_delete_repository_discussion_comment,
+            commands::github_get_repository_reactions,
+            commands::github_update_repository_reaction,
             commands::github_list_repository_releases,
             commands::github_get_repository_release,
             commands::github_download_repository_release_asset,

--- a/src/features/github/github-data.ts
+++ b/src/features/github/github-data.ts
@@ -22,6 +22,42 @@ export type GitHubRepositoryPage = {
   hasMore: boolean;
 };
 
+export type GitHubReactionSubjectKind =
+  | "issue"
+  | "pullRequest"
+  | "issueComment"
+  | "pullRequestReview"
+  | "pullRequestReviewComment"
+  | "discussion"
+  | "discussionComment"
+  | "release";
+
+export type GitHubReactionSubjectRef = {
+  id: string;
+  kind: GitHubReactionSubjectKind;
+};
+
+export type GitHubReactionContent =
+  | "thumbsUp"
+  | "thumbsDown"
+  | "laugh"
+  | "hooray"
+  | "confused"
+  | "heart"
+  | "rocket"
+  | "eyes";
+
+export type GitHubReactionGroup = {
+  content: GitHubReactionContent;
+  count: number;
+  viewerHasReacted: boolean;
+};
+
+export type GitHubReactionSubject = GitHubReactionSubjectRef & {
+  viewerCanReact: boolean;
+  groups: GitHubReactionGroup[];
+};
+
 export type GitHubDiscoverySearchKind =
   | "repositories"
   | "code"
@@ -825,6 +861,7 @@ export type GitHubReleaseAsset = {
 
 export type GitHubRelease = {
   id: number;
+  reactionSubject: GitHubReactionSubjectRef;
   tagName: string;
   targetCommitish: string;
   name?: string;
@@ -876,6 +913,7 @@ export type GitHubIssueInboxScope = "authored" | "assigned" | "mentioned";
 
 export type GitHubIssue = {
   id: number;
+  reactionSubject: GitHubReactionSubjectRef;
   number: number;
   title: string;
   body?: string;
@@ -923,6 +961,7 @@ export type GitHubIssueInboxPage = {
 
 export type GitHubIssueTimelineItem = {
   id: string;
+  reactionSubject?: GitHubReactionSubjectRef;
   kind: "comment" | "event";
   event: string;
   actor?: string;
@@ -1092,6 +1131,7 @@ export type GitHubPullRequestPage = {
 
 export type GitHubPullRequest = {
   id: number;
+  reactionSubject?: GitHubReactionSubjectRef;
   number: number;
   title: string;
   body?: string;

--- a/src/features/github/github-discussion-comment.tsx
+++ b/src/features/github/github-discussion-comment.tsx
@@ -50,6 +50,7 @@ import {
 } from "./github-discussion-mutations";
 import { formatIssueDate } from "./github-issue-shared";
 import { GitHubMarkdownEditor } from "./github-markdown-editor";
+import { GitHubReactionBar } from "./github-reaction-bar";
 
 const GitHubReadme = lazy(() => import("./github-readme"));
 
@@ -388,6 +389,9 @@ export function GitHubDiscussionCommentCard({
       </Collapsible>
 
       <footer className="flex flex-wrap items-center gap-1 border-t px-3 py-2">
+        {!deleted ? (
+          <GitHubReactionBar subject={{ id: comment.id, kind: "discussionComment" }} />
+        ) : null}
         {!deleted ? (
           <Button
             type="button"

--- a/src/features/github/github-discussion-detail.tsx
+++ b/src/features/github/github-discussion-detail.tsx
@@ -65,9 +65,12 @@ import type {
   GitHubDiscussionCloseReason,
   GitHubDiscussionComment,
   GitHubDiscussionSummary,
+  GitHubReactionSubjectRef,
   GitHubRepositoryContentContext,
 } from "./github-data";
 import { DiscussionCommentEditor, GitHubDiscussionCommentCard } from "./github-discussion-comment";
+import { GitHubReactionBar } from "./github-reaction-bar";
+import { GitHubReactionsProvider } from "./github-reactions-provider";
 import { GitHubDiscussionFormDialog } from "./github-discussion-form-dialog";
 import { GitHubDiscussionPollCard } from "./github-discussion-poll";
 import {
@@ -85,6 +88,21 @@ import { formatIssueDate } from "./github-issue-shared";
 import { discussionCategoriesQueryOptions, discussionDetailQueryOptions } from "./github-queries";
 
 const GitHubReadme = lazy(() => import("./github-readme"));
+
+function discussionReactionSubjects(
+  discussion: GitHubDiscussionSummary | undefined,
+  comments: GitHubDiscussionComment[]
+) {
+  const subjects: GitHubReactionSubjectRef[] = discussion
+    ? [{ id: discussion.id, kind: "discussion" }]
+    : [];
+  const visit = (comment: GitHubDiscussionComment) => {
+    if (!comment.deletedAt) subjects.push({ id: comment.id, kind: "discussionComment" });
+    for (const reply of comment.replies) visit(reply);
+  };
+  for (const comment of comments) visit(comment);
+  return subjects;
+}
 
 function DiscussionDeleteDialog({
   discussion,
@@ -322,6 +340,10 @@ export function GitHubDiscussionDetail({
     }
     return [...byId.values()];
   }, [result.data?.pages]);
+  const reactionSubjects = useMemo(
+    () => discussionReactionSubjects(discussion, comments),
+    [comments, discussion]
+  );
   const error = !discussion && result.error ? parseIpcError(result.error) : null;
   const supplementalError =
     discussion && result.error
@@ -417,206 +439,213 @@ export function GitHubDiscussionDetail({
             </EmptyContent>
           </Empty>
         ) : (
-          <div className="mx-auto w-full max-w-[1050px] px-4 py-5 sm:px-5">
-            <header className="mb-5 flex flex-wrap items-start gap-3">
-              <div className="min-w-0 flex-1">
-                <div className="mb-2 flex flex-wrap items-center gap-2">
-                  <Badge variant="outline">
-                    <span aria-hidden="true">{discussion.category.emoji}</span>
-                    {discussion.category.name}
-                  </Badge>
-                  <Badge variant={discussion.state === "open" ? "outline" : "secondary"}>
-                    {discussion.state === "open" ? <MessageCircle /> : <CheckCircle2 />}
-                    {t(`workspace.repositories.discussionStates.${discussion.state}`)}
-                  </Badge>
-                  {discussion.answerId ? (
-                    <Badge variant="secondary">
-                      <CheckCircle2 /> {t("workspace.repositories.answered")}
-                    </Badge>
-                  ) : null}
-                  {discussion.locked ? (
+          <GitHubReactionsProvider repository={repository} subjects={reactionSubjects}>
+            <div className="mx-auto w-full max-w-[1050px] px-4 py-5 sm:px-5">
+              <header className="mb-5 flex flex-wrap items-start gap-3">
+                <div className="min-w-0 flex-1">
+                  <div className="mb-2 flex flex-wrap items-center gap-2">
                     <Badge variant="outline">
-                      <LockKeyhole /> {t("workspace.repositories.lockedConversation")}
+                      <span aria-hidden="true">{discussion.category.emoji}</span>
+                      {discussion.category.name}
                     </Badge>
+                    <Badge variant={discussion.state === "open" ? "outline" : "secondary"}>
+                      {discussion.state === "open" ? <MessageCircle /> : <CheckCircle2 />}
+                      {t(`workspace.repositories.discussionStates.${discussion.state}`)}
+                    </Badge>
+                    {discussion.answerId ? (
+                      <Badge variant="secondary">
+                        <CheckCircle2 /> {t("workspace.repositories.answered")}
+                      </Badge>
+                    ) : null}
+                    {discussion.locked ? (
+                      <Badge variant="outline">
+                        <LockKeyhole /> {t("workspace.repositories.lockedConversation")}
+                      </Badge>
+                    ) : null}
+                  </div>
+                  <h2 className="text-foreground text-xl leading-7 font-semibold tracking-[-0.025em]">
+                    {discussion.title}{" "}
+                    <span className="text-muted-foreground font-normal">#{discussion.number}</span>
+                  </h2>
+                  <p className="text-muted-foreground mt-2 text-[11px]">
+                    {t("workspace.repositories.discussionStartedBy", {
+                      author: discussion.author
+                        ? `@${discussion.author}`
+                        : t("workspace.repositories.unknownActor"),
+                      date: formatIssueDate(discussion.createdAt, i18n.language),
+                    })}
+                  </p>
+                </div>
+                <div className="flex flex-wrap items-center gap-2">
+                  <Button
+                    type="button"
+                    variant={discussion.viewerHasUpvoted ? "secondary" : "outline"}
+                    size="sm"
+                    disabled={!discussion.viewerCanUpvote || voteMutation.isPending}
+                    onClick={() => voteMutation.mutate()}
+                  >
+                    {voteMutation.isPending ? (
+                      <Spinner data-icon="inline-start" />
+                    ) : (
+                      <ThumbsUp data-icon="inline-start" />
+                    )}
+                    {discussion.upvoteCount}
+                  </Button>
+                  {discussion.viewerCanUpdate ? (
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      disabled={!availableCategories.length}
+                      onClick={() => setEditing(true)}
+                    >
+                      <Pencil data-icon="inline-start" />
+                      {t("workspace.repositories.editDiscussion")}
+                    </Button>
                   ) : null}
+                  {discussion.state === "open" && discussion.viewerCanClose ? (
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      onClick={() => setCloseOpen(true)}
+                    >
+                      <CheckCircle2 data-icon="inline-start" />
+                      {t("workspace.repositories.closeDiscussion")}
+                    </Button>
+                  ) : discussion.state === "closed" && discussion.viewerCanReopen ? (
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      disabled={reopenMutation.isPending}
+                      onClick={() => reopenMutation.mutate()}
+                    >
+                      {reopenMutation.isPending ? (
+                        <Spinner data-icon="inline-start" />
+                      ) : (
+                        <RotateCcw data-icon="inline-start" />
+                      )}
+                      {t("workspace.repositories.reopenDiscussion")}
+                    </Button>
+                  ) : null}
+                  {discussion.viewerCanDelete ? (
+                    <Button
+                      type="button"
+                      variant="destructive"
+                      size="sm"
+                      onClick={() => setDeleteOpen(true)}
+                    >
+                      <Trash2 data-icon="inline-start" />
+                      {t("workspace.repositories.deleteDiscussion")}
+                    </Button>
+                  ) : null}
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() => void openExternalUrl(discussion.url)}
+                  >
+                    <ExternalLink data-icon="inline-end" />
+                    {t("workspace.openOnGitHub")}
+                  </Button>
                 </div>
-                <h2 className="text-foreground text-xl leading-7 font-semibold tracking-[-0.025em]">
-                  {discussion.title}{" "}
-                  <span className="text-muted-foreground font-normal">#{discussion.number}</span>
-                </h2>
-                <p className="text-muted-foreground mt-2 text-[11px]">
-                  {t("workspace.repositories.discussionStartedBy", {
-                    author: discussion.author
-                      ? `@${discussion.author}`
-                      : t("workspace.repositories.unknownActor"),
-                    date: formatIssueDate(discussion.createdAt, i18n.language),
-                  })}
-                </p>
-              </div>
-              <div className="flex flex-wrap items-center gap-2">
-                <Button
-                  type="button"
-                  variant={discussion.viewerHasUpvoted ? "secondary" : "outline"}
-                  size="sm"
-                  disabled={!discussion.viewerCanUpvote || voteMutation.isPending}
-                  onClick={() => voteMutation.mutate()}
-                >
-                  {voteMutation.isPending ? (
-                    <Spinner data-icon="inline-start" />
-                  ) : (
-                    <ThumbsUp data-icon="inline-start" />
-                  )}
-                  {discussion.upvoteCount}
-                </Button>
-                {discussion.viewerCanUpdate ? (
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="sm"
-                    disabled={!availableCategories.length}
-                    onClick={() => setEditing(true)}
-                  >
-                    <Pencil data-icon="inline-start" />
-                    {t("workspace.repositories.editDiscussion")}
-                  </Button>
-                ) : null}
-                {discussion.state === "open" && discussion.viewerCanClose ? (
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="sm"
-                    onClick={() => setCloseOpen(true)}
-                  >
-                    <CheckCircle2 data-icon="inline-start" />
-                    {t("workspace.repositories.closeDiscussion")}
-                  </Button>
-                ) : discussion.state === "closed" && discussion.viewerCanReopen ? (
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="sm"
-                    disabled={reopenMutation.isPending}
-                    onClick={() => reopenMutation.mutate()}
-                  >
-                    {reopenMutation.isPending ? (
-                      <Spinner data-icon="inline-start" />
-                    ) : (
-                      <RotateCcw data-icon="inline-start" />
-                    )}
-                    {t("workspace.repositories.reopenDiscussion")}
-                  </Button>
-                ) : null}
-                {discussion.viewerCanDelete ? (
-                  <Button
-                    type="button"
-                    variant="destructive"
-                    size="sm"
-                    onClick={() => setDeleteOpen(true)}
-                  >
-                    <Trash2 data-icon="inline-start" />
-                    {t("workspace.repositories.deleteDiscussion")}
-                  </Button>
-                ) : null}
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  onClick={() => void openExternalUrl(discussion.url)}
-                >
-                  <ExternalLink data-icon="inline-end" />
-                  {t("workspace.openOnGitHub")}
-                </Button>
-              </div>
-            </header>
-
-            <article className="bg-card/30 overflow-hidden rounded-lg border">
-              <header className="bg-card/40 flex min-h-11 items-center gap-2 border-b px-3.5 py-2 text-xs font-medium">
-                {discussion.author
-                  ? `@${discussion.author}`
-                  : t("workspace.repositories.unknownActor")}
-                <span className="text-muted-foreground ml-auto text-[10px]">
-                  {formatIssueDate(discussion.updatedAt, i18n.language)}
-                </span>
               </header>
-              <div className="harbor-markdown min-h-24 px-4 py-4 text-[12px]">
-                <Suspense fallback={<Skeleton className="h-20 w-full" />}>
-                  <GitHubReadme
-                    content={discussion.body}
-                    path=""
-                    reference={repository.defaultBranch}
-                    repository={repository}
-                    onOpenExternal={(url) => void openExternalUrl(url)}
-                  />
-                </Suspense>
-              </div>
-            </article>
 
-            {poll ? (
-              <GitHubDiscussionPollCard repository={repository} target={target} poll={poll} />
-            ) : null}
+              <article className="bg-card/30 overflow-hidden rounded-lg border">
+                <header className="bg-card/40 flex min-h-11 items-center gap-2 border-b px-3.5 py-2 text-xs font-medium">
+                  {discussion.author
+                    ? `@${discussion.author}`
+                    : t("workspace.repositories.unknownActor")}
+                  <span className="text-muted-foreground ml-auto text-[10px]">
+                    {formatIssueDate(discussion.updatedAt, i18n.language)}
+                  </span>
+                </header>
+                <div className="harbor-markdown min-h-24 px-4 py-4 text-[12px]">
+                  <Suspense fallback={<Skeleton className="h-20 w-full" />}>
+                    <GitHubReadme
+                      content={discussion.body}
+                      path=""
+                      reference={repository.defaultBranch}
+                      repository={repository}
+                      onOpenExternal={(url) => void openExternalUrl(url)}
+                    />
+                  </Suspense>
+                </div>
+                <footer className="flex min-h-10 items-center border-t px-3 py-1.5">
+                  <GitHubReactionBar subject={{ id: discussion.id, kind: "discussion" }} />
+                </footer>
+              </article>
 
-            <div className="mt-5 flex items-center justify-between gap-3">
-              <h3 className="text-sm font-semibold">
-                {t("workspace.repositories.discussionComments", { count: discussion.commentCount })}
-              </h3>
-              {canComment ? (
-                <Button type="button" size="sm" onClick={() => setCommenting((value) => !value)}>
-                  <MessageSquarePlus data-icon="inline-start" />
-                  {t("workspace.repositories.addDiscussionComment")}
-                </Button>
+              {poll ? (
+                <GitHubDiscussionPollCard repository={repository} target={target} poll={poll} />
               ) : null}
-            </div>
-            {commenting ? (
-              <div className="mt-3 overflow-hidden rounded-lg border">
-                <DiscussionCommentEditor
-                  repository={repository}
-                  target={target}
-                  onCancel={() => setCommenting(false)}
-                />
-              </div>
-            ) : null}
-            <div className="mt-3 flex flex-col gap-3">
-              {comments.map((comment) => (
-                <GitHubDiscussionCommentCard
-                  key={comment.id}
-                  repository={repository}
-                  target={target}
-                  comment={comment}
-                  canReply={Boolean(canComment)}
-                />
-              ))}
-              {!comments.length ? (
-                <Empty className="min-h-48 rounded-lg border">
-                  <EmptyHeader>
-                    <EmptyMedia variant="icon">
-                      <MessageCircle />
-                    </EmptyMedia>
-                    <EmptyTitle>{t("workspace.repositories.noDiscussionComments")}</EmptyTitle>
-                    <EmptyDescription>
-                      {t("workspace.repositories.noDiscussionCommentsDescription")}
-                    </EmptyDescription>
-                  </EmptyHeader>
-                </Empty>
-              ) : null}
-              {result.hasNextPage ? (
-                <div className="flex justify-center pt-2">
-                  <Button
-                    type="button"
-                    variant="outline"
-                    disabled={result.isFetchingNextPage}
-                    onClick={() => void result.fetchNextPage()}
-                  >
-                    {result.isFetchingNextPage ? (
-                      <Spinner data-icon="inline-start" />
-                    ) : (
-                      <MessageCircle data-icon="inline-start" />
-                    )}
-                    {t("workspace.repositories.loadMoreDiscussionComments")}
+
+              <div className="mt-5 flex items-center justify-between gap-3">
+                <h3 className="text-sm font-semibold">
+                  {t("workspace.repositories.discussionComments", {
+                    count: discussion.commentCount,
+                  })}
+                </h3>
+                {canComment ? (
+                  <Button type="button" size="sm" onClick={() => setCommenting((value) => !value)}>
+                    <MessageSquarePlus data-icon="inline-start" />
+                    {t("workspace.repositories.addDiscussionComment")}
                   </Button>
+                ) : null}
+              </div>
+              {commenting ? (
+                <div className="mt-3 overflow-hidden rounded-lg border">
+                  <DiscussionCommentEditor
+                    repository={repository}
+                    target={target}
+                    onCancel={() => setCommenting(false)}
+                  />
                 </div>
               ) : null}
+              <div className="mt-3 flex flex-col gap-3">
+                {comments.map((comment) => (
+                  <GitHubDiscussionCommentCard
+                    key={comment.id}
+                    repository={repository}
+                    target={target}
+                    comment={comment}
+                    canReply={Boolean(canComment)}
+                  />
+                ))}
+                {!comments.length ? (
+                  <Empty className="min-h-48 rounded-lg border">
+                    <EmptyHeader>
+                      <EmptyMedia variant="icon">
+                        <MessageCircle />
+                      </EmptyMedia>
+                      <EmptyTitle>{t("workspace.repositories.noDiscussionComments")}</EmptyTitle>
+                      <EmptyDescription>
+                        {t("workspace.repositories.noDiscussionCommentsDescription")}
+                      </EmptyDescription>
+                    </EmptyHeader>
+                  </Empty>
+                ) : null}
+                {result.hasNextPage ? (
+                  <div className="flex justify-center pt-2">
+                    <Button
+                      type="button"
+                      variant="outline"
+                      disabled={result.isFetchingNextPage}
+                      onClick={() => void result.fetchNextPage()}
+                    >
+                      {result.isFetchingNextPage ? (
+                        <Spinner data-icon="inline-start" />
+                      ) : (
+                        <MessageCircle data-icon="inline-start" />
+                      )}
+                      {t("workspace.repositories.loadMoreDiscussionComments")}
+                    </Button>
+                  </div>
+                ) : null}
+              </div>
             </div>
-          </div>
+          </GitHubReactionsProvider>
         )}
       </ScrollArea>
       {discussion ? (

--- a/src/features/github/github-issue-mutations.test.ts
+++ b/src/features/github/github-issue-mutations.test.ts
@@ -33,6 +33,7 @@ const target = {
 
 const issue: GitHubIssue = {
   id: 2,
+  reactionSubject: { id: "I_2", kind: "issue" },
   number: 7,
   title: "Keep the example focused",
   url: "https://github.com/octocat/hello-world/issues/7",

--- a/src/features/github/github-issue-timeline.tsx
+++ b/src/features/github/github-issue-timeline.tsx
@@ -10,8 +10,11 @@ import type {
   GitHubIssueTimelineItem,
   GitHubPullRequest,
   GitHubPullRequestReviewState,
+  GitHubReactionSubjectRef,
   GitHubRepositoryContentContext,
 } from "./github-data";
+import { GitHubReactionBar } from "./github-reaction-bar";
+import { GitHubReactionsProvider } from "./github-reactions-provider";
 import { formatIssueDate, GitHubIssuePagination } from "./github-issue-shared";
 
 const GitHubReadme = lazy(() => import("./github-readme"));
@@ -58,6 +61,7 @@ function ConversationCard({
   locale,
   emptyBody,
   reviewState,
+  reactionSubject,
 }: {
   actor: string;
   avatarUrl?: string;
@@ -68,6 +72,7 @@ function ConversationCard({
   locale: string;
   emptyBody: string;
   reviewState?: GitHubPullRequestReviewState;
+  reactionSubject?: GitHubReactionSubjectRef;
 }) {
   const { t } = useTranslation();
   return (
@@ -123,6 +128,11 @@ function ConversationCard({
           <p className="text-muted-foreground">{emptyBody}</p>
         )}
       </div>
+      {reactionSubject ? (
+        <footer className="flex min-h-10 items-center border-t px-3 py-1.5">
+          <GitHubReactionBar subject={reactionSubject} />
+        </footer>
+      ) : null}
     </article>
   );
 }
@@ -140,7 +150,7 @@ export function GitHubIssueTimeline({
 }: {
   issue: Pick<
     GitHubIssue | GitHubPullRequest,
-    "author" | "authorAvatarUrl" | "authorAssociation" | "body" | "createdAt"
+    "author" | "authorAvatarUrl" | "authorAssociation" | "body" | "createdAt" | "reactionSubject"
   >;
   timeline: GitHubIssueTimelineItem[];
   repository: GitHubRepositoryContentContext;
@@ -153,58 +163,67 @@ export function GitHubIssueTimeline({
 }) {
   const { t } = useTranslation();
   const emptyBodyText = emptyBody ?? t("workspace.repositories.noIssueBody");
+  const reactionSubjects = [
+    issue.reactionSubject,
+    ...timeline.map((item) => item.reactionSubject),
+  ].filter((subject): subject is GitHubReactionSubjectRef => Boolean(subject));
   return (
-    <div className="before:bg-border relative flex min-w-0 flex-col gap-3 before:absolute before:top-8 before:bottom-4 before:left-[13px] before:w-px">
-      <div className="relative z-10 pl-10">
-        <ConversationCard
-          actor={issue.author}
-          avatarUrl={issue.authorAvatarUrl}
-          association={issue.authorAssociation}
-          body={issue.body}
-          createdAt={issue.createdAt}
-          repository={repository}
-          locale={locale}
-          emptyBody={emptyBodyText}
+    <GitHubReactionsProvider repository={repository} subjects={reactionSubjects}>
+      <div className="before:bg-border relative flex min-w-0 flex-col gap-3 before:absolute before:top-8 before:bottom-4 before:left-[13px] before:w-px">
+        <div className="relative z-10 pl-10">
+          <ConversationCard
+            actor={issue.author}
+            avatarUrl={issue.authorAvatarUrl}
+            association={issue.authorAssociation}
+            body={issue.body}
+            createdAt={issue.createdAt}
+            repository={repository}
+            locale={locale}
+            emptyBody={emptyBodyText}
+            reactionSubject={issue.reactionSubject}
+          />
+        </div>
+        {timeline.map((item) =>
+          item.kind === "comment" && item.actor && item.createdAt ? (
+            <div key={item.id} className="relative z-10 pl-10">
+              <ConversationCard
+                actor={item.actor}
+                avatarUrl={item.actorAvatarUrl}
+                association={item.authorAssociation}
+                body={item.body}
+                createdAt={item.createdAt}
+                repository={repository}
+                locale={locale}
+                emptyBody={emptyBodyText}
+                reactionSubject={item.reactionSubject}
+              />
+            </div>
+          ) : item.event === "reviewed" && item.actor && item.createdAt ? (
+            <div key={item.id} className="relative z-10 pl-10">
+              <ConversationCard
+                actor={item.actor}
+                avatarUrl={item.actorAvatarUrl}
+                association={item.authorAssociation}
+                body={item.body}
+                createdAt={item.createdAt}
+                repository={repository}
+                locale={locale}
+                emptyBody={t("workspace.repositories.reviewWithoutBody")}
+                reviewState={item.reviewState ?? "commented"}
+                reactionSubject={item.reactionSubject}
+              />
+            </div>
+          ) : (
+            <TimelineEvent key={item.id} item={item} locale={locale} />
+          )
+        )}
+        <GitHubIssuePagination
+          page={page}
+          hasPrevious={hasPrevious}
+          hasMore={hasMore}
+          onPageChange={onPageChange}
         />
       </div>
-      {timeline.map((item) =>
-        item.kind === "comment" && item.actor && item.createdAt ? (
-          <div key={item.id} className="relative z-10 pl-10">
-            <ConversationCard
-              actor={item.actor}
-              avatarUrl={item.actorAvatarUrl}
-              association={item.authorAssociation}
-              body={item.body}
-              createdAt={item.createdAt}
-              repository={repository}
-              locale={locale}
-              emptyBody={emptyBodyText}
-            />
-          </div>
-        ) : item.event === "reviewed" && item.actor && item.createdAt ? (
-          <div key={item.id} className="relative z-10 pl-10">
-            <ConversationCard
-              actor={item.actor}
-              avatarUrl={item.actorAvatarUrl}
-              association={item.authorAssociation}
-              body={item.body}
-              createdAt={item.createdAt}
-              repository={repository}
-              locale={locale}
-              emptyBody={t("workspace.repositories.reviewWithoutBody")}
-              reviewState={item.reviewState ?? "commented"}
-            />
-          </div>
-        ) : (
-          <TimelineEvent key={item.id} item={item} locale={locale} />
-        )
-      )}
-      <GitHubIssuePagination
-        page={page}
-        hasPrevious={hasPrevious}
-        hasMore={hasMore}
-        onPageChange={onPageChange}
-      />
-    </div>
+    </GitHubReactionsProvider>
   );
 }

--- a/src/features/github/github-pull-request-files.tsx
+++ b/src/features/github/github-pull-request-files.tsx
@@ -43,6 +43,7 @@ import {
 } from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { parseIpcError } from "@/lib/ipc-error";
 import { openExternalUrl } from "@/lib/window";
 import type {
@@ -703,15 +704,20 @@ export function GitHubPullRequestFiles({
                     <span className="text-success text-[10px]">+{file.additions}</span>
                     <span className="text-destructive text-[10px]">-{file.deletions}</span>
                     {file.blobUrl ? (
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="icon-xs"
-                        aria-label={t("workspace.repositories.viewSource")}
-                        onClick={() => file.blobUrl && void openExternalUrl(file.blobUrl)}
-                      >
-                        <ExternalLink />
-                      </Button>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="icon-xs"
+                            aria-label={t("workspace.repositories.viewSource")}
+                            onClick={() => file.blobUrl && void openExternalUrl(file.blobUrl)}
+                          >
+                            <ExternalLink />
+                          </Button>
+                        </TooltipTrigger>
+                        <TooltipContent>{t("workspace.repositories.viewSource")}</TooltipContent>
+                      </Tooltip>
                     ) : null}
                   </div>
                   <CollapsibleContent>

--- a/src/features/github/github-pull-request-files.tsx
+++ b/src/features/github/github-pull-request-files.tsx
@@ -52,6 +52,7 @@ import type {
   GitHubPullRequestFile,
   GitHubPullRequestReviewComment,
   GitHubPullRequestReviewCommentSide,
+  GitHubReactionSubjectRef,
   GitHubPullRequestRepository,
   GitHubPullRequestReviewThread,
 } from "./github-data";
@@ -67,6 +68,7 @@ import {
 } from "./github-pull-request-review-comments";
 import { GitHubPullRequestReviewDialog } from "./github-pull-request-review-dialog";
 import { GitHubPullRequestReviewThreadView } from "./github-pull-request-review-thread";
+import { GitHubReactionsProvider } from "./github-reactions-provider";
 import {
   deletePendingRepositoryPullRequestReviewComment,
   markPullRequestReviewThreadsStale,
@@ -512,6 +514,11 @@ export function GitHubPullRequestFiles({
   const reviewThreads = (
     reviewThreadsResult.data?.pages.flatMap((threadPage) => threadPage.threads) ?? []
   ).filter((thread) => !thread.comments.some((comment) => pendingCommentIds.has(comment.id)));
+  const reactionSubjects = reviewThreads.flatMap((thread) =>
+    thread.comments.flatMap((comment): GitHubReactionSubjectRef[] =>
+      comment.pending ? [] : [{ id: comment.id, kind: "pullRequestReviewComment" }]
+    )
+  );
   const reviewThreadsError = reviewThreadsResult.error
     ? parseIpcError(reviewThreadsResult.error)
     : null;
@@ -545,233 +552,235 @@ export function GitHubPullRequestFiles({
   };
 
   return (
-    <div className="flex min-h-0 min-w-0 flex-1 flex-col">
-      <div className="flex min-h-12 items-center justify-between gap-3 border-b px-4 py-2">
-        <p className="text-muted-foreground text-[11px]">
-          {data
-            ? t("workspace.repositories.changedFileCount", { count: data.files.length })
-            : t("workspace.repositories.filesChanged")}
-        </p>
-        <div className="flex flex-wrap items-center justify-end gap-2">
-          {reviewThreadsResult.isPending || pendingReviewResult.isPending ? (
-            <span className="text-muted-foreground inline-flex items-center gap-1.5 text-[10px]">
-              <Spinner className="size-3" />
-              {t("workspace.repositories.reviewThreadsLoading")}
-            </span>
-          ) : null}
-          <Select value={viewType} onValueChange={(value) => setViewType(value as ViewType)}>
-            <SelectTrigger size="sm" className="w-[140px]">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectGroup>
-                <SelectItem value="unified">{t("workspace.repositories.unifiedDiff")}</SelectItem>
-                <SelectItem value="split">{t("workspace.repositories.splitDiff")}</SelectItem>
-              </SelectGroup>
-            </SelectContent>
-          </Select>
-          {pullRequest.state === "open" && !pullRequest.merged ? (
-            <Button
-              type="button"
-              size="sm"
-              disabled={pendingReviewResult.isPending || Boolean(pendingReviewError)}
-              onClick={() => setReviewOpen(true)}
-            >
-              <ShieldCheck data-icon="inline-start" />
-              {t("workspace.repositories.reviewChanges")}
-              {comments.length + (pendingReview?.uneditableCommentCount ?? 0) ? (
-                <Badge className="bg-primary-foreground/15 text-primary-foreground ml-1 rounded-sm px-1 py-0 text-[9px]">
-                  {comments.length + (pendingReview?.uneditableCommentCount ?? 0)}
-                </Badge>
-              ) : null}
-            </Button>
-          ) : null}
-        </div>
-      </div>
-      <ScrollArea className="min-h-0 min-w-0 flex-1" constrainContentWidth>
-        <div className="mx-auto flex w-full max-w-[1280px] flex-col gap-3 px-4 py-5 sm:px-5">
-          {reviewThreadsError ? (
-            <Alert variant="destructive">
-              <CircleAlert />
-              <AlertTitle>{t("workspace.repositories.reviewThreadsLoadFailed")}</AlertTitle>
-              <AlertDescription className="flex flex-wrap items-center justify-between gap-2">
-                <span>{reviewThreadsError.message}</span>
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="xs"
-                  onClick={() => void reviewThreadsResult.refetch()}
-                >
-                  <RefreshCw data-icon="inline-start" />
-                  {t("workspace.repositories.retry")}
-                </Button>
-              </AlertDescription>
-            </Alert>
-          ) : null}
-          {pendingReviewError ? (
-            <Alert variant="destructive">
-              <CircleAlert />
-              <AlertTitle>{t("workspace.repositories.pendingReviewLoadFailed")}</AlertTitle>
-              <AlertDescription className="flex flex-wrap items-center justify-between gap-2">
-                <span>{pendingReviewError.message}</span>
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="xs"
-                  onClick={() => void pendingReviewResult.refetch()}
-                >
-                  <RefreshCw data-icon="inline-start" />
-                  {t("workspace.repositories.retry")}
-                </Button>
-              </AlertDescription>
-            </Alert>
-          ) : null}
-          {pendingReview && !pendingReviewError ? (
-            <Alert>
-              <ShieldCheck />
-              <AlertTitle>
-                {t(
-                  stalePendingReview
-                    ? "workspace.repositories.pendingReviewOutdated"
-                    : "workspace.repositories.pendingReviewRestored"
-                )}
-              </AlertTitle>
-              <AlertDescription>
-                {t(
-                  stalePendingReview
-                    ? "workspace.repositories.pendingReviewOutdatedDescription"
-                    : "workspace.repositories.pendingReviewRestoredDescription",
-                  {
-                    count: comments.length + (pendingReview.uneditableCommentCount ?? 0),
-                  }
-                )}
-              </AlertDescription>
-            </Alert>
-          ) : null}
-          {result.isPending ? (
-            Array.from({ length: 4 }, (_, index) => (
-              <Skeleton key={index} className="h-32 w-full" />
-            ))
-          ) : error ? (
-            <Empty className="min-h-80">
-              <EmptyHeader>
-                <EmptyMedia variant="icon">
-                  <FileDiff />
-                </EmptyMedia>
-                <EmptyTitle>{t("workspace.repositories.pullRequestFilesLoadFailed")}</EmptyTitle>
-                <EmptyDescription>{error.message}</EmptyDescription>
-              </EmptyHeader>
-              <EmptyContent>
-                <Button variant="outline" onClick={() => void result.refetch()}>
-                  <RefreshCw data-icon="inline-start" />
-                  {t("workspace.repositories.retry")}
-                </Button>
-              </EmptyContent>
-            </Empty>
-          ) : data?.files.length ? (
-            data.files.map((file, index) => (
-              <Collapsible
-                key={`${file.sha ?? file.path}-${file.path}`}
-                defaultOpen={index < 2}
-                className="overflow-hidden rounded-lg border"
-              >
-                <div className="bg-card/45 flex min-w-0 items-center gap-2 border-b px-2 py-1.5">
-                  <CollapsibleTrigger asChild>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="sm"
-                      className="group min-w-0 flex-1 justify-start"
-                    >
-                      <ChevronDown className="transition-transform group-data-[state=closed]:-rotate-90" />
-                      <span className="truncate font-mono text-[11px]">{file.path}</span>
-                    </Button>
-                  </CollapsibleTrigger>
-                  <Badge variant="outline" className="shrink-0 rounded-md text-[9px]">
-                    {t(`workspace.repositories.fileStatuses.${file.status}`, {
-                      defaultValue: file.status,
-                    })}
-                  </Badge>
-                  <span className="text-success text-[10px]">+{file.additions}</span>
-                  <span className="text-destructive text-[10px]">-{file.deletions}</span>
-                  {file.blobUrl ? (
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="icon-xs"
-                      aria-label={t("workspace.repositories.viewSource")}
-                      onClick={() => file.blobUrl && void openExternalUrl(file.blobUrl)}
-                    >
-                      <ExternalLink />
-                    </Button>
-                  ) : null}
-                </div>
-                <CollapsibleContent>
-                  <PullRequestFileDiff
-                    file={file}
-                    viewType={viewType}
-                    repository={repository}
-                    pullRequest={pullRequest}
-                    comments={comments}
-                    threads={reviewThreads}
-                    canCreateComment={
-                      !pendingReviewResult.isPending && !pendingReviewError && !stalePendingReview
-                    }
-                    onSaveComment={saveComment}
-                    onDeleteComment={deleteComment}
-                  />
-                </CollapsibleContent>
-              </Collapsible>
-            ))
-          ) : (
-            <Empty className="min-h-80">
-              <EmptyHeader>
-                <EmptyMedia variant="icon">
-                  <FileDiff />
-                </EmptyMedia>
-                <EmptyTitle>{t("workspace.repositories.noPullRequestFiles")}</EmptyTitle>
-              </EmptyHeader>
-            </Empty>
-          )}
-          {data ? (
-            <GitHubPagination
-              page={data.page}
-              hasPrevious={data.hasPrevious}
-              hasMore={data.hasMore}
-              onPageChange={onPageChange}
-              ariaLabel={t("workspace.repositories.pullRequestFilePagination")}
-            />
-          ) : null}
-          {reviewThreadsResult.hasNextPage ? (
-            <div className="border-border/50 flex justify-center border-t pt-3">
+    <GitHubReactionsProvider repository={repository} subjects={reactionSubjects}>
+      <div className="flex min-h-0 min-w-0 flex-1 flex-col">
+        <div className="flex min-h-12 items-center justify-between gap-3 border-b px-4 py-2">
+          <p className="text-muted-foreground text-[11px]">
+            {data
+              ? t("workspace.repositories.changedFileCount", { count: data.files.length })
+              : t("workspace.repositories.filesChanged")}
+          </p>
+          <div className="flex flex-wrap items-center justify-end gap-2">
+            {reviewThreadsResult.isPending || pendingReviewResult.isPending ? (
+              <span className="text-muted-foreground inline-flex items-center gap-1.5 text-[10px]">
+                <Spinner className="size-3" />
+                {t("workspace.repositories.reviewThreadsLoading")}
+              </span>
+            ) : null}
+            <Select value={viewType} onValueChange={(value) => setViewType(value as ViewType)}>
+              <SelectTrigger size="sm" className="w-[140px]">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectGroup>
+                  <SelectItem value="unified">{t("workspace.repositories.unifiedDiff")}</SelectItem>
+                  <SelectItem value="split">{t("workspace.repositories.splitDiff")}</SelectItem>
+                </SelectGroup>
+              </SelectContent>
+            </Select>
+            {pullRequest.state === "open" && !pullRequest.merged ? (
               <Button
                 type="button"
-                variant="outline"
                 size="sm"
-                disabled={reviewThreadsResult.isFetchingNextPage}
-                onClick={() => void reviewThreadsResult.fetchNextPage()}
+                disabled={pendingReviewResult.isPending || Boolean(pendingReviewError)}
+                onClick={() => setReviewOpen(true)}
               >
-                {reviewThreadsResult.isFetchingNextPage ? (
-                  <Spinner data-icon="inline-start" />
+                <ShieldCheck data-icon="inline-start" />
+                {t("workspace.repositories.reviewChanges")}
+                {comments.length + (pendingReview?.uneditableCommentCount ?? 0) ? (
+                  <Badge className="bg-primary-foreground/15 text-primary-foreground ml-1 rounded-sm px-1 py-0 text-[9px]">
+                    {comments.length + (pendingReview?.uneditableCommentCount ?? 0)}
+                  </Badge>
                 ) : null}
-                {t(
-                  reviewThreadsResult.isFetchingNextPage
-                    ? "workspace.repositories.loadingMoreReviewThreads"
-                    : "workspace.repositories.loadMoreReviewThreads"
-                )}
               </Button>
-            </div>
-          ) : null}
+            ) : null}
+          </div>
         </div>
-      </ScrollArea>
-      <GitHubPullRequestReviewDialog
-        repository={repository}
-        pullRequest={pullRequest}
-        open={reviewOpen}
-        onOpenChange={setReviewOpen}
-        pendingReview={pendingReview}
-        onPendingReviewChange={setPendingReview}
-      />
-    </div>
+        <ScrollArea className="min-h-0 min-w-0 flex-1" constrainContentWidth>
+          <div className="mx-auto flex w-full max-w-[1280px] flex-col gap-3 px-4 py-5 sm:px-5">
+            {reviewThreadsError ? (
+              <Alert variant="destructive">
+                <CircleAlert />
+                <AlertTitle>{t("workspace.repositories.reviewThreadsLoadFailed")}</AlertTitle>
+                <AlertDescription className="flex flex-wrap items-center justify-between gap-2">
+                  <span>{reviewThreadsError.message}</span>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="xs"
+                    onClick={() => void reviewThreadsResult.refetch()}
+                  >
+                    <RefreshCw data-icon="inline-start" />
+                    {t("workspace.repositories.retry")}
+                  </Button>
+                </AlertDescription>
+              </Alert>
+            ) : null}
+            {pendingReviewError ? (
+              <Alert variant="destructive">
+                <CircleAlert />
+                <AlertTitle>{t("workspace.repositories.pendingReviewLoadFailed")}</AlertTitle>
+                <AlertDescription className="flex flex-wrap items-center justify-between gap-2">
+                  <span>{pendingReviewError.message}</span>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="xs"
+                    onClick={() => void pendingReviewResult.refetch()}
+                  >
+                    <RefreshCw data-icon="inline-start" />
+                    {t("workspace.repositories.retry")}
+                  </Button>
+                </AlertDescription>
+              </Alert>
+            ) : null}
+            {pendingReview && !pendingReviewError ? (
+              <Alert>
+                <ShieldCheck />
+                <AlertTitle>
+                  {t(
+                    stalePendingReview
+                      ? "workspace.repositories.pendingReviewOutdated"
+                      : "workspace.repositories.pendingReviewRestored"
+                  )}
+                </AlertTitle>
+                <AlertDescription>
+                  {t(
+                    stalePendingReview
+                      ? "workspace.repositories.pendingReviewOutdatedDescription"
+                      : "workspace.repositories.pendingReviewRestoredDescription",
+                    {
+                      count: comments.length + (pendingReview.uneditableCommentCount ?? 0),
+                    }
+                  )}
+                </AlertDescription>
+              </Alert>
+            ) : null}
+            {result.isPending ? (
+              Array.from({ length: 4 }, (_, index) => (
+                <Skeleton key={index} className="h-32 w-full" />
+              ))
+            ) : error ? (
+              <Empty className="min-h-80">
+                <EmptyHeader>
+                  <EmptyMedia variant="icon">
+                    <FileDiff />
+                  </EmptyMedia>
+                  <EmptyTitle>{t("workspace.repositories.pullRequestFilesLoadFailed")}</EmptyTitle>
+                  <EmptyDescription>{error.message}</EmptyDescription>
+                </EmptyHeader>
+                <EmptyContent>
+                  <Button variant="outline" onClick={() => void result.refetch()}>
+                    <RefreshCw data-icon="inline-start" />
+                    {t("workspace.repositories.retry")}
+                  </Button>
+                </EmptyContent>
+              </Empty>
+            ) : data?.files.length ? (
+              data.files.map((file, index) => (
+                <Collapsible
+                  key={`${file.sha ?? file.path}-${file.path}`}
+                  defaultOpen={index < 2}
+                  className="overflow-hidden rounded-lg border"
+                >
+                  <div className="bg-card/45 flex min-w-0 items-center gap-2 border-b px-2 py-1.5">
+                    <CollapsibleTrigger asChild>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        className="group min-w-0 flex-1 justify-start"
+                      >
+                        <ChevronDown className="transition-transform group-data-[state=closed]:-rotate-90" />
+                        <span className="truncate font-mono text-[11px]">{file.path}</span>
+                      </Button>
+                    </CollapsibleTrigger>
+                    <Badge variant="outline" className="shrink-0 rounded-md text-[9px]">
+                      {t(`workspace.repositories.fileStatuses.${file.status}`, {
+                        defaultValue: file.status,
+                      })}
+                    </Badge>
+                    <span className="text-success text-[10px]">+{file.additions}</span>
+                    <span className="text-destructive text-[10px]">-{file.deletions}</span>
+                    {file.blobUrl ? (
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon-xs"
+                        aria-label={t("workspace.repositories.viewSource")}
+                        onClick={() => file.blobUrl && void openExternalUrl(file.blobUrl)}
+                      >
+                        <ExternalLink />
+                      </Button>
+                    ) : null}
+                  </div>
+                  <CollapsibleContent>
+                    <PullRequestFileDiff
+                      file={file}
+                      viewType={viewType}
+                      repository={repository}
+                      pullRequest={pullRequest}
+                      comments={comments}
+                      threads={reviewThreads}
+                      canCreateComment={
+                        !pendingReviewResult.isPending && !pendingReviewError && !stalePendingReview
+                      }
+                      onSaveComment={saveComment}
+                      onDeleteComment={deleteComment}
+                    />
+                  </CollapsibleContent>
+                </Collapsible>
+              ))
+            ) : (
+              <Empty className="min-h-80">
+                <EmptyHeader>
+                  <EmptyMedia variant="icon">
+                    <FileDiff />
+                  </EmptyMedia>
+                  <EmptyTitle>{t("workspace.repositories.noPullRequestFiles")}</EmptyTitle>
+                </EmptyHeader>
+              </Empty>
+            )}
+            {data ? (
+              <GitHubPagination
+                page={data.page}
+                hasPrevious={data.hasPrevious}
+                hasMore={data.hasMore}
+                onPageChange={onPageChange}
+                ariaLabel={t("workspace.repositories.pullRequestFilePagination")}
+              />
+            ) : null}
+            {reviewThreadsResult.hasNextPage ? (
+              <div className="border-border/50 flex justify-center border-t pt-3">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  disabled={reviewThreadsResult.isFetchingNextPage}
+                  onClick={() => void reviewThreadsResult.fetchNextPage()}
+                >
+                  {reviewThreadsResult.isFetchingNextPage ? (
+                    <Spinner data-icon="inline-start" />
+                  ) : null}
+                  {t(
+                    reviewThreadsResult.isFetchingNextPage
+                      ? "workspace.repositories.loadingMoreReviewThreads"
+                      : "workspace.repositories.loadMoreReviewThreads"
+                  )}
+                </Button>
+              </div>
+            ) : null}
+          </div>
+        </ScrollArea>
+        <GitHubPullRequestReviewDialog
+          repository={repository}
+          pullRequest={pullRequest}
+          open={reviewOpen}
+          onOpenChange={setReviewOpen}
+          pendingReview={pendingReview}
+          onPendingReviewChange={setPendingReview}
+        />
+      </div>
+    </GitHubReactionsProvider>
   );
 }

--- a/src/features/github/github-pull-request-review-thread.tsx
+++ b/src/features/github/github-pull-request-review-thread.tsx
@@ -28,6 +28,7 @@ import type {
 } from "./github-data";
 import { formatIssueDate } from "./github-issue-shared";
 import { GitHubMarkdownEditor } from "./github-markdown-editor";
+import { GitHubReactionBar } from "./github-reaction-bar";
 import {
   markPullRequestReviewThreadsStale,
   replyToPullRequestReviewThread,
@@ -103,6 +104,11 @@ function ReviewThreadComment({
           />
         </Suspense>
       </div>
+      {!comment.pending ? (
+        <footer className="flex min-h-9 items-center border-t px-3 py-1">
+          <GitHubReactionBar subject={{ id: comment.id, kind: "pullRequestReviewComment" }} />
+        </footer>
+      ) : null}
     </article>
   );
 }

--- a/src/features/github/github-queries.ts
+++ b/src/features/github/github-queries.ts
@@ -56,6 +56,8 @@ import type {
   GitHubPullRequestReviewTeamPage,
   GitHubPullRequestSort,
   GitHubPullRequestState,
+  GitHubReactionSubject,
+  GitHubReactionSubjectRef,
   GitHubRelease,
   GitHubReleasePage,
   GitHubRepositoryPage,
@@ -100,7 +102,15 @@ type GitHubContentsTarget = GitHubCodeTarget & {
   path: string;
 };
 
-type GitHubRepositoryTarget = Pick<GitHubCodeTarget, "owner" | "repository">;
+export type GitHubRepositoryTarget = Pick<GitHubCodeTarget, "owner" | "repository">;
+
+export type GitHubReactionsTarget = GitHubRepositoryTarget & {
+  subjects: GitHubReactionSubjectRef[];
+};
+
+export type GitHubReactionTarget = GitHubRepositoryTarget & {
+  subject: GitHubReactionSubjectRef;
+};
 
 export type GitHubDiscussionsTarget = GitHubRepositoryTarget & {
   categoryId: string | null;
@@ -453,6 +463,28 @@ export const githubQueryKeys = {
     ["github", "repository", owner, repository, "discussions"] as const,
   discussionDetail: ({ owner, repository, discussionNumber }: GitHubDiscussionTarget) =>
     ["github", "repository", owner, repository, "discussion", discussionNumber] as const,
+  reactions: ({ owner, repository, subjects }: GitHubReactionsTarget) =>
+    [
+      "github",
+      "repository",
+      owner,
+      repository,
+      "reactions",
+      ...subjects.map((subject) => `${subject.kind}:${subject.id}`),
+    ] as const,
+  reaction: ({ owner, repository, subject }: GitHubReactionTarget) =>
+    [
+      "github",
+      "repository",
+      owner,
+      repository,
+      "reactions",
+      "subject",
+      subject.kind,
+      subject.id,
+    ] as const,
+  reactionsRoot: ({ owner, repository }: GitHubRepositoryTarget) =>
+    ["github", "repository", owner, repository, "reactions"] as const,
   releases: ({ owner, repository, page }: GitHubReleasesTarget) =>
     ["github", "repository", owner, repository, "releases", page] as const,
   releasesRoot: ({ owner, repository }: GitHubRepositoryTarget) =>
@@ -1201,6 +1233,14 @@ export function discussionDetailQueryOptions(target: GitHubDiscussionTarget) {
       }),
     initialPageParam: null as string | null,
     getNextPageParam: (lastPage) => (lastPage.hasMore ? lastPage.endCursor : undefined),
+    staleTime: GITHUB_QUERY_STALE_TIME,
+  });
+}
+
+export function repositoryReactionsQueryOptions(target: GitHubReactionsTarget) {
+  return queryOptions({
+    queryKey: githubQueryKeys.reactions(target),
+    queryFn: () => invoke<GitHubReactionSubject[]>("github_get_repository_reactions", target),
     staleTime: GITHUB_QUERY_STALE_TIME,
   });
 }

--- a/src/features/github/github-reaction-bar.tsx
+++ b/src/features/github/github-reaction-bar.tsx
@@ -1,5 +1,4 @@
 import { RefreshCw, SmilePlus } from "lucide-react";
-import { useTranslation } from "react-i18next";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -10,6 +9,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { useAppTranslation } from "@/hooks/use-app-translation";
 import { cn } from "@/lib/utils";
 import type { GitHubReactionContent, GitHubReactionSubjectRef } from "./github-data";
 import { useGitHubReactions } from "./github-reactions-provider";
@@ -40,7 +40,7 @@ export function GitHubReactionBar({
   subject: GitHubReactionSubjectRef;
   className?: string;
 }) {
-  const { t } = useTranslation();
+  const { t } = useAppTranslation();
   const reactions = useGitHubReactions();
   if (!reactions) return null;
   const current = reactions.subject(subject);

--- a/src/features/github/github-reaction-bar.tsx
+++ b/src/features/github/github-reaction-bar.tsx
@@ -1,0 +1,157 @@
+import { RefreshCw, SmilePlus } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+import type { GitHubReactionContent, GitHubReactionSubjectRef } from "./github-data";
+import { useGitHubReactions } from "./github-reactions-provider";
+
+const REACTIONS: Array<{ content: GitHubReactionContent; emoji: string }> = [
+  { content: "thumbsUp", emoji: "👍" },
+  { content: "thumbsDown", emoji: "👎" },
+  { content: "laugh", emoji: "😄" },
+  { content: "hooray", emoji: "🎉" },
+  { content: "confused", emoji: "😕" },
+  { content: "heart", emoji: "❤️" },
+  { content: "rocket", emoji: "🚀" },
+  { content: "eyes", emoji: "👀" },
+];
+
+function supportedReactions(subject: GitHubReactionSubjectRef) {
+  return subject.kind === "release"
+    ? REACTIONS.filter(
+        (reaction) => reaction.content !== "thumbsDown" && reaction.content !== "confused"
+      )
+    : REACTIONS;
+}
+
+export function GitHubReactionBar({
+  subject,
+  className,
+}: {
+  subject: GitHubReactionSubjectRef;
+  className?: string;
+}) {
+  const { t } = useTranslation();
+  const reactions = useGitHubReactions();
+  if (!reactions) return null;
+  const current = reactions.subject(subject);
+
+  if (!current && reactions.loading) {
+    return <Skeleton className={cn("h-7 w-20", className)} />;
+  }
+  if (!current && reactions.error) {
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            className={className}
+            aria-label={t("workspace.repositories.reactions.retry")}
+            onClick={reactions.retry}
+          >
+            <RefreshCw />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>{t("workspace.repositories.reactions.loadFailed")}</TooltipContent>
+      </Tooltip>
+    );
+  }
+  if (!current) return null;
+
+  const available = supportedReactions(subject);
+  const visibleGroups = available.flatMap((reaction) => {
+    const group = current.groups.find((group) => group.content === reaction.content);
+    return group && group.count > 0 ? [{ ...reaction, group }] : [];
+  });
+  if (!visibleGroups.length && !current.viewerCanReact) return null;
+
+  return (
+    <div className={cn("flex min-w-0 flex-wrap items-center gap-1", className)}>
+      {visibleGroups.map(({ content, emoji, group }) => {
+        const canToggle = current.viewerCanReact || group.viewerHasReacted;
+        return (
+          <Tooltip key={content}>
+            <TooltipTrigger asChild>
+              <Button
+                type="button"
+                variant={group.viewerHasReacted ? "secondary" : "outline"}
+                size="xs"
+                className="h-7 min-w-10 px-2"
+                aria-pressed={group.viewerHasReacted}
+                aria-label={t(
+                  group.viewerHasReacted
+                    ? "workspace.repositories.reactions.toggleLabelSelected"
+                    : "workspace.repositories.reactions.toggleLabel",
+                  {
+                    reaction: t(`workspace.repositories.reactions.names.${content}`),
+                    count: group.count,
+                  }
+                )}
+                disabled={!canToggle || reactions.pending}
+                onClick={() => reactions.toggle(subject, content)}
+              >
+                <span aria-hidden="true">{emoji}</span>
+                <span>{group.count}</span>
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+              {t(`workspace.repositories.reactions.names.${content}`)}
+            </TooltipContent>
+          </Tooltip>
+        );
+      })}
+
+      {current.viewerCanReact ? (
+        <DropdownMenu>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-xs"
+                  aria-label={t("workspace.repositories.reactions.add")}
+                  disabled={reactions.pending}
+                >
+                  <SmilePlus />
+                </Button>
+              </DropdownMenuTrigger>
+            </TooltipTrigger>
+            <TooltipContent>{t("workspace.repositories.reactions.add")}</TooltipContent>
+          </Tooltip>
+          <DropdownMenuContent align="start" className="min-w-44">
+            <DropdownMenuGroup>
+              {available.map(({ content, emoji }) => {
+                const selected = current.groups.some(
+                  (group) => group.content === content && group.viewerHasReacted
+                );
+                return (
+                  <DropdownMenuCheckboxItem
+                    key={content}
+                    checked={selected}
+                    disabled={reactions.pending}
+                    onCheckedChange={() => reactions.toggle(subject, content)}
+                  >
+                    <span aria-hidden="true">{emoji}</span>
+                    <span>{t(`workspace.repositories.reactions.names.${content}`)}</span>
+                  </DropdownMenuCheckboxItem>
+                );
+              })}
+            </DropdownMenuGroup>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      ) : null}
+    </div>
+  );
+}

--- a/src/features/github/github-reactions-provider.tsx
+++ b/src/features/github/github-reactions-provider.tsx
@@ -1,7 +1,7 @@
 import { createContext, useContext, useEffect, useMemo, type ReactNode } from "react";
 import { useMutation, useQueries, useQueryClient } from "@tanstack/react-query";
-import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
+import { useAppTranslation } from "@/hooks/use-app-translation";
 import { parseIpcError, type IpcError } from "@/lib/ipc-error";
 import type {
   GitHubReactionContent,
@@ -13,6 +13,8 @@ import { githubQueryKeys, repositoryReactionsQueryOptions } from "./github-queri
 import {
   chunkReactionSubjects,
   optimisticallyUpdateReaction,
+  restoreReactionQueries,
+  snapshotReactionQueries,
   syncReactionSubject,
   updateRepositoryReaction,
 } from "./github-reactions";
@@ -48,7 +50,7 @@ export function GitHubReactionsProvider({
   subjects: GitHubReactionSubjectRef[];
   children: ReactNode;
 }) {
-  const { t } = useTranslation();
+  const { t } = useAppTranslation();
   const queryClient = useQueryClient();
   const batches = useMemo(() => chunkReactionSubjects(subjects), [subjects]);
   const results = useQueries({
@@ -96,11 +98,9 @@ export function GitHubReactionsProvider({
           repository: repository.name,
         }),
       });
-      const snapshots = queryClient.getQueriesData<unknown>({
-        queryKey: githubQueryKeys.reactionsRoot({
-          owner: repository.owner,
-          repository: repository.name,
-        }),
+      const snapshots = snapshotReactionQueries(queryClient, {
+        owner: repository.owner,
+        repository: repository.name,
       });
       syncReactionSubject(
         queryClient,
@@ -116,9 +116,7 @@ export function GitHubReactionsProvider({
         subject
       ),
     onError: (reason, _variables, context) => {
-      for (const [queryKey, data] of context?.snapshots ?? []) {
-        queryClient.setQueryData(queryKey, data);
-      }
+      restoreReactionQueries(queryClient, context?.snapshots ?? []);
       void queryClient.invalidateQueries({
         queryKey: githubQueryKeys.reactionsRoot({
           owner: repository.owner,

--- a/src/features/github/github-reactions-provider.tsx
+++ b/src/features/github/github-reactions-provider.tsx
@@ -1,0 +1,166 @@
+import { createContext, useContext, useEffect, useMemo, type ReactNode } from "react";
+import { useMutation, useQueries, useQueryClient } from "@tanstack/react-query";
+import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
+import { parseIpcError, type IpcError } from "@/lib/ipc-error";
+import type {
+  GitHubReactionContent,
+  GitHubReactionSubject,
+  GitHubReactionSubjectRef,
+  GitHubRepositoryIdentity,
+} from "./github-data";
+import { githubQueryKeys, repositoryReactionsQueryOptions } from "./github-queries";
+import {
+  chunkReactionSubjects,
+  optimisticallyUpdateReaction,
+  syncReactionSubject,
+  updateRepositoryReaction,
+} from "./github-reactions";
+
+type ReactionMutation = {
+  subject: GitHubReactionSubjectRef;
+  content: GitHubReactionContent;
+  reacted: boolean;
+  current: GitHubReactionSubject;
+};
+
+type GitHubReactionsContextValue = {
+  subject: (reference: GitHubReactionSubjectRef) => GitHubReactionSubject | undefined;
+  loading: boolean;
+  error: IpcError | null;
+  pending: boolean;
+  toggle: (reference: GitHubReactionSubjectRef, content: GitHubReactionContent) => void;
+  retry: () => void;
+};
+
+const GitHubReactionsContext = createContext<GitHubReactionsContextValue | null>(null);
+
+function reactionKey(subject: GitHubReactionSubjectRef) {
+  return `${subject.kind}:${subject.id}`;
+}
+
+export function GitHubReactionsProvider({
+  repository,
+  subjects,
+  children,
+}: {
+  repository: GitHubRepositoryIdentity;
+  subjects: GitHubReactionSubjectRef[];
+  children: ReactNode;
+}) {
+  const { t } = useTranslation();
+  const queryClient = useQueryClient();
+  const batches = useMemo(() => chunkReactionSubjects(subjects), [subjects]);
+  const results = useQueries({
+    queries: batches.map((batch) =>
+      repositoryReactionsQueryOptions({
+        owner: repository.owner,
+        repository: repository.name,
+        subjects: batch,
+      })
+    ),
+  });
+  const subjectsByKey = useMemo(() => {
+    const values = new Map<string, GitHubReactionSubject>();
+    for (const result of results) {
+      for (const subject of result.data ?? []) values.set(reactionKey(subject), subject);
+    }
+    return values;
+  }, [results]);
+
+  useEffect(() => {
+    for (const subject of subjectsByKey.values()) {
+      queryClient.setQueryData(
+        githubQueryKeys.reaction({
+          owner: repository.owner,
+          repository: repository.name,
+          subject,
+        }),
+        subject
+      );
+    }
+  }, [queryClient, repository.name, repository.owner, subjectsByKey]);
+
+  const mutation = useMutation({
+    mutationFn: ({ subject, content, reacted }: ReactionMutation) =>
+      updateRepositoryReaction(
+        { owner: repository.owner, repository: repository.name },
+        subject,
+        content,
+        reacted
+      ),
+    onMutate: async ({ current, content, reacted }) => {
+      await queryClient.cancelQueries({
+        queryKey: githubQueryKeys.reactionsRoot({
+          owner: repository.owner,
+          repository: repository.name,
+        }),
+      });
+      const snapshots = queryClient.getQueriesData<unknown>({
+        queryKey: githubQueryKeys.reactionsRoot({
+          owner: repository.owner,
+          repository: repository.name,
+        }),
+      });
+      syncReactionSubject(
+        queryClient,
+        { owner: repository.owner, repository: repository.name },
+        optimisticallyUpdateReaction(current, content, reacted)
+      );
+      return { snapshots };
+    },
+    onSuccess: (subject) =>
+      syncReactionSubject(
+        queryClient,
+        { owner: repository.owner, repository: repository.name },
+        subject
+      ),
+    onError: (reason, _variables, context) => {
+      for (const [queryKey, data] of context?.snapshots ?? []) {
+        queryClient.setQueryData(queryKey, data);
+      }
+      void queryClient.invalidateQueries({
+        queryKey: githubQueryKeys.reactionsRoot({
+          owner: repository.owner,
+          repository: repository.name,
+        }),
+        refetchType: "active",
+      });
+      const error = parseIpcError(reason);
+      toast.error(t("workspace.repositories.reactions.updateFailed"), {
+        description:
+          error.code === "githubPermission"
+            ? t("workspace.repositories.reactions.permissionDenied")
+            : error.message,
+      });
+    },
+  });
+  const queryError = results.find((result) => result.error)?.error;
+  const value = useMemo<GitHubReactionsContextValue>(
+    () => ({
+      subject: (reference) => subjectsByKey.get(reactionKey(reference)),
+      loading: results.some((result) => result.isPending),
+      error: queryError ? parseIpcError(queryError) : null,
+      pending: mutation.isPending,
+      toggle: (reference, content) => {
+        const subject = subjectsByKey.get(reactionKey(reference));
+        if (!subject || mutation.isPending) return;
+        const group = subject.groups.find((group) => group.content === content);
+        const reacted = !(group?.viewerHasReacted ?? false);
+        if (reacted && !subject.viewerCanReact) return;
+        mutation.reset();
+        mutation.mutate({ subject: reference, content, reacted, current: subject });
+      },
+      retry: () => {
+        for (const result of results) void result.refetch();
+      },
+    }),
+    [mutation, queryError, results, subjectsByKey]
+  );
+
+  return <GitHubReactionsContext value={value}>{children}</GitHubReactionsContext>;
+}
+
+export function useGitHubReactions() {
+  return useContext(GitHubReactionsContext);
+}

--- a/src/features/github/github-reactions.test.ts
+++ b/src/features/github/github-reactions.test.ts
@@ -7,6 +7,8 @@ import {
   chunkReactionSubjects,
   normalizeReactionSubjects,
   optimisticallyUpdateReaction,
+  restoreReactionQueries,
+  snapshotReactionQueries,
   syncReactionSubject,
   updateRepositoryReaction,
 } from "./github-reactions";
@@ -93,5 +95,44 @@ describe("GitHub reactions", () => {
     ).toEqual(updated);
     expect(queryClient.getQueryData<GitHubReactionSubject[]>(batchKey)).toEqual([updated]);
     expect(queryClient.getQueryData<GitHubReactionSubject[]>(otherKey)).toEqual([issue]);
+  });
+
+  it("restores every repository reaction cache after an optimistic write fails", () => {
+    const queryClient = new QueryClient();
+    const batchKey = githubQueryKeys.reactions({ ...repository, subjects: [issueRef] });
+    const canonicalKey = githubQueryKeys.reaction({ ...repository, subject: issueRef });
+    queryClient.setQueryData(batchKey, [issue]);
+    queryClient.setQueryData(canonicalKey, issue);
+    const snapshots = snapshotReactionQueries(queryClient, repository);
+
+    syncReactionSubject(
+      queryClient,
+      repository,
+      optimisticallyUpdateReaction(issue, "rocket", true)
+    );
+    restoreReactionQueries(queryClient, snapshots);
+
+    expect(queryClient.getQueryData<GitHubReactionSubject[]>(batchKey)).toEqual([issue]);
+    expect(queryClient.getQueryData<GitHubReactionSubject>(canonicalKey)).toEqual(issue);
+  });
+
+  it("serializes desired-state writes and continues after a failed request", async () => {
+    let rejectFirst: (reason: Error) => void = () => undefined;
+    const firstRequest = new Promise<GitHubReactionSubject>((_resolve, reject) => {
+      rejectFirst = reject;
+    });
+    vi.mocked(invoke)
+      .mockImplementationOnce(() => firstRequest)
+      .mockResolvedValueOnce(issue);
+
+    const firstUpdate = updateRepositoryReaction(repository, issueRef, "rocket", true);
+    const secondUpdate = updateRepositoryReaction(repository, issueRef, "rocket", false);
+    await Promise.resolve();
+
+    expect(invoke).toHaveBeenCalledTimes(1);
+    rejectFirst(new Error("network unavailable"));
+    await expect(firstUpdate).rejects.toThrow("network unavailable");
+    await expect(secondUpdate).resolves.toEqual(issue);
+    expect(invoke).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/features/github/github-reactions.test.ts
+++ b/src/features/github/github-reactions.test.ts
@@ -1,0 +1,97 @@
+import { QueryClient } from "@tanstack/react-query";
+import { invoke } from "@tauri-apps/api/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { GitHubReactionSubject } from "./github-data";
+import { githubQueryKeys, repositoryReactionsQueryOptions } from "./github-queries";
+import {
+  chunkReactionSubjects,
+  normalizeReactionSubjects,
+  optimisticallyUpdateReaction,
+  syncReactionSubject,
+  updateRepositoryReaction,
+} from "./github-reactions";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+const repository = { owner: "octocat", repository: "hello-world" };
+const issueRef = { id: "I_kwDOA", kind: "issue" } as const;
+const issue: GitHubReactionSubject = {
+  ...issueRef,
+  viewerCanReact: true,
+  groups: [
+    { content: "thumbsUp", count: 3, viewerHasReacted: false },
+    { content: "heart", count: 1, viewerHasReacted: true },
+  ],
+};
+
+describe("GitHub reactions", () => {
+  beforeEach(() => {
+    vi.mocked(invoke).mockReset();
+  });
+
+  it("normalizes stable subjects and batches at GitHub's nodes limit", () => {
+    const subjects = Array.from({ length: 101 }, (_, index) => ({
+      id: ` I_${String(index).padStart(3, "0")} `,
+      kind: "issueComment" as const,
+    }));
+    subjects.push({ id: " I_000 ", kind: "issueComment" });
+
+    expect(normalizeReactionSubjects(subjects)).toHaveLength(101);
+    expect(chunkReactionSubjects(subjects).map((batch) => batch.length)).toEqual([100, 1]);
+    expect(chunkReactionSubjects(subjects)[0][0]).toEqual({
+      id: "I_000",
+      kind: "issueComment",
+    });
+  });
+
+  it("invokes native reads and desired-state writes with opaque subject references", async () => {
+    vi.mocked(invoke).mockResolvedValueOnce([issue]).mockResolvedValueOnce(issue);
+    const query = repositoryReactionsQueryOptions({ ...repository, subjects: [issueRef] });
+
+    await query.queryFn?.({} as never);
+    await updateRepositoryReaction(repository, issueRef, "rocket", true);
+
+    expect(invoke).toHaveBeenNthCalledWith(1, "github_get_repository_reactions", {
+      ...repository,
+      subjects: [issueRef],
+    });
+    expect(invoke).toHaveBeenNthCalledWith(2, "github_update_repository_reaction", {
+      ...repository,
+      subject: issueRef,
+      content: "rocket",
+      reacted: true,
+    });
+  });
+
+  it("applies optimistic add and remove states without negative or empty groups", () => {
+    expect(optimisticallyUpdateReaction(issue, "thumbsUp", true).groups[0]).toEqual({
+      content: "thumbsUp",
+      count: 4,
+      viewerHasReacted: true,
+    });
+    expect(optimisticallyUpdateReaction(issue, "heart", false).groups).toEqual([
+      { content: "thumbsUp", count: 3, viewerHasReacted: false },
+    ]);
+    expect(optimisticallyUpdateReaction(issue, "eyes", false)).toBe(issue);
+  });
+
+  it("replaces canonical and batch caches only inside the selected repository", () => {
+    const queryClient = new QueryClient();
+    const batchKey = githubQueryKeys.reactions({ ...repository, subjects: [issueRef] });
+    const otherRepository = { owner: "octocat", repository: "other" };
+    const otherKey = githubQueryKeys.reactions({ ...otherRepository, subjects: [issueRef] });
+    queryClient.setQueryData(batchKey, [issue]);
+    queryClient.setQueryData(otherKey, [issue]);
+
+    const updated = optimisticallyUpdateReaction(issue, "rocket", true);
+    syncReactionSubject(queryClient, repository, updated);
+
+    expect(
+      queryClient.getQueryData(githubQueryKeys.reaction({ ...repository, subject: issueRef }))
+    ).toEqual(updated);
+    expect(queryClient.getQueryData<GitHubReactionSubject[]>(batchKey)).toEqual([updated]);
+    expect(queryClient.getQueryData<GitHubReactionSubject[]>(otherKey)).toEqual([issue]);
+  });
+});

--- a/src/features/github/github-reactions.ts
+++ b/src/features/github/github-reactions.ts
@@ -1,4 +1,4 @@
-import type { QueryClient } from "@tanstack/react-query";
+import type { QueryClient, QueryKey } from "@tanstack/react-query";
 import { invoke } from "@tauri-apps/api/core";
 import type {
   GitHubReactionContent,
@@ -11,6 +11,8 @@ export type GitHubReactionRepositoryTarget = {
   owner: string;
   repository: string;
 };
+
+export type GitHubReactionQuerySnapshot = [QueryKey, unknown];
 
 export const GITHUB_REACTION_BATCH_SIZE = 100;
 
@@ -126,4 +128,20 @@ export function syncReactionSubject(
       )
     );
   }
+}
+
+export function snapshotReactionQueries(
+  queryClient: QueryClient,
+  target: GitHubReactionRepositoryTarget
+): GitHubReactionQuerySnapshot[] {
+  return queryClient.getQueriesData<unknown>({
+    queryKey: githubQueryKeys.reactionsRoot(target),
+  });
+}
+
+export function restoreReactionQueries(
+  queryClient: QueryClient,
+  snapshots: GitHubReactionQuerySnapshot[]
+) {
+  for (const [queryKey, data] of snapshots) queryClient.setQueryData(queryKey, data);
 }

--- a/src/features/github/github-reactions.ts
+++ b/src/features/github/github-reactions.ts
@@ -1,0 +1,129 @@
+import type { QueryClient } from "@tanstack/react-query";
+import { invoke } from "@tauri-apps/api/core";
+import type {
+  GitHubReactionContent,
+  GitHubReactionSubject,
+  GitHubReactionSubjectRef,
+} from "./github-data";
+import { githubQueryKeys } from "./github-queries";
+
+export type GitHubReactionRepositoryTarget = {
+  owner: string;
+  repository: string;
+};
+
+export const GITHUB_REACTION_BATCH_SIZE = 100;
+
+let reactionMutationQueue: Promise<void> = Promise.resolve();
+
+const REACTION_ORDER: GitHubReactionContent[] = [
+  "thumbsUp",
+  "thumbsDown",
+  "laugh",
+  "hooray",
+  "confused",
+  "heart",
+  "rocket",
+  "eyes",
+];
+
+export function normalizeReactionSubjects(
+  subjects: GitHubReactionSubjectRef[]
+): GitHubReactionSubjectRef[] {
+  const byKey = new Map<string, GitHubReactionSubjectRef>();
+  for (const subject of subjects) {
+    const id = subject.id.trim();
+    const key = `${subject.kind}:${id}`;
+    if (!id || byKey.has(key)) continue;
+    byKey.set(key, { id, kind: subject.kind });
+  }
+  return [...byKey.values()].sort((left, right) =>
+    `${left.kind}:${left.id}`.localeCompare(`${right.kind}:${right.id}`)
+  );
+}
+
+export function chunkReactionSubjects(
+  subjects: GitHubReactionSubjectRef[]
+): GitHubReactionSubjectRef[][] {
+  const normalized = normalizeReactionSubjects(subjects);
+  const chunks: GitHubReactionSubjectRef[][] = [];
+  for (let index = 0; index < normalized.length; index += GITHUB_REACTION_BATCH_SIZE) {
+    chunks.push(normalized.slice(index, index + GITHUB_REACTION_BATCH_SIZE));
+  }
+  return chunks;
+}
+
+export function updateRepositoryReaction(
+  target: GitHubReactionRepositoryTarget,
+  subject: GitHubReactionSubjectRef,
+  content: GitHubReactionContent,
+  reacted: boolean
+) {
+  const update = reactionMutationQueue.then(() =>
+    invoke<GitHubReactionSubject>("github_update_repository_reaction", {
+      ...target,
+      subject,
+      content,
+      reacted,
+    })
+  );
+  reactionMutationQueue = update.then(
+    () => undefined,
+    () => undefined
+  );
+  return update;
+}
+
+export function optimisticallyUpdateReaction(
+  subject: GitHubReactionSubject,
+  content: GitHubReactionContent,
+  reacted: boolean
+): GitHubReactionSubject {
+  const current = subject.groups.find((group) => group.content === content);
+  if ((current?.viewerHasReacted ?? false) === reacted) return subject;
+  const groups = current
+    ? subject.groups
+        .map((group) =>
+          group.content === content
+            ? {
+                ...group,
+                count: Math.max(0, group.count + (reacted ? 1 : -1)),
+                viewerHasReacted: reacted,
+              }
+            : group
+        )
+        .filter((group) => group.count > 0 || group.viewerHasReacted)
+    : reacted
+      ? [...subject.groups, { content, count: 1, viewerHasReacted: true }]
+      : subject.groups;
+  return {
+    ...subject,
+    groups: groups.sort(
+      (left, right) => REACTION_ORDER.indexOf(left.content) - REACTION_ORDER.indexOf(right.content)
+    ),
+  };
+}
+
+export function syncReactionSubject(
+  queryClient: QueryClient,
+  target: GitHubReactionRepositoryTarget,
+  subject: GitHubReactionSubject
+) {
+  queryClient.setQueryData<GitHubReactionSubject>(
+    githubQueryKeys.reaction({ ...target, subject }),
+    subject
+  );
+  for (const [queryKey, cached] of queryClient.getQueriesData<unknown>({
+    queryKey: githubQueryKeys.reactionsRoot(target),
+  })) {
+    if (!Array.isArray(cached)) continue;
+    const subjects = cached as GitHubReactionSubject[];
+    if (!subjects.some((item) => item.id === subject.id && item.kind === subject.kind)) continue;
+    queryClient.setQueryData<GitHubReactionSubject[]>(
+      queryKey,
+      subjects.map((item) =>
+        item.id === subject.id && item.kind === subject.kind ? subject : item
+      )
+    );
+  }
+}

--- a/src/features/github/github-release-detail.tsx
+++ b/src/features/github/github-release-detail.tsx
@@ -51,6 +51,8 @@ import type {
 } from "./github-data";
 import { formatBytes } from "./github-format";
 import { formatIssueDate } from "./github-issue-shared";
+import { GitHubReactionBar } from "./github-reaction-bar";
+import { GitHubReactionsProvider } from "./github-reactions-provider";
 import { GitHubReleaseEditDialog } from "./github-release-edit-dialog";
 import {
   deleteRepositoryRelease,
@@ -301,243 +303,255 @@ export function GitHubReleaseDetail({
             </EmptyContent>
           </Empty>
         ) : (
-          <div className="mx-auto w-full max-w-[960px] px-4 py-5 sm:px-5">
-            <header className="flex flex-wrap items-start gap-4">
-              <div className="min-w-0 flex-1">
-                <div className="mb-2 flex flex-wrap items-center gap-2">
-                  <Badge variant="outline">
-                    <Tag /> {release.tagName}
-                  </Badge>
-                  {release.draft ? (
-                    <Badge variant="destructive">{t("workspace.repositories.releaseDraft")}</Badge>
-                  ) : release.prerelease ? (
-                    <Badge variant="secondary">
-                      {t("workspace.repositories.releasePrerelease")}
-                    </Badge>
-                  ) : null}
-                  {release.immutable ? (
+          <GitHubReactionsProvider repository={repository} subjects={[release.reactionSubject]}>
+            <div className="mx-auto w-full max-w-[960px] px-4 py-5 sm:px-5">
+              <header className="flex flex-wrap items-start gap-4">
+                <div className="min-w-0 flex-1">
+                  <div className="mb-2 flex flex-wrap items-center gap-2">
                     <Badge variant="outline">
-                      <LockKeyhole /> {t("workspace.repositories.releaseImmutable")}
+                      <Tag /> {release.tagName}
                     </Badge>
-                  ) : null}
+                    {release.draft ? (
+                      <Badge variant="destructive">
+                        {t("workspace.repositories.releaseDraft")}
+                      </Badge>
+                    ) : release.prerelease ? (
+                      <Badge variant="secondary">
+                        {t("workspace.repositories.releasePrerelease")}
+                      </Badge>
+                    ) : null}
+                    {release.immutable ? (
+                      <Badge variant="outline">
+                        <LockKeyhole /> {t("workspace.repositories.releaseImmutable")}
+                      </Badge>
+                    ) : null}
+                  </div>
+                  <h2 className="text-foreground text-xl leading-7 font-semibold tracking-[-0.025em]">
+                    {release.name?.trim() || release.tagName}
+                  </h2>
+                  <p className="text-muted-foreground mt-2 text-[11px]">
+                    {t(
+                      release.draft
+                        ? "workspace.repositories.releaseCreatedBy"
+                        : "workspace.repositories.releasePublishedBy",
+                      {
+                        author: release.author
+                          ? `@${release.author}`
+                          : t("workspace.repositories.unknownActor"),
+                        date: formatIssueDate(
+                          release.publishedAt ?? release.createdAt,
+                          i18n.language
+                        ),
+                      }
+                    )}
+                  </p>
+                  <p className="text-muted-foreground mt-1 flex items-center gap-1 text-[10px]">
+                    <GitCommitHorizontal className="size-3" />
+                    {t("workspace.repositories.releaseTarget", {
+                      target: release.targetCommitish,
+                    })}
+                  </p>
                 </div>
-                <h2 className="text-foreground text-xl leading-7 font-semibold tracking-[-0.025em]">
-                  {release.name?.trim() || release.tagName}
-                </h2>
-                <p className="text-muted-foreground mt-2 text-[11px]">
-                  {t(
-                    release.draft
-                      ? "workspace.repositories.releaseCreatedBy"
-                      : "workspace.repositories.releasePublishedBy",
-                    {
-                      author: release.author
-                        ? `@${release.author}`
-                        : t("workspace.repositories.unknownActor"),
-                      date: formatIssueDate(
-                        release.publishedAt ?? release.createdAt,
-                        i18n.language
-                      ),
-                    }
-                  )}
-                </p>
-                <p className="text-muted-foreground mt-1 flex items-center gap-1 text-[10px]">
-                  <GitCommitHorizontal className="size-3" />
-                  {t("workspace.repositories.releaseTarget", {
-                    target: release.targetCommitish,
-                  })}
-                </p>
-              </div>
-              <div className="flex w-full shrink-0 flex-wrap items-center gap-2 min-[1200px]:w-auto min-[1200px]:justify-end">
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  onClick={() => void openExternalUrl(release.url)}
-                >
-                  <ExternalLink data-icon="inline-end" />
-                  {t("workspace.openOnGitHub")}
-                </Button>
-                <Button type="button" variant="outline" size="sm" onClick={() => setEditing(true)}>
-                  <Pencil data-icon="inline-start" />
-                  {t("workspace.repositories.editRelease")}
-                </Button>
-                <Button
-                  type="button"
-                  variant="destructive"
-                  size="sm"
-                  disabled={releaseDelete.isPending}
-                  onClick={() => setReleaseDeleteOpen(true)}
-                >
-                  {releaseDelete.isPending ? (
-                    <Spinner data-icon="inline-start" />
-                  ) : (
-                    <Trash2 data-icon="inline-start" />
-                  )}
-                  {t("workspace.repositories.deleteRelease")}
-                </Button>
-              </div>
-            </header>
-
-            <article className="bg-card/30 mt-5 overflow-hidden rounded-lg border">
-              <header className="bg-card/40 flex min-h-11 items-center gap-2 border-b px-3.5 py-2 text-xs font-medium">
-                <Tag />
-                {t("workspace.repositories.releaseNotes")}
-              </header>
-              {release.body?.trim() ? (
-                <div className="harbor-markdown min-h-24 px-4 py-4 text-[12px]">
-                  <Suspense fallback={<Skeleton className="h-20 w-full" />}>
-                    <GitHubReadme
-                      content={release.body}
-                      path=""
-                      reference={release.tagName}
-                      repository={repository}
-                      onOpenExternal={(url) => void openExternalUrl(url)}
-                    />
-                  </Suspense>
-                </div>
-              ) : (
-                <p className="text-muted-foreground px-4 py-6 text-center text-xs">
-                  {t("workspace.repositories.noReleaseNotes")}
-                </p>
-              )}
-            </article>
-
-            <section className="mt-4 overflow-hidden rounded-lg border">
-              <header className="flex min-h-11 items-center gap-2 border-b px-3 py-2.5">
-                <Archive className="text-primary size-4" />
-                <h3 className="text-xs font-semibold">
-                  {t("workspace.repositories.releaseAssets")}
-                </h3>
-                <Badge variant="outline">{release.assets.length}</Badge>
-                {!release.immutable ? (
+                <div className="flex w-full shrink-0 flex-wrap items-center gap-2 min-[1200px]:w-auto min-[1200px]:justify-end">
                   <Button
                     type="button"
                     variant="outline"
-                    size="xs"
-                    className="ml-auto"
-                    disabled={assetUpload.isPending || assetDelete.isPending}
-                    onClick={() => assetUpload.mutate()}
+                    size="sm"
+                    onClick={() => void openExternalUrl(release.url)}
                   >
-                    {assetUpload.isPending ? (
+                    <ExternalLink data-icon="inline-end" />
+                    {t("workspace.openOnGitHub")}
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setEditing(true)}
+                  >
+                    <Pencil data-icon="inline-start" />
+                    {t("workspace.repositories.editRelease")}
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="destructive"
+                    size="sm"
+                    disabled={releaseDelete.isPending}
+                    onClick={() => setReleaseDeleteOpen(true)}
+                  >
+                    {releaseDelete.isPending ? (
                       <Spinner data-icon="inline-start" />
                     ) : (
-                      <Plus data-icon="inline-start" />
+                      <Trash2 data-icon="inline-start" />
                     )}
-                    {t("workspace.repositories.uploadReleaseAsset")}
+                    {t("workspace.repositories.deleteRelease")}
                   </Button>
-                ) : null}
-              </header>
-              {release.assets.length ? (
-                <div className="flex flex-col">
-                  {release.assets.map((asset) => (
-                    <ReleaseAssetRow
-                      key={asset.id}
-                      asset={asset}
-                      locale={i18n.language}
-                      disabled={
-                        assetDownload.isPending ||
-                        archiveDownload.isPending ||
-                        assetUpload.isPending ||
-                        assetDelete.isPending ||
-                        releaseDelete.isPending
-                      }
-                      downloading={
-                        assetDownload.isPending && assetDownload.variables?.assetId === asset.id
-                      }
-                      deleting={assetDelete.isPending && assetDelete.variables?.id === asset.id}
-                      canDelete={!release.immutable}
-                      onDownload={() =>
-                        assetDownload.mutate({
-                          ...target,
-                          assetId: asset.id,
-                          assetName: asset.name,
-                        })
-                      }
-                      onDelete={() => setAssetToDelete(asset)}
-                    />
-                  ))}
                 </div>
-              ) : (
-                <p className="text-muted-foreground px-4 py-6 text-center text-xs">
-                  {t("workspace.repositories.noReleaseAssets")}
-                </p>
-              )}
-            </section>
+              </header>
 
-            {release.hasZipball || release.hasTarball ? (
+              <article className="bg-card/30 mt-5 overflow-hidden rounded-lg border">
+                <header className="bg-card/40 flex min-h-11 items-center gap-2 border-b px-3.5 py-2 text-xs font-medium">
+                  <Tag />
+                  {t("workspace.repositories.releaseNotes")}
+                </header>
+                {release.body?.trim() ? (
+                  <div className="harbor-markdown min-h-24 px-4 py-4 text-[12px]">
+                    <Suspense fallback={<Skeleton className="h-20 w-full" />}>
+                      <GitHubReadme
+                        content={release.body}
+                        path=""
+                        reference={release.tagName}
+                        repository={repository}
+                        onOpenExternal={(url) => void openExternalUrl(url)}
+                      />
+                    </Suspense>
+                  </div>
+                ) : (
+                  <p className="text-muted-foreground px-4 py-6 text-center text-xs">
+                    {t("workspace.repositories.noReleaseNotes")}
+                  </p>
+                )}
+                <footer className="border-t px-4 py-2.5">
+                  <GitHubReactionBar subject={release.reactionSubject} />
+                </footer>
+              </article>
+
               <section className="mt-4 overflow-hidden rounded-lg border">
                 <header className="flex min-h-11 items-center gap-2 border-b px-3 py-2.5">
-                  <FileArchive className="text-primary size-4" />
+                  <Archive className="text-primary size-4" />
                   <h3 className="text-xs font-semibold">
-                    {t("workspace.repositories.releaseSourceCode")}
+                    {t("workspace.repositories.releaseAssets")}
                   </h3>
+                  <Badge variant="outline">{release.assets.length}</Badge>
+                  {!release.immutable ? (
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="xs"
+                      className="ml-auto"
+                      disabled={assetUpload.isPending || assetDelete.isPending}
+                      onClick={() => assetUpload.mutate()}
+                    >
+                      {assetUpload.isPending ? (
+                        <Spinner data-icon="inline-start" />
+                      ) : (
+                        <Plus data-icon="inline-start" />
+                      )}
+                      {t("workspace.repositories.uploadReleaseAsset")}
+                    </Button>
+                  ) : null}
                 </header>
-                <div className="flex flex-wrap gap-2 p-3">
-                  {release.hasZipball ? (
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="sm"
-                      disabled={assetDownload.isPending || archiveDownload.isPending}
-                      onClick={() => downloadArchive("zip")}
-                    >
-                      {archiveDownload.isPending &&
-                      archiveDownload.variables?.archiveFormat === "zip" ? (
-                        <Spinner data-icon="inline-start" />
-                      ) : (
-                        <Download data-icon="inline-start" />
-                      )}
-                      {t("workspace.repositories.releaseSourceZip")}
-                    </Button>
-                  ) : null}
-                  {release.hasTarball ? (
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="sm"
-                      disabled={assetDownload.isPending || archiveDownload.isPending}
-                      onClick={() => downloadArchive("tarGz")}
-                    >
-                      {archiveDownload.isPending &&
-                      archiveDownload.variables?.archiveFormat === "tarGz" ? (
-                        <Spinner data-icon="inline-start" />
-                      ) : (
-                        <Download data-icon="inline-start" />
-                      )}
-                      {t("workspace.repositories.releaseSourceTarGz")}
-                    </Button>
-                  ) : null}
-                </div>
+                {release.assets.length ? (
+                  <div className="flex flex-col">
+                    {release.assets.map((asset) => (
+                      <ReleaseAssetRow
+                        key={asset.id}
+                        asset={asset}
+                        locale={i18n.language}
+                        disabled={
+                          assetDownload.isPending ||
+                          archiveDownload.isPending ||
+                          assetUpload.isPending ||
+                          assetDelete.isPending ||
+                          releaseDelete.isPending
+                        }
+                        downloading={
+                          assetDownload.isPending && assetDownload.variables?.assetId === asset.id
+                        }
+                        deleting={assetDelete.isPending && assetDelete.variables?.id === asset.id}
+                        canDelete={!release.immutable}
+                        onDownload={() =>
+                          assetDownload.mutate({
+                            ...target,
+                            assetId: asset.id,
+                            assetName: asset.name,
+                          })
+                        }
+                        onDelete={() => setAssetToDelete(asset)}
+                      />
+                    ))}
+                  </div>
+                ) : (
+                  <p className="text-muted-foreground px-4 py-6 text-center text-xs">
+                    {t("workspace.repositories.noReleaseAssets")}
+                  </p>
+                )}
               </section>
-            ) : null}
 
-            {downloadError ? (
-              <Alert variant="destructive" className="mt-4" aria-live="polite">
-                <CircleAlert />
-                <AlertTitle>{t("workspace.repositories.releaseDownloadFailed")}</AlertTitle>
-                <AlertDescription>
-                  {releaseErrorMessage(
-                    downloadError.code,
-                    downloadError.message,
-                    t("workspace.repositories.releasePermissionDenied")
-                  )}
-                </AlertDescription>
-              </Alert>
-            ) : null}
-            {writeError ? (
-              <Alert variant="destructive" className="mt-4" aria-live="polite">
-                <CircleAlert />
-                <AlertTitle>{t("workspace.repositories.releaseWriteFailed")}</AlertTitle>
-                <AlertDescription>
-                  {releaseErrorMessage(
-                    writeError.code,
-                    writeError.message,
-                    t("workspace.repositories.releaseWritePermissionDenied")
-                  )}
-                </AlertDescription>
-              </Alert>
-            ) : null}
-          </div>
+              {release.hasZipball || release.hasTarball ? (
+                <section className="mt-4 overflow-hidden rounded-lg border">
+                  <header className="flex min-h-11 items-center gap-2 border-b px-3 py-2.5">
+                    <FileArchive className="text-primary size-4" />
+                    <h3 className="text-xs font-semibold">
+                      {t("workspace.repositories.releaseSourceCode")}
+                    </h3>
+                  </header>
+                  <div className="flex flex-wrap gap-2 p-3">
+                    {release.hasZipball ? (
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        disabled={assetDownload.isPending || archiveDownload.isPending}
+                        onClick={() => downloadArchive("zip")}
+                      >
+                        {archiveDownload.isPending &&
+                        archiveDownload.variables?.archiveFormat === "zip" ? (
+                          <Spinner data-icon="inline-start" />
+                        ) : (
+                          <Download data-icon="inline-start" />
+                        )}
+                        {t("workspace.repositories.releaseSourceZip")}
+                      </Button>
+                    ) : null}
+                    {release.hasTarball ? (
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        disabled={assetDownload.isPending || archiveDownload.isPending}
+                        onClick={() => downloadArchive("tarGz")}
+                      >
+                        {archiveDownload.isPending &&
+                        archiveDownload.variables?.archiveFormat === "tarGz" ? (
+                          <Spinner data-icon="inline-start" />
+                        ) : (
+                          <Download data-icon="inline-start" />
+                        )}
+                        {t("workspace.repositories.releaseSourceTarGz")}
+                      </Button>
+                    ) : null}
+                  </div>
+                </section>
+              ) : null}
+
+              {downloadError ? (
+                <Alert variant="destructive" className="mt-4" aria-live="polite">
+                  <CircleAlert />
+                  <AlertTitle>{t("workspace.repositories.releaseDownloadFailed")}</AlertTitle>
+                  <AlertDescription>
+                    {releaseErrorMessage(
+                      downloadError.code,
+                      downloadError.message,
+                      t("workspace.repositories.releasePermissionDenied")
+                    )}
+                  </AlertDescription>
+                </Alert>
+              ) : null}
+              {writeError ? (
+                <Alert variant="destructive" className="mt-4" aria-live="polite">
+                  <CircleAlert />
+                  <AlertTitle>{t("workspace.repositories.releaseWriteFailed")}</AlertTitle>
+                  <AlertDescription>
+                    {releaseErrorMessage(
+                      writeError.code,
+                      writeError.message,
+                      t("workspace.repositories.releaseWritePermissionDenied")
+                    )}
+                  </AlertDescription>
+                </Alert>
+              ) : null}
+            </div>
+          </GitHubReactionsProvider>
         )}
       </ScrollArea>
       {release ? (

--- a/src/features/github/github-release-mutations.test.ts
+++ b/src/features/github/github-release-mutations.test.ts
@@ -30,6 +30,7 @@ const target = {
 
 const release: GitHubRelease = {
   id: 88,
+  reactionSubject: { id: "RE_kwDOA", kind: "release" },
   tagName: "v1.0.0",
   targetCommitish: "main",
   url: "https://github.com/octocat/hello-world/releases/tag/v1.0.0",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -876,6 +876,25 @@
       },
       "releases": "Releases",
       "releasesDescription": "Published versions, release notes, and downloadable assets.",
+      "reactions": {
+        "add": "Add reaction",
+        "retry": "Retry loading reactions",
+        "loadFailed": "Harbor could not load reactions",
+        "updateFailed": "Harbor could not update this reaction",
+        "permissionDenied": "GitHub does not allow you to react here.",
+        "toggleLabel": "{{reaction}}, {{count}} reactions",
+        "toggleLabelSelected": "{{reaction}}, {{count}} reactions; you reacted",
+        "names": {
+          "thumbsUp": "Thumbs up",
+          "thumbsDown": "Thumbs down",
+          "laugh": "Laugh",
+          "hooray": "Hooray",
+          "confused": "Confused",
+          "heart": "Heart",
+          "rocket": "Rocket",
+          "eyes": "Eyes"
+        }
+      },
       "releasesLoadFailed": "Harbor could not load Releases",
       "releaseLoadFailed": "Harbor could not load this release",
       "releasePermissionDenied": "Harbor needs Contents read permission for this repository's Releases",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -872,6 +872,25 @@
       },
       "releases": "版本发布",
       "releasesDescription": "查看已发布版本、更新说明和可下载文件。",
+      "reactions": {
+        "add": "添加表态",
+        "retry": "重新加载表态",
+        "loadFailed": "表态暂时没有加载成功",
+        "updateFailed": "表态没有更新成功",
+        "permissionDenied": "GitHub 不允许你在这里添加表态。",
+        "toggleLabel": "{{reaction}}，共 {{count}} 个表态",
+        "toggleLabelSelected": "{{reaction}}，共 {{count}} 个表态；你已表态",
+        "names": {
+          "thumbsUp": "赞",
+          "thumbsDown": "不赞同",
+          "laugh": "笑脸",
+          "hooray": "庆祝",
+          "confused": "疑惑",
+          "heart": "爱心",
+          "rocket": "火箭",
+          "eyes": "关注"
+        }
+      },
       "releasesLoadFailed": "Harbor 暂时无法读取版本发布记录",
       "releaseLoadFailed": "Harbor 暂时无法读取这个版本",
       "releasePermissionDenied": "Harbor 需要这个仓库的 Contents 读取权限，才能查看版本发布记录",


### PR DESCRIPTION
## Summary

- add a repository-scoped Reactable GraphQL boundary with desired-state add/remove mutations
- share batched reaction state, optimistic updates, rollback, and serialized writes across Issues, pull requests, Discussions, and Releases
- validate subject types, repository ownership, supported reaction vocabulary, and authoritative mutation responses
- add English and Simplified Chinese UI copy plus current API research notes

## Verification

- pnpm check: 129 tests passed and production build succeeded
- cargo test: 228 passed, 1 existing external integration test ignored
- cargo check and cargo clippy passed; clippy reports only the same 11 pre-existing warnings
- Playwright desktop QA at 1600x1000 and 900x620 covered Issue and PR bodies, comments, review summaries, inline review comments, Discussions and nested replies, and Releases
- exact batch and mutation IPC arguments verified; no root horizontal overflow and no browser errors or warnings