### PR TITLE
feat(github): navigate linked pull requests natively

### DIFF
--- a/src-tauri/src/github/issue_linked_pull_request.rs
+++ b/src-tauri/src/github/issue_linked_pull_request.rs
@@ -9,7 +9,7 @@ use super::{
         graphql_node_id_is_valid, issue_url_matches, split_repository_full_name,
         IssueGraphQlRequest,
     },
-    GitHubPullRequestState, GitHubService, OctocrabGitHubClient,
+    GitHubPullRequestRepository, GitHubPullRequestState, GitHubService, OctocrabGitHubClient,
 };
 use crate::error::AppError;
 
@@ -59,7 +59,7 @@ query HarborIssueLinkedPullRequests(
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GitHubIssueLinkedPullRequestReference {
-    pub full_name: String,
+    pub repository: GitHubPullRequestRepository,
     pub number: u64,
     pub title: String,
     pub url: String,
@@ -287,7 +287,12 @@ fn linked_pull_request_reference(
 
     Ok(ValidatedLinkedPullRequest {
         id: pull_request.id,
-        full_name: pull_request.repository.name_with_owner,
+        repository: GitHubPullRequestRepository {
+            url: format!("https://github.com/{owner}/{repository}"),
+            owner,
+            name: repository,
+            full_name: pull_request.repository.name_with_owner,
+        },
         number: pull_request.number,
         title: pull_request.title,
         url: pull_request.url,
@@ -307,7 +312,7 @@ fn invalid_linked_pull_request() -> AppError {
 
 struct ValidatedLinkedPullRequest {
     id: String,
-    full_name: String,
+    repository: GitHubPullRequestRepository,
     number: u64,
     title: String,
     url: String,
@@ -319,7 +324,7 @@ struct ValidatedLinkedPullRequest {
 impl ValidatedLinkedPullRequest {
     fn into_public(self) -> GitHubIssueLinkedPullRequestReference {
         GitHubIssueLinkedPullRequestReference {
-            full_name: self.full_name,
+            repository: self.repository,
             number: self.number,
             title: self.title,
             url: self.url,

--- a/src-tauri/src/github/issue_linked_pull_request/tests.rs
+++ b/src-tauri/src/github/issue_linked_pull_request/tests.rs
@@ -61,7 +61,13 @@ async fn transport_loads_a_page_of_current_issues_linked_pull_requests() {
     server.await.expect("mock server");
 
     assert_eq!(page.pull_requests.len(), 1);
-    assert_eq!(page.pull_requests[0].full_name, "octocat/api");
+    assert_eq!(page.pull_requests[0].repository.owner, "octocat");
+    assert_eq!(page.pull_requests[0].repository.name, "api");
+    assert_eq!(page.pull_requests[0].repository.full_name, "octocat/api");
+    assert_eq!(
+        page.pull_requests[0].repository.url,
+        "https://github.com/octocat/api"
+    );
     assert_eq!(page.pull_requests[0].number, 9);
     assert_eq!(page.pull_requests[0].title, "Ship API");
     assert_eq!(page.next_cursor.as_deref(), Some("cursor-2"));

--- a/src/features/github/github-data.ts
+++ b/src/features/github/github-data.ts
@@ -1472,7 +1472,7 @@ export type GitHubIssueDuplicateReference = {
 };
 
 export type GitHubIssueLinkedPullRequestReference = {
-  fullName: string;
+  repository: GitHubPullRequestRepository;
   number: number;
   title: string;
   url: string;

--- a/src/features/github/github-issue-detail-navigation.interaction.test.tsx
+++ b/src/features/github/github-issue-detail-navigation.interaction.test.tsx
@@ -48,6 +48,70 @@ vi.mock("./github-issue-relationships", () => ({
     </button>
   ),
 }));
+vi.mock("./github-issue-linked-pull-requests", () => ({
+  GitHubIssueLinkedPullRequests: ({
+    onNavigate,
+  }: {
+    onNavigate: (pullRequest: {
+      repository: {
+        owner: string;
+        name: string;
+        fullName: string;
+        url: string;
+      };
+      number: number;
+      title: string;
+      url: string;
+      state: "open";
+      draft: false;
+      merged: false;
+    }) => void;
+  }) => (
+    <button
+      type="button"
+      onClick={() =>
+        onNavigate({
+          repository: {
+            owner: "octocat",
+            name: "api",
+            fullName: "octocat/api",
+            url: "https://github.com/octocat/api",
+          },
+          number: 9,
+          title: "Ship API",
+          url: "https://github.com/octocat/api/pull/9",
+          state: "open",
+          draft: false,
+          merged: false,
+        })
+      }
+    >
+      Open linked PR natively
+    </button>
+  ),
+}));
+vi.mock("./github-pull-request-detail", () => ({
+  GitHubPullRequestDetail: ({
+    repository,
+    pullRequestNumber,
+    onBack,
+    backLabel,
+  }: {
+    repository: { fullName: string };
+    pullRequestNumber: number;
+    onBack: () => void;
+    backLabel: string;
+  }) => (
+    <section>
+      <p>
+        {repository.fullName} #{pullRequestNumber}
+      </p>
+      <button type="button" onClick={onBack}>
+        {backLabel}
+      </button>
+    </section>
+  ),
+}));
 vi.mock("./github-issue-metadata", () => ({ GitHubIssueMetadata: () => null }));
 vi.mock("./github-issue-edit-dialog", () => ({ GitHubIssueEditDialog: () => null }));
 vi.mock("./github-comment-form", () => ({ GitHubCommentForm: () => null }));
@@ -156,5 +220,32 @@ describe("GitHub Issue detail relationship navigation", () => {
     expect(onBack).not.toHaveBeenCalled();
     await user.click(screen.getByRole("button", { name: "Return to host" }));
     expect(onBack).toHaveBeenCalledOnce();
+  });
+
+  it("opens a cross-repository linked pull request in place and returns to the Issue", async () => {
+    const onBack = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <QueryClientProvider
+        client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}
+      >
+        <GitHubIssueDetail
+          repository={repository}
+          issueNumber={7}
+          onBack={onBack}
+          backLabel="Return to host"
+        />
+      </QueryClientProvider>
+    );
+
+    expect(await screen.findByText("Root issue detail")).toBeDefined();
+    await user.click(screen.getByRole("button", { name: "Open linked PR natively" }));
+    expect(await screen.findByText("octocat/api #9")).toBeDefined();
+
+    await user.click(
+      screen.getByRole("button", { name: "workspace.repositories.backToPreviousIssue" })
+    );
+    expect(await screen.findByText("Root issue detail")).toBeDefined();
+    expect(onBack).not.toHaveBeenCalled();
   });
 });

--- a/src/features/github/github-issue-detail.tsx
+++ b/src/features/github/github-issue-detail.tsx
@@ -18,7 +18,11 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { useAppTranslation } from "@/hooks/use-app-translation";
 import { parseIpcError } from "@/lib/ipc-error";
 import { openExternalUrl } from "@/lib/window";
-import type { GitHubIssue, GitHubRepositoryContentContext } from "./github-data";
+import type {
+  GitHubIssue,
+  GitHubIssueLinkedPullRequestReference,
+  GitHubRepositoryContentContext,
+} from "./github-data";
 import { GitHubCommentForm } from "./github-comment-form";
 import { GitHubIssueEditDialog } from "./github-issue-edit-dialog";
 import { GitHubIssueMetadata } from "./github-issue-metadata";
@@ -49,6 +53,7 @@ import {
 } from "./github-issue-state-queries";
 import { formatIssueDate, GitHubIssueStateBadge } from "./github-issue-shared";
 import { GitHubIssueTimeline } from "./github-issue-timeline";
+import { GitHubPullRequestDetail } from "./github-pull-request-detail";
 import { githubQueryKeys, repositoryIssueDetailQueryOptions } from "./github-queries";
 
 export function GitHubIssueComposer({
@@ -209,12 +214,14 @@ function GitHubIssueDetailScreen({
   onBack,
   backLabel,
   onNavigate,
+  onNavigatePullRequest,
 }: {
   repository: GitHubRepositoryContentContext;
   issueNumber: number;
   onBack: () => void;
   backLabel?: string;
   onNavigate: (repository: GitHubRepositoryContentContext, issueNumber: number) => void;
+  onNavigatePullRequest: (pullRequest: GitHubIssueLinkedPullRequestReference) => void;
 }) {
   const { t, i18n } = useTranslation();
   const [timelinePage, setTimelinePage] = useState(1);
@@ -342,7 +349,11 @@ function GitHubIssueDetailScreen({
                           )
                         }
                       />
-                      <GitHubIssueLinkedPullRequests repository={repository} issue={detail.issue} />
+                      <GitHubIssueLinkedPullRequests
+                        repository={repository}
+                        issue={detail.issue}
+                        onNavigate={onNavigatePullRequest}
+                      />
                       <GitHubIssueRelationships
                         repository={repository}
                         issueNumber={detail.issue.number}
@@ -402,9 +413,15 @@ export function GitHubIssueDetail({
   const root = issueDetailLocation(repository, issueNumber);
   const rootKey = `${repository.owner.toLowerCase()}/${repository.name.toLowerCase()}#${issueNumber}`;
   const [navigation, setNavigation] = useState({ rootKey, history: [root] });
+  const [pullRequestNavigation, setPullRequestNavigation] = useState<{
+    sourceKey: string;
+    pullRequest: GitHubIssueLinkedPullRequestReference;
+  } | null>(null);
   const history = navigation.rootKey === rootKey ? navigation.history : [root];
   const current = history[history.length - 1] ?? root;
   const currentKey = `${current.repository.owner.toLowerCase()}/${current.repository.name.toLowerCase()}#${current.issueNumber}`;
+  const selectedPullRequest =
+    pullRequestNavigation?.sourceKey === currentKey ? pullRequestNavigation.pullRequest : null;
 
   const navigate = (nextRepository: GitHubRepositoryContentContext, nextIssueNumber: number) => {
     const next = issueDetailLocation(nextRepository, nextIssueNumber);
@@ -427,6 +444,18 @@ export function GitHubIssueDetail({
     }));
   };
 
+  if (selectedPullRequest) {
+    return (
+      <GitHubPullRequestDetail
+        key={`${selectedPullRequest.repository.fullName.toLowerCase()}#${selectedPullRequest.number}`}
+        repository={selectedPullRequest.repository}
+        pullRequestNumber={selectedPullRequest.number}
+        onBack={() => setPullRequestNavigation(null)}
+        backLabel={t("workspace.repositories.backToPreviousIssue")}
+      />
+    );
+  }
+
   return (
     <GitHubIssueDetailScreen
       key={currentKey}
@@ -435,6 +464,9 @@ export function GitHubIssueDetail({
       onBack={goBack}
       backLabel={history.length > 1 ? t("workspace.repositories.backToPreviousIssue") : backLabel}
       onNavigate={navigate}
+      onNavigatePullRequest={(pullRequest) =>
+        setPullRequestNavigation({ sourceKey: currentKey, pullRequest })
+      }
     />
   );
 }

--- a/src/features/github/github-issue-linked-pull-requests.interaction.test.tsx
+++ b/src/features/github/github-issue-linked-pull-requests.interaction.test.tsx
@@ -41,7 +41,12 @@ const issue: GitHubIssue = {
 const firstPage = {
   pullRequests: [
     {
-      fullName: "octocat/api",
+      repository: {
+        owner: "octocat",
+        name: "api",
+        fullName: "octocat/api",
+        url: "https://github.com/octocat/api",
+      },
       number: 9,
       title: "Ship API",
       url: "https://github.com/octocat/api/pull/9",
@@ -53,12 +58,16 @@ const firstPage = {
   nextCursor: "cursor-2",
 };
 
-function renderLinkedPullRequests() {
+function renderLinkedPullRequests(onNavigate = vi.fn()) {
   return render(
     <QueryClientProvider
       client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}
     >
-      <GitHubIssueLinkedPullRequests repository={repository} issue={issue} />
+      <GitHubIssueLinkedPullRequests
+        repository={repository}
+        issue={issue}
+        onNavigate={onNavigate}
+      />
     </QueryClientProvider>
   );
 }
@@ -84,14 +93,23 @@ describe("GitHub Issue linked pull requests", () => {
     expect(await screen.findByText("workspace.repositories.noLinkedPullRequests")).toBeDefined();
   });
 
-  it("shows linked pull requests and opens their canonical GitHub URL", async () => {
+  it("opens a linked pull request natively and keeps its canonical GitHub URL independent", async () => {
     vi.mocked(invoke).mockResolvedValueOnce(firstPage);
+    const onNavigate = vi.fn();
     const user = userEvent.setup();
-    renderLinkedPullRequests();
+    renderLinkedPullRequests(onNavigate);
 
     await user.click(await screen.findByRole("button", { name: /Ship API/ }));
 
+    expect(onNavigate).toHaveBeenCalledWith(firstPage.pullRequests[0]);
+    expect(openExternalUrl).not.toHaveBeenCalled();
+    await user.click(
+      screen.getByRole("button", {
+        name: "workspace.repositories.openLinkedPullRequestOnGitHub",
+      })
+    );
     expect(openExternalUrl).toHaveBeenCalledWith("https://github.com/octocat/api/pull/9");
+    expect(onNavigate).toHaveBeenCalledOnce();
     expect(invoke).toHaveBeenCalledWith("github_get_repository_issue_linked_pull_requests", {
       owner: "octocat",
       repository: "hello-world",

--- a/src/features/github/github-issue-linked-pull-requests.tsx
+++ b/src/features/github/github-issue-linked-pull-requests.tsx
@@ -34,35 +34,54 @@ function LinkedPullRequestsSkeleton() {
 
 function LinkedPullRequestRow({
   pullRequest,
+  onNavigate,
 }: {
   pullRequest: GitHubIssueLinkedPullRequestReference;
+  onNavigate: (pullRequest: GitHubIssueLinkedPullRequestReference) => void;
 }) {
+  const { t } = useAppTranslation();
   return (
-    <Button
-      type="button"
-      variant="ghost"
-      className="h-auto w-full min-w-0 justify-start gap-2 rounded-md px-2.5 py-2 text-left"
-      onClick={() => void openExternalUrl(pullRequest.url)}
-    >
-      <GitPullRequest data-icon="inline-start" className="text-muted-foreground" />
-      <span className="min-w-0 flex-1">
-        <span className="block truncate text-xs font-medium">{pullRequest.title}</span>
-        <span className="text-muted-foreground block truncate text-[10px] font-normal">
-          {pullRequest.fullName} #{pullRequest.number}
+    <div className="hover:bg-accent/30 flex min-w-0 items-center rounded-md">
+      <Button
+        type="button"
+        variant="ghost"
+        className="h-auto min-w-0 flex-1 justify-start gap-2 rounded-md px-2.5 py-2 text-left"
+        onClick={() => onNavigate(pullRequest)}
+      >
+        <GitPullRequest data-icon="inline-start" className="text-muted-foreground" />
+        <span className="min-w-0 flex-1">
+          <span className="block truncate text-xs font-medium">{pullRequest.title}</span>
+          <span className="text-muted-foreground block truncate text-[10px] font-normal">
+            {pullRequest.repository.fullName} #{pullRequest.number}
+          </span>
         </span>
-      </span>
-      <GitHubPullRequestStateBadge pullRequest={pullRequest} />
-      <ExternalLink data-icon="inline-end" className="text-muted-foreground" />
-    </Button>
+        <GitHubPullRequestStateBadge pullRequest={pullRequest} />
+      </Button>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon-xs"
+        className="mr-1 shrink-0"
+        aria-label={t("workspace.repositories.openLinkedPullRequestOnGitHub", {
+          repository: pullRequest.repository.fullName,
+          number: pullRequest.number,
+        })}
+        onClick={() => void openExternalUrl(pullRequest.url)}
+      >
+        <ExternalLink />
+      </Button>
+    </div>
   );
 }
 
 function GitHubIssueLinkedPullRequestsContent({
   repository,
   issue,
+  onNavigate,
 }: {
   repository: GitHubRepositoryContentContext;
   issue: GitHubIssue;
+  onNavigate: (pullRequest: GitHubIssueLinkedPullRequestReference) => void;
 }) {
   const { t } = useAppTranslation();
   const [cursors, setCursors] = useState<(string | null)[]>([null]);
@@ -131,7 +150,11 @@ function GitHubIssueLinkedPullRequestsContent({
         ) : (
           <div className="flex flex-col gap-0.5">
             {pullRequests.map((pullRequest) => (
-              <LinkedPullRequestRow key={pullRequest.url} pullRequest={pullRequest} />
+              <LinkedPullRequestRow
+                key={pullRequest.url}
+                pullRequest={pullRequest}
+                onNavigate={onNavigate}
+              />
             ))}
           </div>
         )}
@@ -150,6 +173,7 @@ function GitHubIssueLinkedPullRequestsContent({
 export function GitHubIssueLinkedPullRequests(props: {
   repository: GitHubRepositoryContentContext;
   issue: GitHubIssue;
+  onNavigate: (pullRequest: GitHubIssueLinkedPullRequestReference) => void;
 }) {
   const { repository, issue } = props;
   if (!issue.reactionSubject.id.trim()) return null;

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2197,6 +2197,7 @@
       "issueDuplicateLoadFailed": "Harbor could not load the canonical Issue",
       "issueDuplicatePermissionDenied": "Harbor needs Issues read permission to find the canonical Issue",
       "linkedPullRequests": "Linked pull requests",
+      "openLinkedPullRequestOnGitHub": "Open {{repository}} #{{number}} on GitHub",
       "noLinkedPullRequests": "No linked pull requests",
       "noLinkedPullRequestsDescription": "No pull request currently references this Issue.",
       "issueLinkedPullRequestsLoadFailed": "Harbor could not load linked pull requests",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -2190,6 +2190,7 @@
       "issueDuplicateLoadFailed": "Harbor 暂时无法读取这个重复 Issue 对应的原始 Issue",
       "issueDuplicatePermissionDenied": "Harbor 需要 Issues 读取权限，才能找到原始 Issue",
       "linkedPullRequests": "关联的 Pull Request",
+      "openLinkedPullRequestOnGitHub": "在 GitHub 打开 {{repository}} #{{number}}",
       "noLinkedPullRequests": "没有关联的 Pull Request",
       "noLinkedPullRequestsDescription": "目前没有 Pull Request 引用了这个 Issue。",
       "issueLinkedPullRequestsLoadFailed": "Harbor 暂时无法读取关联的 Pull Request",


### PR DESCRIPTION
## Summary
- open Issue-linked pull requests in the existing native Harbor PR detail, including cross-repository references
- keep a separate canonical GitHub link and preserve the return path to the source Issue
- expose the already validated linked repository as structured backend identity instead of parsing display text in the UI

## Verification
- pnpm check (65 files, 319 tests, production build)
- cargo test --manifest-path src-tauri/Cargo.toml (469 passed, 2 ignored)
- cargo check --manifest-path src-tauri/Cargo.toml
- cargo clippy --manifest-path src-tauri/Cargo.toml --lib (15 pre-existing warnings, none new)
- cargo fmt --manifest-path src-tauri/Cargo.toml -- --check
- git diff --check
- Dependabot open alerts: 0 before Draft