### PR TITLE
feat: manage received repository invitations

### DIFF
--- a/.cairn/items/github-web-parity.md
+++ b/.cairn/items/github-web-parity.md
@@ -361,19 +361,36 @@ SHA confirmation. The focused `GitHubCodeMutationClient` owns normalization, per
 repository guards, conflict mapping, Git transport, response verification, and tests. The Code UI
 reuses the existing overview, Markdown editor, Shiki preview, shadcn dialogs, toasts, and query roots;
 workflow-file scope requirements and protected/default-branch failures remain explicit.
+Received repository invitations now stay inside the personal account workspace. The focused
+two-method `GitHubRepositoryInvitationClient` Interface lists every open invitation for the signed-in
+user and accepts or declines it through GitHub's official account-scoped routes. The Notifications
+header keeps a permanent invitation entry even when the inbox is empty, while exact
+`RepositoryInvitation` subjects open the same native view and mark the notification read. The lazy
+UI preserves repository, inviter, permission, privacy, pagination, loading, empty, retry, confirmed
+decline, mutation failure, and responsive states. Accepted invitations invalidate the authenticated
+repository cache; both actions reconcile the invitation and notification caches by immutable IDs.
 The workspace shell is responsive, starts at 1600x1000, and remains usable down to 900x620.
 
 ## Next action
 
-Complete the remaining deterministic desktop checks for repository file rename, file deletion, and
-the 900x620 layout, then audit the next missing personal-developer GitHub Web workflow. Keep
-organization administration, Enterprise controls, and advanced organization security out of scope.
+Audit the next missing personal-developer GitHub Web workflow. Keep organization administration,
+Enterprise controls, and advanced organization security out of scope.
 
 ## Verification
 
 Each GitHub parity slice must use real API data, cover loading/empty/error/permission states, preserve
 repository context and navigation, and complete its primary path without forcing a browser fallback.
 Run `pnpm check`, the Rust check suite when Rust changes, and a focused desktop interaction check.
+
+Received repository invitation verification covers the official account-scoped list, accept, and
+decline contracts; exact Tauri argument names; repository, inviter, permission, and pagination
+mapping; saved-credential delegation; notification routing; and focused TanStack Query
+reconciliation. `pnpm check` passes with 129 frontend tests. `cargo fmt --check`, 227 Rust tests,
+and `cargo check` pass with one external DeepWiki test ignored by design; Clippy retains the same 11
+pre-existing warnings. A deterministic desktop fixture verified the permanent inbox entry,
+notification-to-native routing, authoritative accept and decline payloads, confirmation, empty and
+permission-error states, no console errors, and no page-level horizontal overflow at 1600x1000 and
+900x620.
 
 Repository Code mutation verification covers exact Tauri contracts, atomic rename payloads, stale
 file and branch guards, Git-compatible branch validation, empty-repository initialization, stable

--- a/.cairn/items/github-web-parity.md
+++ b/.cairn/items/github-web-parity.md
@@ -369,6 +369,7 @@ header keeps a permanent invitation entry even when the inbox is empty, while ex
 UI preserves repository, inviter, permission, privacy, pagination, loading, empty, retry, confirmed
 decline, mutation failure, and responsive states. Accepted invitations invalidate the authenticated
 repository cache; both actions reconcile the invitation and notification caches by immutable IDs.
+The verified slice is open as PR #9 from `feat/github-repository-invitations`.
 The workspace shell is responsive, starts at 1600x1000, and remains usable down to 900x620.
 
 ## Next action

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -39,6 +39,7 @@ use crate::{
         GitHubPullRequestReviewTeamPage, GitHubPullRequestReviewThreadComment,
         GitHubPullRequestReviewThreadPage, GitHubPullRequestReviewThreadResolution,
         GitHubPullRequestReviewThreadState, GitHubPullRequestSort, GitHubPullRequestState,
+        GitHubReceivedRepositoryInvitationAction, GitHubReceivedRepositoryInvitationPage,
         GitHubRelease, GitHubReleaseArchiveFormat, GitHubReleaseAsset, GitHubReleaseMutationInput,
         GitHubReleasePage, GitHubRepositoryCommitPage, GitHubRepositoryCreateInput,
         GitHubRepositoryCreationOptions, GitHubRepositoryFileCommit, GitHubRepositoryFileMutation,
@@ -532,6 +533,32 @@ pub async fn github_mark_all_notifications_read(
     state: State<'_, AppState>,
 ) -> Result<(), AppError> {
     state.github.mark_all_notifications_read().await
+}
+
+#[tauri::command]
+pub async fn github_list_received_repository_invitations(
+    page: u32,
+    state: State<'_, AppState>,
+) -> Result<GitHubReceivedRepositoryInvitationPage, AppError> {
+    state
+        .github
+        .received_repository_invitations(validate_page(page)?)
+        .await
+}
+
+#[tauri::command]
+pub async fn github_update_received_repository_invitation(
+    invitation_id: u64,
+    action: GitHubReceivedRepositoryInvitationAction,
+    state: State<'_, AppState>,
+) -> Result<(), AppError> {
+    state
+        .github
+        .update_received_repository_invitation(
+            validate_item_number(invitation_id, "repository invitation")?,
+            action,
+        )
+        .await
 }
 
 #[tauri::command]

--- a/src-tauri/src/github.rs
+++ b/src-tauri/src/github.rs
@@ -24,6 +24,7 @@ pub(crate) mod profile;
 pub(crate) mod projects;
 pub(crate) mod pull_request;
 pub(crate) mod release;
+pub(crate) mod repository_invitations;
 pub(crate) mod repository_relationships;
 pub(crate) mod repository_settings;
 pub(crate) mod security;
@@ -88,6 +89,9 @@ pub use pull_request::update_branch::{
 pub use release::{
     GitHubRelease, GitHubReleaseArchiveFormat, GitHubReleaseAsset, GitHubReleaseMutationInput,
     GitHubReleasePage,
+};
+pub use repository_invitations::{
+    GitHubReceivedRepositoryInvitationAction, GitHubReceivedRepositoryInvitationPage,
 };
 pub use repository_relationships::{
     GitHubForkInput, GitHubForkResult, GitHubRepositoryRelationship, GitHubRepositoryWatchLevel,
@@ -579,6 +583,7 @@ pub(crate) trait GitHubClient:
     + pull_request::reviewer::GitHubPullRequestReviewerClient
     + pull_request::update_branch::GitHubPullRequestBranchClient
     + release::GitHubReleaseClient
+    + repository_invitations::GitHubRepositoryInvitationClient
     + repository_relationships::GitHubRepositoryRelationshipsClient
     + repository_settings::GitHubRepositorySettingsClient
     + security::GitHubSecurityClient
@@ -2595,6 +2600,10 @@ mod tests {
 
         let repositories = service.repositories(1).await.expect("repositories");
         let notifications = service.notifications(true, 2).await.expect("notifications");
+        let repository_invitations = service
+            .received_repository_invitations(1)
+            .await
+            .expect("repository invitations");
         let issue_filters = GitHubIssueFilters {
             state: GitHubIssueState::Open,
             assignment: GitHubIssueAssignment::All,
@@ -2747,6 +2756,7 @@ mod tests {
             "octocat/hello-world"
         );
         assert_eq!(notifications.page, 2);
+        assert_eq!(repository_invitations.page, 1);
         assert_eq!(issues.issues[0].number, 7);
         assert_eq!(issue_inbox.issues[0].issue.number, 7);
         assert!(discussion_categories.enabled);
@@ -2791,6 +2801,13 @@ mod tests {
             .mark_all_notifications_read()
             .await
             .expect("mark all notifications read");
+        service
+            .update_received_repository_invitation(
+                73,
+                GitHubReceivedRepositoryInvitationAction::Accept,
+            )
+            .await
+            .expect("accept repository invitation");
     }
 
     #[tokio::test]

--- a/src-tauri/src/github/notification.rs
+++ b/src-tauri/src/github/notification.rs
@@ -29,7 +29,7 @@ pub enum GitHubNotificationSubjectKind {
     CodeScanningAlert,
     SecretScanningAlert,
     SecurityAlert,
-    Repository,
+    RepositoryInvitation,
     Other,
 }
 
@@ -428,7 +428,7 @@ fn notification_subject_kind(subject_type: &str) -> GitHubNotificationSubjectKin
         "CodeScanningAlert" => GitHubNotificationSubjectKind::CodeScanningAlert,
         "SecretScanningAlert" => GitHubNotificationSubjectKind::SecretScanningAlert,
         "SecurityAdvisory" => GitHubNotificationSubjectKind::SecurityAlert,
-        "RepositoryInvitation" => GitHubNotificationSubjectKind::Repository,
+        "RepositoryInvitation" => GitHubNotificationSubjectKind::RepositoryInvitation,
         _ => GitHubNotificationSubjectKind::Other,
     }
 }
@@ -591,6 +591,12 @@ mod tests {
             "hello-world",
             repository_url,
         );
+        let repository_invitation = notification_subject_from_octocrab(
+            notification("RepositoryInvitation", None).subject,
+            "octocat",
+            "hello-world",
+            repository_url,
+        );
 
         assert_eq!(issue.number, Some(9));
         assert_eq!(issue.url, "https://github.com/octocat/hello-world/issues/9");
@@ -614,6 +620,11 @@ mod tests {
             "https://github.com/octocat/hello-world/releases"
         );
         assert_eq!(release.release_id, Some(88));
+        assert_eq!(
+            repository_invitation.kind,
+            GitHubNotificationSubjectKind::RepositoryInvitation
+        );
+        assert_eq!(repository_invitation.url, repository_url);
     }
 
     #[test]

--- a/src-tauri/src/github/repository_invitations.rs
+++ b/src-tauri/src/github/repository_invitations.rs
@@ -1,0 +1,298 @@
+use async_trait::async_trait;
+use http::StatusCode;
+use serde::{Deserialize, Serialize};
+
+use super::{
+    authenticated_client, github_error, repository_from_octocrab, AppError, GitHubRepository,
+    GitHubService, OctocrabGitHubClient,
+};
+
+const REPOSITORY_INVITATION_PAGE_SIZE: u8 = 100;
+
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum GitHubReceivedRepositoryInvitationAction {
+    Accept,
+    Decline,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GitHubRepositoryInvitationActor {
+    pub id: u64,
+    pub login: String,
+    pub avatar_url: String,
+    pub url: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GitHubReceivedRepositoryInvitation {
+    pub id: u64,
+    pub repository: GitHubRepository,
+    pub inviter: GitHubRepositoryInvitationActor,
+    pub permission: String,
+    pub created_at: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GitHubReceivedRepositoryInvitationPage {
+    pub invitations: Vec<GitHubReceivedRepositoryInvitation>,
+    pub page: u32,
+    pub has_previous: bool,
+    pub has_more: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawReceivedRepositoryInvitation {
+    id: u64,
+    repository: octocrab::models::Repository,
+    inviter: RawRepositoryInvitationActor,
+    #[serde(rename = "permissions")]
+    permission: String,
+    created_at: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawRepositoryInvitationActor {
+    id: u64,
+    login: String,
+    avatar_url: String,
+    html_url: String,
+}
+
+#[derive(Serialize)]
+struct RepositoryInvitationPageParameters {
+    per_page: u8,
+    page: u32,
+}
+
+#[async_trait]
+pub(crate) trait GitHubRepositoryInvitationClient: Send + Sync {
+    async fn list_received_repository_invitations(
+        &self,
+        token: &str,
+        page: u32,
+    ) -> Result<GitHubReceivedRepositoryInvitationPage, AppError>;
+
+    async fn update_received_repository_invitation(
+        &self,
+        token: &str,
+        invitation_id: u64,
+        action: GitHubReceivedRepositoryInvitationAction,
+    ) -> Result<(), AppError>;
+}
+
+#[async_trait]
+impl GitHubRepositoryInvitationClient for OctocrabGitHubClient {
+    async fn list_received_repository_invitations(
+        &self,
+        token: &str,
+        page: u32,
+    ) -> Result<GitHubReceivedRepositoryInvitationPage, AppError> {
+        let response: octocrab::Page<RawReceivedRepositoryInvitation> =
+            authenticated_client(token)?
+                .get(
+                    "/user/repository_invitations",
+                    Some(&RepositoryInvitationPageParameters {
+                        per_page: REPOSITORY_INVITATION_PAGE_SIZE,
+                        page,
+                    }),
+                )
+                .await
+                .map_err(github_error)?;
+        Ok(received_repository_invitation_page(
+            response.items,
+            page,
+            response.next.is_some(),
+        ))
+    }
+
+    async fn update_received_repository_invitation(
+        &self,
+        token: &str,
+        invitation_id: u64,
+        action: GitHubReceivedRepositoryInvitationAction,
+    ) -> Result<(), AppError> {
+        let client = authenticated_client(token)?;
+        let route = repository_invitation_route(invitation_id);
+        let response = match action {
+            GitHubReceivedRepositoryInvitationAction::Accept => {
+                client._patch(route, None::<&()>).await
+            }
+            GitHubReceivedRepositoryInvitationAction::Decline => {
+                client._delete(route, None::<&()>).await
+            }
+        }
+        .map_err(github_error)?;
+        let status = response.status();
+        if status == StatusCode::NO_CONTENT {
+            return Ok(());
+        }
+
+        octocrab::map_github_error(response)
+            .await
+            .map_err(github_error)?;
+        Err(AppError::GitHub(format!(
+            "GitHub returned unexpected repository invitation status {status}"
+        )))
+    }
+}
+
+impl GitHubService {
+    pub async fn received_repository_invitations(
+        &self,
+        page: u32,
+    ) -> Result<GitHubReceivedRepositoryInvitationPage, AppError> {
+        let token = self.load_access_token().await?;
+        self.client
+            .list_received_repository_invitations(&token, page)
+            .await
+    }
+
+    pub async fn update_received_repository_invitation(
+        &self,
+        invitation_id: u64,
+        action: GitHubReceivedRepositoryInvitationAction,
+    ) -> Result<(), AppError> {
+        let token = self.load_access_token().await?;
+        self.client
+            .update_received_repository_invitation(&token, invitation_id, action)
+            .await
+    }
+}
+
+fn received_repository_invitation_page(
+    invitations: Vec<RawReceivedRepositoryInvitation>,
+    page: u32,
+    has_more: bool,
+) -> GitHubReceivedRepositoryInvitationPage {
+    GitHubReceivedRepositoryInvitationPage {
+        invitations: invitations
+            .into_iter()
+            .filter_map(received_repository_invitation)
+            .collect(),
+        page,
+        has_previous: page > 1,
+        has_more,
+    }
+}
+
+fn received_repository_invitation(
+    invitation: RawReceivedRepositoryInvitation,
+) -> Option<GitHubReceivedRepositoryInvitation> {
+    let repository = repository_from_octocrab(invitation.repository)?;
+    let permission = invitation.permission.trim().to_string();
+    if permission.is_empty() || permission.len() > 100 || permission.chars().any(char::is_control) {
+        return None;
+    }
+    Some(GitHubReceivedRepositoryInvitation {
+        id: invitation.id,
+        repository,
+        inviter: GitHubRepositoryInvitationActor {
+            id: invitation.inviter.id,
+            login: invitation.inviter.login,
+            avatar_url: invitation.inviter.avatar_url,
+            url: invitation.inviter.html_url,
+        },
+        permission,
+        created_at: invitation.created_at,
+    })
+}
+
+fn repository_invitation_route(invitation_id: u64) -> String {
+    format!("/user/repository_invitations/{invitation_id}")
+}
+
+#[cfg(test)]
+#[async_trait]
+impl GitHubRepositoryInvitationClient for super::tests::FakeGitHubClient {
+    async fn list_received_repository_invitations(
+        &self,
+        token: &str,
+        page: u32,
+    ) -> Result<GitHubReceivedRepositoryInvitationPage, AppError> {
+        assert_eq!(token, "github-user-access-token");
+        Ok(GitHubReceivedRepositoryInvitationPage {
+            invitations: Vec::new(),
+            page,
+            has_previous: page > 1,
+            has_more: false,
+        })
+    }
+
+    async fn update_received_repository_invitation(
+        &self,
+        token: &str,
+        invitation_id: u64,
+        action: GitHubReceivedRepositoryInvitationAction,
+    ) -> Result<(), AppError> {
+        assert_eq!(token, "github-user-access-token");
+        assert_eq!(invitation_id, 73);
+        assert_eq!(action, GitHubReceivedRepositoryInvitationAction::Accept);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn invitation(permission: &str) -> RawReceivedRepositoryInvitation {
+        serde_json::from_value(serde_json::json!({
+            "id": 73,
+            "repository": {
+                "id": 1,
+                "name": "hello-world",
+                "full_name": "octocat/hello-world",
+                "private": true,
+                "html_url": "https://github.com/octocat/hello-world",
+                "description": "A repository",
+                "fork": false,
+                "url": "https://api.github.com/repos/octocat/hello-world",
+                "archived": false
+            },
+            "inviter": {
+                "id": 2,
+                "login": "monalisa",
+                "avatar_url": "https://github.com/monalisa.png",
+                "html_url": "https://github.com/monalisa"
+            },
+            "permissions": permission,
+            "created_at": "2026-08-29T08:00:00Z"
+        }))
+        .expect("repository invitation fixture")
+    }
+
+    #[test]
+    fn invitations_keep_repository_inviter_permission_and_pagination() {
+        let page = received_repository_invitation_page(vec![invitation("write")], 2, true);
+
+        assert_eq!(page.page, 2);
+        assert!(page.has_previous);
+        assert!(page.has_more);
+        let invitation = &page.invitations[0];
+        assert_eq!(invitation.id, 73);
+        assert_eq!(invitation.repository.full_name, "octocat/hello-world");
+        assert!(invitation.repository.is_private);
+        assert_eq!(invitation.inviter.login, "monalisa");
+        assert_eq!(invitation.permission, "write");
+        assert_eq!(invitation.created_at, "2026-08-29T08:00:00Z");
+    }
+
+    #[test]
+    fn invalid_permissions_are_not_sent_to_the_webview() {
+        let page = received_repository_invitation_page(vec![invitation("\n")], 1, false);
+
+        assert!(page.invitations.is_empty());
+    }
+
+    #[test]
+    fn invitation_action_route_is_account_scoped() {
+        assert_eq!(
+            repository_invitation_route(73),
+            "/user/repository_invitations/73"
+        );
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -72,6 +72,8 @@ pub fn run() {
             commands::github_list_notifications,
             commands::github_update_notification,
             commands::github_mark_all_notifications_read,
+            commands::github_list_received_repository_invitations,
+            commands::github_update_received_repository_invitation,
             commands::github_list_personal_projects,
             commands::github_get_personal_project,
             commands::github_create_personal_project,

--- a/src/features/github/github-data.ts
+++ b/src/features/github/github-data.ts
@@ -426,6 +426,29 @@ export type GitHubRepositoryContentContext = Pick<
 >;
 
 export type GitHubNotificationAction = "read" | "done";
+export type GitHubReceivedRepositoryInvitationAction = "accept" | "decline";
+
+export type GitHubRepositoryInvitationActor = {
+  id: number;
+  login: string;
+  avatarUrl: string;
+  url: string;
+};
+
+export type GitHubReceivedRepositoryInvitation = {
+  id: number;
+  repository: GitHubRepository;
+  inviter: GitHubRepositoryInvitationActor;
+  permission: string;
+  createdAt: string;
+};
+
+export type GitHubReceivedRepositoryInvitationPage = {
+  invitations: GitHubReceivedRepositoryInvitation[];
+  page: number;
+  hasPrevious: boolean;
+  hasMore: boolean;
+};
 
 export type GitHubNotificationSubjectKind =
   | "issue"
@@ -439,7 +462,7 @@ export type GitHubNotificationSubjectKind =
   | "codeScanningAlert"
   | "secretScanningAlert"
   | "securityAlert"
-  | "repository"
+  | "repositoryInvitation"
   | "other";
 
 export type GitHubNotificationSubject = {

--- a/src/features/github/github-notification-mutations.test.ts
+++ b/src/features/github/github-notification-mutations.test.ts
@@ -148,5 +148,16 @@ describe("GitHub notification mutations", () => {
     ]) {
       expect(notificationCanOpenInApp({ ...release, subject })).toBe(true);
     }
+
+    expect(
+      notificationCanOpenInApp({
+        ...release,
+        subject: {
+          title: "Invitation to octocat/hello-world",
+          kind: "repositoryInvitation",
+          url: "https://github.com/octocat/hello-world",
+        },
+      })
+    ).toBe(true);
   });
 });

--- a/src/features/github/github-notification-target.ts
+++ b/src/features/github/github-notification-target.ts
@@ -14,6 +14,8 @@ export function notificationCanOpenInApp(notification: GitHubNotification) {
     case "codeScanningAlert":
     case "secretScanningAlert":
       return notification.subject.number !== undefined;
+    case "repositoryInvitation":
+      return true;
     case "issue":
     case "pullRequest":
     case "discussion":

--- a/src/features/github/github-notifications.tsx
+++ b/src/features/github/github-notifications.tsx
@@ -17,6 +17,7 @@ import {
   RefreshCw,
   Rocket,
   ShieldAlert,
+  UserPlus,
   type LucideIcon,
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
@@ -104,6 +105,12 @@ const GitHubSecurityAlertDetail = lazy(() =>
   }))
 );
 
+const GitHubRepositoryInvitations = lazy(() =>
+  import("./github-repository-invitations-view").then((module) => ({
+    default: module.GitHubRepositoryInvitations,
+  }))
+);
+
 type NotificationScope = "all" | "participating";
 
 const notificationIcons: Record<GitHubNotificationSubjectKind, LucideIcon> = {
@@ -118,7 +125,7 @@ const notificationIcons: Record<GitHubNotificationSubjectKind, LucideIcon> = {
   codeScanningAlert: ShieldAlert,
   secretScanningAlert: ShieldAlert,
   securityAlert: ShieldAlert,
-  repository: Github,
+  repositoryInvitation: UserPlus,
   other: Bell,
 };
 
@@ -273,6 +280,7 @@ export function GitHubNotifications({
   const [scope, setScope] = useState<NotificationScope>("all");
   const [page, setPage] = useState(1);
   const [selectedNotification, setSelectedNotification] = useState<GitHubNotification | null>(null);
+  const [showRepositoryInvitations, setShowRepositoryInvitations] = useState(false);
   const [doneCandidate, setDoneCandidate] = useState<GitHubNotification | null>(null);
   const [markAllOpen, setMarkAllOpen] = useState(false);
   const result = useQuery({
@@ -346,6 +354,25 @@ export function GitHubNotifications({
       void openExternalUrl(notification.subject.url);
     }
   };
+
+  if (showRepositoryInvitations || selectedNotification?.subject.kind === "repositoryInvitation") {
+    return (
+      <Suspense fallback={<NotificationSkeletons />}>
+        <GitHubRepositoryInvitations
+          highlightRepositoryId={selectedNotification?.repository.id}
+          onBack={() => {
+            setShowRepositoryInvitations(false);
+            setSelectedNotification(null);
+          }}
+          onResolved={(invitation) => {
+            if (selectedNotification?.repository.id === invitation.repository.id) {
+              setSelectedNotification(null);
+            }
+          }}
+        />
+      </Suspense>
+    );
+  }
 
   if (selectedNotification?.subject.kind === "issue" && selectedNotification.subject.number) {
     return (
@@ -481,6 +508,17 @@ export function GitHubNotifications({
             </h1>
           </div>
           <div className="flex items-center gap-2">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => {
+                setSelectedNotification(null);
+                setShowRepositoryInvitations(true);
+              }}
+            >
+              <UserPlus data-icon="inline-start" />
+              {t("workspace.notifications.invitations.open")}
+            </Button>
             <Button
               variant="ghost"
               size="sm"

--- a/src/features/github/github-queries.test.ts
+++ b/src/features/github/github-queries.test.ts
@@ -34,6 +34,7 @@ import {
   userContributionsQueryOptions,
   userProfileQueryOptions,
   notificationsQueryOptions,
+  receivedRepositoryInvitationsQueryOptions,
   pendingPullRequestReviewQueryOptions,
   pullRequestAutoMergeStatusQueryOptions,
   pullRequestBranchUpdateStatusQueryOptions,
@@ -112,6 +113,28 @@ describe("GitHub repository queries", () => {
     expect(invoke).toHaveBeenNthCalledWith(1, "github_list_repositories", { page: 1 });
     expect(invoke).toHaveBeenNthCalledWith(2, "github_list_repositories", { page: 2 });
     expect(observer.getCurrentResult().data?.pages.map((page) => page.page)).toEqual([1, 2]);
+  });
+
+  it("loads received repository invitations through one paginated account cache", async () => {
+    const client = createTestQueryClient();
+    vi.mocked(invoke)
+      .mockResolvedValueOnce({ invitations: [{ id: 73 }], page: 1, hasMore: true })
+      .mockResolvedValueOnce({ invitations: [{ id: 74 }], page: 2, hasMore: false });
+    const options = receivedRepositoryInvitationsQueryOptions();
+
+    await client.fetchInfiniteQuery(options);
+    const observer = new InfiniteQueryObserver(client, options);
+    const unsubscribe = observer.subscribe(() => undefined);
+    await observer.fetchNextPage();
+    unsubscribe();
+
+    expect(options.queryKey).toEqual(["github", "repository-invitations"]);
+    expect(invoke).toHaveBeenNthCalledWith(1, "github_list_received_repository_invitations", {
+      page: 1,
+    });
+    expect(invoke).toHaveBeenNthCalledWith(2, "github_list_received_repository_invitations", {
+      page: 2,
+    });
   });
 
   it("loads the signed-in user's starred workspace and repository relationship state", async () => {

--- a/src/features/github/github-queries.ts
+++ b/src/features/github/github-queries.ts
@@ -35,6 +35,7 @@ import type {
   GitHubIssueSort,
   GitHubIssueState,
   GitHubNotificationPage,
+  GitHubReceivedRepositoryInvitationPage,
   GitHubContributionSummary,
   GitHubProfileActivityPage,
   GitHubProfileConnectionKind,
@@ -342,6 +343,7 @@ export const githubQueryKeys = {
   notifications: ({ participating, page }: GitHubNotificationsTarget) =>
     ["github", "notifications", participating ? "participating" : "all", page] as const,
   notificationsRoot: ["github", "notifications"] as const,
+  receivedRepositoryInvitations: ["github", "repository-invitations"] as const,
   projects: ({ state, query, sort }: GitHubProjectsTarget) =>
     ["github", "personal-projects", state, query, sort] as const,
   projectsRoot: ["github", "personal-projects"] as const,
@@ -947,6 +949,20 @@ export function notificationsQueryOptions(target: GitHubNotificationsTarget) {
       }),
     staleTime: 30_000,
     refetchInterval: 60_000,
+  });
+}
+
+export function receivedRepositoryInvitationsQueryOptions() {
+  return infiniteQueryOptions({
+    queryKey: githubQueryKeys.receivedRepositoryInvitations,
+    queryFn: ({ pageParam }) =>
+      invoke<GitHubReceivedRepositoryInvitationPage>(
+        "github_list_received_repository_invitations",
+        { page: pageParam }
+      ),
+    initialPageParam: 1,
+    getNextPageParam: (lastPage) => (lastPage.hasMore ? lastPage.page + 1 : undefined),
+    staleTime: 30_000,
   });
 }
 

--- a/src/features/github/github-repository-invitations-view.tsx
+++ b/src/features/github/github-repository-invitations-view.tsx
@@ -47,6 +47,7 @@ import {
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { parseIpcError } from "@/lib/ipc-error";
 import { cn } from "@/lib/utils";
 import type {
@@ -172,18 +173,23 @@ export function GitHubRepositoryInvitations({
 
   return (
     <section className="flex min-w-0 flex-1 flex-col bg-[color-mix(in_srgb,var(--background)_95%,transparent)]">
-      <header className="h-[74px] shrink-0 border-b border-white/[0.075] px-4 sm:px-5">
+      <header className="h-[74px] shrink-0 border-b px-4 sm:px-5">
         <div className="mx-auto flex h-full w-full max-w-[960px] items-center justify-between gap-3">
           <div className="flex min-w-0 items-center gap-3">
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon-sm"
-              aria-label={t("workspace.notifications.back")}
-              onClick={onBack}
-            >
-              <ArrowLeft />
-            </Button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-sm"
+                  aria-label={t("workspace.notifications.back")}
+                  onClick={onBack}
+                >
+                  <ArrowLeft />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>{t("workspace.notifications.back")}</TooltipContent>
+            </Tooltip>
             <div className="min-w-0">
               <p className="text-primary/80 text-[10px] font-medium tracking-[0.14em] uppercase">
                 {t("workspace.notifications.invitations.eyebrow")}
@@ -210,8 +216,8 @@ export function GitHubRepositoryInvitations({
         </div>
       </header>
 
-      <div className="mx-auto flex min-h-0 w-full max-w-[960px] flex-1 flex-col border-x border-white/[0.055]">
-        <div className="border-b border-white/[0.065] px-4 py-3 sm:px-5">
+      <div className="mx-auto flex min-h-0 w-full max-w-[960px] flex-1 flex-col border-x">
+        <div className="border-b px-4 py-3 sm:px-5">
           <p className="text-muted-foreground max-w-2xl text-xs leading-5">
             {t("workspace.notifications.invitations.description")}
           </p>

--- a/src/features/github/github-repository-invitations-view.tsx
+++ b/src/features/github/github-repository-invitations-view.tsx
@@ -1,0 +1,424 @@
+import { useMemo, useState } from "react";
+import { useInfiniteQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { isTauri } from "@tauri-apps/api/core";
+import {
+  ArrowLeft,
+  Check,
+  CircleAlert,
+  Inbox,
+  LockKeyhole,
+  RefreshCw,
+  UserPlus,
+  X,
+} from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@/components/ui/empty";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Spinner } from "@/components/ui/spinner";
+import { parseIpcError } from "@/lib/ipc-error";
+import { cn } from "@/lib/utils";
+import type {
+  GitHubReceivedRepositoryInvitation,
+  GitHubReceivedRepositoryInvitationAction,
+} from "./github-data";
+import { formatIssueDate } from "./github-issue-shared";
+import {
+  invalidateReceivedRepositoryInvitationResolution,
+  removeReceivedRepositoryInvitationFromCache,
+  updateReceivedRepositoryInvitation,
+} from "./github-repository-invitations";
+import { receivedRepositoryInvitationsQueryOptions } from "./github-queries";
+
+function RepositoryInvitationSkeletons() {
+  return (
+    <div className="grid gap-3 p-4 sm:p-5">
+      {Array.from({ length: 3 }, (_, index) => (
+        <Card key={index} className="gap-4 py-5 shadow-none">
+          <CardHeader className="gap-2 px-5">
+            <Skeleton className="h-4 w-52" />
+            <Skeleton className="h-3 w-4/5" />
+          </CardHeader>
+          <CardContent className="flex items-center gap-3 px-5">
+            <Skeleton className="size-8 rounded-full" />
+            <Skeleton className="h-3 w-48" />
+          </CardContent>
+          <CardFooter className="justify-end gap-2 px-5">
+            <Skeleton className="h-8 w-20" />
+            <Skeleton className="h-8 w-20" />
+          </CardFooter>
+        </Card>
+      ))}
+    </div>
+  );
+}
+
+function permissionLabel(permission: string, t: ReturnType<typeof useTranslation>["t"]) {
+  return t(`workspace.notifications.invitations.permissions.${permission}`, {
+    defaultValue: permission,
+  });
+}
+
+export function GitHubRepositoryInvitations({
+  highlightRepositoryId,
+  onBack,
+  onResolved,
+}: {
+  highlightRepositoryId?: number;
+  onBack: () => void;
+  onResolved?: (
+    invitation: GitHubReceivedRepositoryInvitation,
+    action: GitHubReceivedRepositoryInvitationAction
+  ) => void;
+}) {
+  const { t, i18n } = useTranslation();
+  const queryClient = useQueryClient();
+  const desktopRuntime = isTauri();
+  const [declineCandidate, setDeclineCandidate] =
+    useState<GitHubReceivedRepositoryInvitation | null>(null);
+  const [mutationError, setMutationError] = useState<{
+    invitationId: number;
+    message: string;
+  } | null>(null);
+  const result = useInfiniteQuery({
+    ...receivedRepositoryInvitationsQueryOptions(),
+    enabled: desktopRuntime,
+  });
+  const invitations = useMemo(() => {
+    const seen = new Set<number>();
+    return (result.data?.pages ?? []).flatMap((page) =>
+      page.invitations.filter((invitation) => {
+        if (seen.has(invitation.id)) return false;
+        seen.add(invitation.id);
+        return true;
+      })
+    );
+  }, [result.data]);
+  const loadError = !desktopRuntime
+    ? { code: "desktopOnly", message: t("workspace.notifications.desktopOnly") }
+    : !result.data && result.error
+      ? parseIpcError(result.error)
+      : null;
+  const supplementalError = result.data && result.error ? parseIpcError(result.error) : null;
+
+  const mutation = useMutation({
+    mutationFn: updateReceivedRepositoryInvitation,
+    onMutate: (target) => {
+      setMutationError((current) =>
+        current?.invitationId === target.invitationId ? null : current
+      );
+    },
+    onSuccess: (_, target) => {
+      const invitation = invitations.find((item) => item.id === target.invitationId);
+      removeReceivedRepositoryInvitationFromCache(queryClient, target.invitationId);
+      toast.success(
+        t(
+          target.action === "accept"
+            ? "workspace.notifications.invitations.acceptSuccess"
+            : "workspace.notifications.invitations.declineSuccess",
+          { repository: invitation?.repository.fullName }
+        )
+      );
+      void invalidateReceivedRepositoryInvitationResolution(queryClient, target.action);
+      if (invitation) onResolved?.(invitation, target.action);
+    },
+    onError: (reason, target) => {
+      const parsed = parseIpcError(reason);
+      setMutationError({ invitationId: target.invitationId, message: parsed.message });
+    },
+  });
+
+  const resolve = (
+    invitation: GitHubReceivedRepositoryInvitation,
+    action: GitHubReceivedRepositoryInvitationAction
+  ) => {
+    setMutationError(null);
+    mutation.mutate(
+      { invitationId: invitation.id, action },
+      action === "decline" ? { onSuccess: () => setDeclineCandidate(null) } : undefined
+    );
+  };
+
+  return (
+    <section className="flex min-w-0 flex-1 flex-col bg-[color-mix(in_srgb,var(--background)_95%,transparent)]">
+      <header className="h-[74px] shrink-0 border-b border-white/[0.075] px-4 sm:px-5">
+        <div className="mx-auto flex h-full w-full max-w-[960px] items-center justify-between gap-3">
+          <div className="flex min-w-0 items-center gap-3">
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              aria-label={t("workspace.notifications.back")}
+              onClick={onBack}
+            >
+              <ArrowLeft />
+            </Button>
+            <div className="min-w-0">
+              <p className="text-primary/80 text-[10px] font-medium tracking-[0.14em] uppercase">
+                {t("workspace.notifications.invitations.eyebrow")}
+              </p>
+              <h1 className="mt-0.5 truncate text-xl font-semibold tracking-[-0.03em]">
+                {t("workspace.notifications.invitations.title")}
+              </h1>
+            </div>
+          </div>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={result.isFetching || !desktopRuntime}
+            onClick={() => void result.refetch()}
+          >
+            {result.isFetching ? (
+              <Spinner data-icon="inline-start" />
+            ) : (
+              <RefreshCw data-icon="inline-start" />
+            )}
+            {t("workspace.notifications.refresh")}
+          </Button>
+        </div>
+      </header>
+
+      <div className="mx-auto flex min-h-0 w-full max-w-[960px] flex-1 flex-col border-x border-white/[0.055]">
+        <div className="border-b border-white/[0.065] px-4 py-3 sm:px-5">
+          <p className="text-muted-foreground max-w-2xl text-xs leading-5">
+            {t("workspace.notifications.invitations.description")}
+          </p>
+        </div>
+        {supplementalError ? (
+          <Alert variant="destructive" className="rounded-none border-x-0 border-t-0 px-4 py-2">
+            <CircleAlert />
+            <AlertDescription className="flex min-w-0 items-center gap-3 text-[11px]">
+              <span className="min-w-0 flex-1 truncate">{supplementalError.message}</span>
+              <Button variant="ghost" size="xs" onClick={() => void result.refetch()}>
+                {t("workspace.repositories.retry")}
+              </Button>
+            </AlertDescription>
+          </Alert>
+        ) : null}
+        <ScrollArea className="min-h-0 flex-1">
+          {result.isPending && !result.data ? (
+            <RepositoryInvitationSkeletons />
+          ) : loadError ? (
+            <Empty className="min-h-80">
+              <EmptyHeader>
+                <EmptyMedia variant="icon">
+                  <CircleAlert />
+                </EmptyMedia>
+                <EmptyTitle>{t("workspace.notifications.invitations.loadFailed")}</EmptyTitle>
+                <EmptyDescription>{loadError.message}</EmptyDescription>
+              </EmptyHeader>
+              <EmptyContent>
+                <Button variant="outline" onClick={() => void result.refetch()}>
+                  <RefreshCw data-icon="inline-start" />
+                  {t("workspace.repositories.retry")}
+                </Button>
+              </EmptyContent>
+            </Empty>
+          ) : invitations.length ? (
+            <div className="grid gap-3 p-4 sm:p-5">
+              {invitations.map((invitation) => {
+                const pending =
+                  mutation.isPending && mutation.variables.invitationId === invitation.id;
+                const highlighted = invitation.repository.id === highlightRepositoryId;
+                return (
+                  <Card
+                    key={invitation.id}
+                    className={cn(
+                      "gap-4 py-5 shadow-none transition-colors",
+                      highlighted && "border-primary/45 bg-primary/[0.035]"
+                    )}
+                  >
+                    <CardHeader className="gap-2 px-5">
+                      <CardTitle className="truncate text-sm">
+                        {invitation.repository.fullName}
+                      </CardTitle>
+                      <CardDescription className="line-clamp-2 text-xs leading-5">
+                        {invitation.repository.description ||
+                          t("workspace.repositories.noDescription")}
+                      </CardDescription>
+                      <CardAction className="flex items-center gap-1.5">
+                        {invitation.repository.isPrivate ? (
+                          <Badge variant="outline" className="gap-1 font-normal">
+                            <LockKeyhole />
+                            {t("workspace.notifications.invitations.private")}
+                          </Badge>
+                        ) : null}
+                        <Badge variant="secondary" className="font-normal">
+                          {permissionLabel(invitation.permission, t)}
+                        </Badge>
+                      </CardAction>
+                    </CardHeader>
+                    <CardContent className="flex items-center gap-3 px-5">
+                      <Avatar>
+                        <AvatarImage
+                          src={invitation.inviter.avatarUrl}
+                          alt={invitation.inviter.login}
+                        />
+                        <AvatarFallback>
+                          {invitation.inviter.login.slice(0, 2).toUpperCase()}
+                        </AvatarFallback>
+                      </Avatar>
+                      <div className="min-w-0 text-xs">
+                        <p className="text-foreground truncate font-medium">
+                          {t("workspace.notifications.invitations.invitedBy", {
+                            login: invitation.inviter.login,
+                          })}
+                        </p>
+                        <time className="text-muted-foreground">
+                          {formatIssueDate(invitation.createdAt, i18n.language)}
+                        </time>
+                      </div>
+                    </CardContent>
+                    {mutationError?.invitationId === invitation.id ? (
+                      <CardContent className="px-5">
+                        <Alert variant="destructive">
+                          <CircleAlert />
+                          <AlertTitle>
+                            {t("workspace.notifications.invitations.updateFailed")}
+                          </AlertTitle>
+                          <AlertDescription>{mutationError.message}</AlertDescription>
+                        </Alert>
+                      </CardContent>
+                    ) : null}
+                    <CardFooter className="justify-end gap-2 px-5">
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        disabled={mutation.isPending}
+                        onClick={() => setDeclineCandidate(invitation)}
+                      >
+                        <X data-icon="inline-start" />
+                        {t("workspace.notifications.invitations.decline")}
+                      </Button>
+                      <Button
+                        type="button"
+                        size="sm"
+                        disabled={mutation.isPending}
+                        onClick={() => resolve(invitation, "accept")}
+                      >
+                        {pending && mutation.variables.action === "accept" ? (
+                          <Spinner data-icon="inline-start" />
+                        ) : (
+                          <Check data-icon="inline-start" />
+                        )}
+                        {t("workspace.notifications.invitations.accept")}
+                      </Button>
+                    </CardFooter>
+                  </Card>
+                );
+              })}
+              {result.hasNextPage ? (
+                <Button
+                  type="button"
+                  variant="outline"
+                  className="justify-self-center"
+                  disabled={result.isFetchingNextPage}
+                  onClick={() => void result.fetchNextPage()}
+                >
+                  {result.isFetchingNextPage ? (
+                    <Spinner data-icon="inline-start" />
+                  ) : (
+                    <UserPlus data-icon="inline-start" />
+                  )}
+                  {t("workspace.notifications.invitations.loadMore")}
+                </Button>
+              ) : null}
+            </div>
+          ) : (
+            <Empty className="min-h-80">
+              <EmptyHeader>
+                <EmptyMedia variant="icon">
+                  <Inbox />
+                </EmptyMedia>
+                <EmptyTitle>{t("workspace.notifications.invitations.empty")}</EmptyTitle>
+                <EmptyDescription>
+                  {t("workspace.notifications.invitations.emptyDescription")}
+                </EmptyDescription>
+              </EmptyHeader>
+            </Empty>
+          )}
+        </ScrollArea>
+      </div>
+
+      <AlertDialog
+        open={Boolean(declineCandidate)}
+        onOpenChange={(open) => {
+          if (!open && !mutation.isPending) setDeclineCandidate(null);
+        }}
+      >
+        <AlertDialogContent size="sm">
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {t("workspace.notifications.invitations.declineTitle")}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {t("workspace.notifications.invitations.declineDescription", {
+                repository: declineCandidate?.repository.fullName,
+              })}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          {declineCandidate && mutationError?.invitationId === declineCandidate.id ? (
+            <Alert variant="destructive">
+              <CircleAlert />
+              <AlertTitle>{t("workspace.notifications.invitations.updateFailed")}</AlertTitle>
+              <AlertDescription>{mutationError.message}</AlertDescription>
+            </Alert>
+          ) : null}
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={mutation.isPending}>
+              {t("workspace.notifications.cancel")}
+            </AlertDialogCancel>
+            <AlertDialogAction
+              variant="destructive"
+              disabled={mutation.isPending || !declineCandidate}
+              onClick={(event) => {
+                event.preventDefault();
+                if (declineCandidate) resolve(declineCandidate, "decline");
+              }}
+            >
+              {mutation.isPending ? (
+                <Spinner data-icon="inline-start" />
+              ) : (
+                <X data-icon="inline-start" />
+              )}
+              {t("workspace.notifications.invitations.decline")}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </section>
+  );
+}

--- a/src/features/github/github-repository-invitations.test.ts
+++ b/src/features/github/github-repository-invitations.test.ts
@@ -1,0 +1,85 @@
+import { QueryClient, type InfiniteData } from "@tanstack/react-query";
+import { invoke } from "@tauri-apps/api/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { GitHubReceivedRepositoryInvitationPage } from "./github-data";
+import {
+  invalidateReceivedRepositoryInvitationResolution,
+  removeReceivedRepositoryInvitationFromCache,
+  updateReceivedRepositoryInvitation,
+} from "./github-repository-invitations";
+import { githubQueryKeys } from "./github-queries";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+describe("received repository invitation mutations", () => {
+  beforeEach(() => {
+    vi.mocked(invoke).mockReset();
+    vi.mocked(invoke).mockResolvedValue(undefined);
+  });
+
+  it("invokes the exact account-scoped invitation command", async () => {
+    await updateReceivedRepositoryInvitation({ invitationId: 73, action: "accept" });
+    await updateReceivedRepositoryInvitation({ invitationId: 74, action: "decline" });
+
+    expect(invoke).toHaveBeenNthCalledWith(1, "github_update_received_repository_invitation", {
+      invitationId: 73,
+      action: "accept",
+    });
+    expect(invoke).toHaveBeenNthCalledWith(2, "github_update_received_repository_invitation", {
+      invitationId: 74,
+      action: "decline",
+    });
+  });
+
+  it("removes the resolved invitation from every loaded page", () => {
+    const queryClient = new QueryClient();
+    const invitation = {
+      id: 73,
+      repository: { id: 1 },
+      inviter: { id: 2 },
+      permission: "write",
+      createdAt: "2026-08-29T08:00:00Z",
+    };
+    queryClient.setQueryData<InfiniteData<GitHubReceivedRepositoryInvitationPage>>(
+      githubQueryKeys.receivedRepositoryInvitations,
+      {
+        pages: [
+          {
+            invitations: [invitation],
+            page: 1,
+            hasPrevious: false,
+            hasMore: true,
+          } as GitHubReceivedRepositoryInvitationPage,
+          {
+            invitations: [{ ...invitation, id: 74 }],
+            page: 2,
+            hasPrevious: true,
+            hasMore: false,
+          } as GitHubReceivedRepositoryInvitationPage,
+        ],
+        pageParams: [1, 2],
+      }
+    );
+
+    removeReceivedRepositoryInvitationFromCache(queryClient, 73);
+
+    const cached = queryClient.getQueryData<InfiniteData<GitHubReceivedRepositoryInvitationPage>>(
+      githubQueryKeys.receivedRepositoryInvitations
+    );
+    expect(cached?.pages[0].invitations).toEqual([]);
+    expect(cached?.pages[1].invitations.map((item) => item.id)).toEqual([74]);
+  });
+
+  it("refreshes repositories only after an accepted invitation", async () => {
+    const queryClient = new QueryClient();
+    const invalidate = vi.spyOn(queryClient, "invalidateQueries");
+
+    await invalidateReceivedRepositoryInvitationResolution(queryClient, "decline");
+    expect(invalidate).not.toHaveBeenCalledWith({ queryKey: githubQueryKeys.repositories });
+
+    await invalidateReceivedRepositoryInvitationResolution(queryClient, "accept");
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: githubQueryKeys.repositories });
+  });
+});

--- a/src/features/github/github-repository-invitations.ts
+++ b/src/features/github/github-repository-invitations.ts
@@ -1,0 +1,52 @@
+import type { InfiniteData, QueryClient } from "@tanstack/react-query";
+import { invoke } from "@tauri-apps/api/core";
+import type {
+  GitHubReceivedRepositoryInvitationAction,
+  GitHubReceivedRepositoryInvitationPage,
+} from "./github-data";
+import { githubQueryKeys } from "./github-queries";
+
+export type GitHubReceivedRepositoryInvitationMutationTarget = {
+  invitationId: number;
+  action: GitHubReceivedRepositoryInvitationAction;
+};
+
+export function updateReceivedRepositoryInvitation(
+  target: GitHubReceivedRepositoryInvitationMutationTarget
+) {
+  return invoke<void>("github_update_received_repository_invitation", target);
+}
+
+export function removeReceivedRepositoryInvitationFromCache(
+  queryClient: QueryClient,
+  invitationId: number
+) {
+  queryClient.setQueryData<InfiniteData<GitHubReceivedRepositoryInvitationPage>>(
+    githubQueryKeys.receivedRepositoryInvitations,
+    (data) =>
+      data
+        ? {
+            ...data,
+            pages: data.pages.map((page) => ({
+              ...page,
+              invitations: page.invitations.filter((invitation) => invitation.id !== invitationId),
+            })),
+          }
+        : data
+  );
+}
+
+export async function invalidateReceivedRepositoryInvitationResolution(
+  queryClient: QueryClient,
+  action: GitHubReceivedRepositoryInvitationAction
+) {
+  await Promise.all([
+    queryClient.invalidateQueries({
+      queryKey: githubQueryKeys.receivedRepositoryInvitations,
+    }),
+    queryClient.invalidateQueries({ queryKey: githubQueryKeys.notificationsRoot }),
+    action === "accept"
+      ? queryClient.invalidateQueries({ queryKey: githubQueryKeys.repositories })
+      : Promise.resolve(),
+  ]);
+}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -218,6 +218,32 @@
       "markAllTitle": "Mark every notification as read?",
       "markAllDescription": "Every notification GitHub currently reports as unread will leave Harbor's inbox. The GitHub API does not provide a mark-unread action.",
       "cancel": "Cancel",
+      "invitations": {
+        "open": "Repository invitations",
+        "eyebrow": "Account access",
+        "title": "Repository invitations",
+        "description": "Review open repository invitations for your GitHub account. Accepted repositories will appear in My repositories after GitHub finishes granting access.",
+        "private": "Private",
+        "invitedBy": "Invited by {{login}}",
+        "accept": "Accept",
+        "decline": "Decline",
+        "acceptSuccess": "Accepted the invitation to {{repository}}",
+        "declineSuccess": "Declined the invitation to {{repository}}",
+        "updateFailed": "The invitation could not be updated",
+        "loadFailed": "Harbor could not load repository invitations",
+        "empty": "No open invitations",
+        "emptyDescription": "New repository invitations for this account will appear here.",
+        "loadMore": "Load more invitations",
+        "declineTitle": "Decline this repository invitation?",
+        "declineDescription": "The invitation to {{repository}} will be removed. The repository owner must send another invitation if you need access later.",
+        "permissions": {
+          "read": "Read",
+          "triage": "Triage",
+          "write": "Write",
+          "maintain": "Maintain",
+          "admin": "Admin"
+        }
+      },
       "kinds": {
         "issue": "Issue",
         "pullRequest": "Pull request",
@@ -230,7 +256,7 @@
         "codeScanningAlert": "Code scanning alert",
         "secretScanningAlert": "Secret scanning alert",
         "securityAlert": "Security alert",
-        "repository": "Repository",
+        "repositoryInvitation": "Repository invitation",
         "other": "GitHub"
       },
       "reasons": {

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -218,6 +218,32 @@
       "markAllTitle": "把所有通知都标为已读吗？",
       "markAllDescription": "GitHub 当前返回的所有未读通知都会从 Harbor 收件箱移除。GitHub API 暂不支持重新标为未读。",
       "cancel": "取消",
+      "invitations": {
+        "open": "仓库邀请",
+        "eyebrow": "账户访问权限",
+        "title": "仓库邀请",
+        "description": "这里会列出当前 GitHub 账户收到、尚未处理的仓库邀请。接受后，GitHub 完成授权时，仓库会出现在“我的仓库”里。",
+        "private": "私有",
+        "invitedBy": "由 {{login}} 邀请",
+        "accept": "接受",
+        "decline": "拒绝",
+        "acceptSuccess": "已接受 {{repository}} 的邀请",
+        "declineSuccess": "已拒绝 {{repository}} 的邀请",
+        "updateFailed": "暂时无法处理这条邀请",
+        "loadFailed": "Harbor 暂时无法读取仓库邀请",
+        "empty": "没有待处理的邀请",
+        "emptyDescription": "这个账户新收到的仓库邀请会显示在这里。",
+        "loadMore": "加载更多邀请",
+        "declineTitle": "拒绝这条仓库邀请吗？",
+        "declineDescription": "拒绝 {{repository}} 的邀请后，这条邀请会被移除。如果之后还需要访问，仓库所有者需要重新邀请你。",
+        "permissions": {
+          "read": "读取",
+          "triage": "分流",
+          "write": "写入",
+          "maintain": "维护",
+          "admin": "管理"
+        }
+      },
       "kinds": {
         "issue": "Issue",
         "pullRequest": "拉取请求",
@@ -230,7 +256,7 @@
         "codeScanningAlert": "代码扫描告警",
         "secretScanningAlert": "密钥扫描告警",
         "securityAlert": "安全提醒",
-        "repository": "仓库",
+        "repositoryInvitation": "仓库邀请",
         "other": "GitHub"
       },
       "reasons": {


### PR DESCRIPTION
## Summary

- add a focused Rust client and Tauri commands for listing, accepting, and declining received repository invitations
- route repository-invitation notifications into a permanent native account workspace
- reconcile invitation, notification, and repository caches after each action

## Verification

- `pnpm check` (129 tests)
- `cargo fmt --check --manifest-path src-tauri/Cargo.toml`
- `cargo test --manifest-path src-tauri/Cargo.toml --lib` (227 passed, 1 ignored)
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets` (same 11 pre-existing warnings)
- Playwright desktop fixture at 1600x1000 and 900x620: permanent entry, notification routing, accept, decline confirmation, empty/error states, exact IPC payloads, no console errors, no page-level horizontal overflow

## References

- [GitHub REST repository invitations](https://docs.github.com/en/rest/collaborators/invitations?apiVersion=2026-03-10)
- [go-github invitation client](https://github.com/google/go-github/blob/master/github/users.go)