### PR TITLE
feat: support minimizing GitHub Discussion comments

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -16,15 +16,16 @@ use crate::{
         GitHubDeveloperFeedPage, GitHubDiscoverySearchKind, GitHubDiscoverySearchPage,
         GitHubDiscoverySearchSort, GitHubDiscussionAnsweredFilter, GitHubDiscussionCategoryPage,
         GitHubDiscussionCloseReason, GitHubDiscussionComment, GitHubDiscussionCommentDeletion,
-        GitHubDiscussionDeletion, GitHubDiscussionDetailPage, GitHubDiscussionFilters,
-        GitHubDiscussionPage, GitHubDiscussionPoll, GitHubDiscussionSort, GitHubDiscussionState,
-        GitHubDiscussionStateFilter, GitHubDiscussionSummary, GitHubDiscussionVote,
-        GitHubFileDownload, GitHubFileDownloadResult, GitHubFilePreview, GitHubForkInput,
-        GitHubForkResult, GitHubGist, GitHubGistComment, GitHubGistCommentMutation,
-        GitHubGistCommentPage, GitHubGistCreateInput, GitHubGistFileInput, GitHubGistFileMutation,
-        GitHubGistPage, GitHubGistRevisionDetail, GitHubGistRevisionPage, GitHubGistSource,
-        GitHubGistUpdateInput, GitHubInsightsTrafficPeriod, GitHubIssue, GitHubIssueAssigneePage,
-        GitHubIssueAssignment, GitHubIssueClone, GitHubIssueCloneStatus, GitHubIssueCreateInput,
+        GitHubDiscussionCommentMutation, GitHubDiscussionDeletion, GitHubDiscussionDetailPage,
+        GitHubDiscussionFilters, GitHubDiscussionPage, GitHubDiscussionPoll, GitHubDiscussionSort,
+        GitHubDiscussionState, GitHubDiscussionStateFilter, GitHubDiscussionSummary,
+        GitHubDiscussionVote, GitHubFileDownload, GitHubFileDownloadResult, GitHubFilePreview,
+        GitHubForkInput, GitHubForkResult, GitHubGist, GitHubGistComment,
+        GitHubGistCommentMutation, GitHubGistCommentPage, GitHubGistCreateInput,
+        GitHubGistFileInput, GitHubGistFileMutation, GitHubGistPage, GitHubGistRevisionDetail,
+        GitHubGistRevisionPage, GitHubGistSource, GitHubGistUpdateInput,
+        GitHubInsightsTrafficPeriod, GitHubIssue, GitHubIssueAssigneePage, GitHubIssueAssignment,
+        GitHubIssueClone, GitHubIssueCloneStatus, GitHubIssueCreateInput,
         GitHubIssueCreationPolicy, GitHubIssueDependenciesPage, GitHubIssueDetailPage,
         GitHubIssueDuplicateReference, GitHubIssueFilters, GitHubIssueInboxFilters,
         GitHubIssueInboxPage, GitHubIssueInboxScope, GitHubIssueLabel, GitHubIssueLabelMutation,
@@ -1158,6 +1159,27 @@ pub async fn github_update_repository_discussion_comment(
         .update_discussion_comment(
             &validate_graphql_node_id(comment_id, "discussion comment")?,
             validate_issue_comment(&body)?,
+        )
+        .await
+}
+
+#[tauri::command]
+pub async fn github_mutate_repository_discussion_comment(
+    owner: String,
+    repository: String,
+    discussion_number: u64,
+    mutation: GitHubDiscussionCommentMutation,
+    state: State<'_, AppState>,
+) -> Result<(), AppError> {
+    let repository = RepositoryRef::new(owner, repository)?;
+    let mutation = validate_discussion_comment_mutation(mutation)?;
+    state
+        .github
+        .mutate_discussion_comment(
+            repository.owner(),
+            repository.name(),
+            validate_item_number(discussion_number, "discussion")?,
+            &mutation,
         )
         .await
 }
@@ -5202,6 +5224,48 @@ fn validate_comment_mutation(
     }
 }
 
+fn validate_discussion_comment_mutation(
+    mutation: GitHubDiscussionCommentMutation,
+) -> Result<GitHubDiscussionCommentMutation, AppError> {
+    match mutation {
+        GitHubDiscussionCommentMutation::Minimize {
+            comment_id,
+            expected_updated_at,
+            expected_minimized,
+            classifier,
+        } => {
+            if expected_minimized {
+                return Err(AppError::Validation(
+                    "minimize mutation must start from a visible discussion comment".to_string(),
+                ));
+            }
+            Ok(GitHubDiscussionCommentMutation::Minimize {
+                comment_id: validate_graphql_node_id(comment_id, "discussion comment")?,
+                expected_updated_at: validate_comment_updated_at(expected_updated_at)?,
+                expected_minimized,
+                classifier,
+            })
+        }
+        GitHubDiscussionCommentMutation::Unminimize {
+            comment_id,
+            expected_updated_at,
+            expected_minimized,
+        } => {
+            if !expected_minimized {
+                return Err(AppError::Validation(
+                    "unminimize mutation must start from a minimized discussion comment"
+                        .to_string(),
+                ));
+            }
+            Ok(GitHubDiscussionCommentMutation::Unminimize {
+                comment_id: validate_graphql_node_id(comment_id, "discussion comment")?,
+                expected_updated_at: validate_comment_updated_at(expected_updated_at)?,
+                expected_minimized,
+            })
+        }
+    }
+}
+
 fn validate_comment_updated_at(updated_at: String) -> Result<String, AppError> {
     let updated_at = updated_at.trim().to_string();
     if updated_at.is_empty()
@@ -5833,6 +5897,35 @@ mod tests {
             })
             .is_err()
         );
+    }
+
+    #[test]
+    fn discussion_comment_mutations_validate_node_revision_and_state() {
+        let mutation =
+            validate_discussion_comment_mutation(GitHubDiscussionCommentMutation::Minimize {
+                comment_id: " DC_kwDOexample ".to_string(),
+                expected_updated_at: " 2026-08-30T08:00:00Z ".to_string(),
+                expected_minimized: false,
+                classifier: GitHubCommentMinimizeClassifier::OffTopic,
+            })
+            .expect("discussion comment minimize");
+        assert!(matches!(
+            mutation,
+            GitHubDiscussionCommentMutation::Minimize {
+                comment_id,
+                expected_updated_at,
+                expected_minimized: false,
+                classifier: GitHubCommentMinimizeClassifier::OffTopic,
+            } if comment_id == "DC_kwDOexample" && expected_updated_at == "2026-08-30T08:00:00Z"
+        ));
+        assert!(validate_discussion_comment_mutation(
+            GitHubDiscussionCommentMutation::Unminimize {
+                comment_id: "DC_kwDOexample".to_string(),
+                expected_updated_at: "2026-08-30T08:00:00Z".to_string(),
+                expected_minimized: false,
+            },
+        )
+        .is_err());
     }
 
     #[test]

--- a/src-tauri/src/github.rs
+++ b/src-tauri/src/github.rs
@@ -20,6 +20,7 @@ pub(crate) mod commit_comment;
 pub(crate) mod conversation;
 pub(crate) mod discovery;
 pub(crate) mod discussion;
+pub(crate) mod discussion_comment_minimize;
 pub(crate) mod download;
 pub(crate) mod gist;
 pub(crate) mod insights;
@@ -85,6 +86,7 @@ pub use discussion::{
     GitHubDiscussionPoll, GitHubDiscussionSort, GitHubDiscussionState, GitHubDiscussionStateFilter,
     GitHubDiscussionSummary, GitHubDiscussionVote,
 };
+pub use discussion_comment_minimize::GitHubDiscussionCommentMutation;
 pub use gist::{
     GitHubGist, GitHubGistComment, GitHubGistCommentMutation, GitHubGistCommentPage,
     GitHubGistCreateInput, GitHubGistFileInput, GitHubGistFileMutation, GitHubGistPage,

--- a/src-tauri/src/github/comment.rs
+++ b/src-tauri/src/github/comment.rs
@@ -738,7 +738,7 @@ fn issue_comment_client_with_base(
         .map_err(|error| AppError::GitHub(error.to_string()))
 }
 
-async fn run_minimize_mutation(
+pub(crate) async fn run_minimize_mutation(
     client: &octocrab::Octocrab,
     mutation: &GitHubCommentMutation,
 ) -> Result<(), AppError> {

--- a/src-tauri/src/github/discussion.rs
+++ b/src-tauri/src/github/discussion.rs
@@ -1,7 +1,14 @@
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 
-use super::{authenticated_client, github_error, GitHubService, OctocrabGitHubClient};
+use super::{
+    authenticated_client,
+    discussion_comment_minimize::{
+        mutate_discussion_comment as mutate_discussion_comment_backend,
+        GitHubDiscussionCommentMutation,
+    },
+    github_error, GitHubService, OctocrabGitHubClient,
+};
 use crate::error::AppError;
 
 const DISCUSSION_PAGE_SIZE: i32 = 30;
@@ -56,6 +63,8 @@ fragment HarborDiscussionComment on DiscussionComment {
   viewerCanUnmarkAsAnswer
   viewerCanUpdate
   viewerCanUpvote
+  viewerCanMinimize
+  viewerCanUnminimize
   viewerDidAuthor
   viewerHasUpvoted
 }
@@ -455,6 +464,8 @@ pub struct GitHubDiscussionComment {
     pub viewer_can_unmark_as_answer: bool,
     pub viewer_can_update: bool,
     pub viewer_can_upvote: bool,
+    pub viewer_can_minimize: bool,
+    pub viewer_can_unminimize: bool,
     pub viewer_did_author: bool,
     pub viewer_has_upvoted: bool,
     pub replies: Vec<GitHubDiscussionComment>,
@@ -583,6 +594,15 @@ pub(crate) trait GitHubDiscussionClient: Send + Sync {
         comment_id: &str,
         body: &str,
     ) -> Result<GitHubDiscussionComment, AppError>;
+
+    async fn mutate_discussion_comment(
+        &self,
+        token: &str,
+        owner: &str,
+        repository: &str,
+        discussion_number: u64,
+        mutation: &GitHubDiscussionCommentMutation,
+    ) -> Result<(), AppError>;
 
     async fn update_discussion_state(
         &self,
@@ -739,6 +759,19 @@ impl GitHubService {
         let token = self.load_access_token().await?;
         self.client
             .update_discussion_comment(&token, comment_id, body)
+            .await
+    }
+
+    pub async fn mutate_discussion_comment(
+        &self,
+        owner: &str,
+        repository: &str,
+        discussion_number: u64,
+        mutation: &GitHubDiscussionCommentMutation,
+    ) -> Result<(), AppError> {
+        let token = self.load_access_token().await?;
+        self.client
+            .mutate_discussion_comment(&token, owner, repository, discussion_number, mutation)
             .await
     }
 
@@ -978,6 +1011,18 @@ impl GitHubDiscussionClient for OctocrabGitHubClient {
         let response: DiscussionCommentMutation =
             client.graphql(&payload).await.map_err(github_error)?;
         discussion_comment_from_mutation(response.update_discussion_comment, "updated")
+    }
+
+    async fn mutate_discussion_comment(
+        &self,
+        token: &str,
+        owner: &str,
+        repository: &str,
+        discussion_number: u64,
+        mutation: &GitHubDiscussionCommentMutation,
+    ) -> Result<(), AppError> {
+        mutate_discussion_comment_backend(token, owner, repository, discussion_number, mutation)
+            .await
     }
 
     async fn update_discussion_state(
@@ -1643,6 +1688,8 @@ fn discussion_comment_from_graphql(comment: GraphQlDiscussionComment) -> GitHubD
         viewer_can_unmark_as_answer: comment.viewer_can_unmark_as_answer,
         viewer_can_update: comment.viewer_can_update,
         viewer_can_upvote: comment.viewer_can_upvote,
+        viewer_can_minimize: comment.viewer_can_minimize,
+        viewer_can_unminimize: comment.viewer_can_unminimize,
         viewer_did_author: comment.viewer_did_author,
         viewer_has_upvoted: comment.viewer_has_upvoted,
         replies_have_more: comment
@@ -1794,6 +1841,8 @@ struct GraphQlDiscussionComment {
     viewer_can_unmark_as_answer: bool,
     viewer_can_update: bool,
     viewer_can_upvote: bool,
+    viewer_can_minimize: bool,
+    viewer_can_unminimize: bool,
     viewer_did_author: bool,
     viewer_has_upvoted: bool,
     #[serde(default)]

--- a/src-tauri/src/github/discussion/tests.rs
+++ b/src-tauri/src/github/discussion/tests.rs
@@ -64,6 +64,8 @@ fn comment(id: &str, body: &str) -> GitHubDiscussionComment {
         viewer_can_unmark_as_answer: false,
         viewer_can_update: true,
         viewer_can_upvote: true,
+        viewer_can_minimize: true,
+        viewer_can_unminimize: false,
         viewer_did_author: false,
         viewer_has_upvoted: false,
         replies: Vec::new(),
@@ -221,6 +223,23 @@ impl GitHubDiscussionClient for super::super::tests::FakeGitHubClient {
         Ok(comment(comment_id, body))
     }
 
+    async fn mutate_discussion_comment(
+        &self,
+        token: &str,
+        owner: &str,
+        repository: &str,
+        discussion_number: u64,
+        mutation: &GitHubDiscussionCommentMutation,
+    ) -> Result<(), AppError> {
+        assert_eq!(token, "github-user-access-token");
+        assert_eq!(
+            (owner, repository, discussion_number),
+            ("octocat", "hello-world", 42)
+        );
+        assert_eq!(mutation.comment_id(), "DC_1");
+        Ok(())
+    }
+
     async fn update_discussion_state(
         &self,
         token: &str,
@@ -356,6 +375,8 @@ fn discussion_graphql_json() -> serde_json::Value {
         "viewerCanUnmarkAsAnswer": false,
         "viewerCanUpdate": false,
         "viewerCanUpvote": true,
+        "viewerCanMinimize": true,
+        "viewerCanUnminimize": false,
         "viewerDidAuthor": false,
         "viewerHasUpvoted": false
     });
@@ -377,6 +398,8 @@ fn discussion_graphql_json() -> serde_json::Value {
         "viewerCanUnmarkAsAnswer": false,
         "viewerCanUpdate": false,
         "viewerCanUpvote": true,
+        "viewerCanMinimize": true,
+        "viewerCanUnminimize": false,
         "viewerDidAuthor": false,
         "viewerHasUpvoted": false,
         "replies": {
@@ -668,6 +691,12 @@ fn discussion_comment_delete_guard_checks_type_scope_and_capability_data() {
         "DC_1",
     )
     .is_err());
+}
+
+#[test]
+fn discussion_comments_expose_minimize_capabilities() {
+    assert!(DISCUSSION_COMMENT_FRAGMENT.contains("viewerCanMinimize"));
+    assert!(DISCUSSION_COMMENT_FRAGMENT.contains("viewerCanUnminimize"));
 }
 
 #[test]

--- a/src-tauri/src/github/discussion_comment_minimize.rs
+++ b/src-tauri/src/github/discussion_comment_minimize.rs
@@ -1,0 +1,428 @@
+use serde::Deserialize;
+
+use super::{
+    comment::{run_minimize_mutation, GitHubCommentMutation},
+    github_error, GitHubCommentMinimizeClassifier,
+};
+use crate::error::AppError;
+
+const DISCUSSION_COMMENT_STATE_QUERY: &str = r#"
+query HarborDiscussionCommentState(
+  $owner: String!
+  $repository: String!
+  $number: Int!
+  $commentId: ID!
+) {
+  repository(owner: $owner, name: $repository) {
+    id
+    discussion(number: $number) { id }
+  }
+  node(id: $commentId) {
+    __typename
+    ... on DiscussionComment {
+      id
+      updatedAt
+      isMinimized
+      minimizedReason
+      deletedAt
+      viewerCanMinimize
+      viewerCanUnminimize
+      discussion {
+        number
+        repository { id nameWithOwner }
+      }
+    }
+  }
+}
+"#;
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+#[serde(tag = "action", rename_all = "camelCase")]
+pub enum GitHubDiscussionCommentMutation {
+    Minimize {
+        comment_id: String,
+        expected_updated_at: String,
+        expected_minimized: bool,
+        classifier: GitHubCommentMinimizeClassifier,
+    },
+    Unminimize {
+        comment_id: String,
+        expected_updated_at: String,
+        expected_minimized: bool,
+    },
+}
+
+impl GitHubDiscussionCommentMutation {
+    pub(crate) fn comment_id(&self) -> &str {
+        match self {
+            Self::Minimize { comment_id, .. } | Self::Unminimize { comment_id, .. } => comment_id,
+        }
+    }
+
+    fn as_comment_mutation(&self) -> GitHubCommentMutation {
+        match self {
+            Self::Minimize {
+                comment_id,
+                expected_updated_at,
+                expected_minimized,
+                classifier,
+            } => GitHubCommentMutation::Minimize {
+                comment_id: comment_id.clone(),
+                expected_updated_at: expected_updated_at.clone(),
+                expected_minimized: *expected_minimized,
+                classifier: *classifier,
+            },
+            Self::Unminimize {
+                comment_id,
+                expected_updated_at,
+                expected_minimized,
+            } => GitHubCommentMutation::Unminimize {
+                comment_id: comment_id.clone(),
+                expected_updated_at: expected_updated_at.clone(),
+                expected_minimized: *expected_minimized,
+            },
+        }
+    }
+}
+
+pub(crate) async fn mutate_discussion_comment(
+    token: &str,
+    owner: &str,
+    repository: &str,
+    discussion_number: u64,
+    mutation: &GitHubDiscussionCommentMutation,
+) -> Result<(), AppError> {
+    let client = discussion_comment_client(token)?;
+    let current = fetch_discussion_comment_state(
+        &client,
+        owner,
+        repository,
+        discussion_number,
+        mutation.comment_id(),
+    )
+    .await?;
+    ensure_discussion_comment_mutation_allowed(mutation, &current)?;
+
+    let generic_mutation = mutation.as_comment_mutation();
+    run_minimize_mutation(&client, &generic_mutation).await?;
+
+    let refreshed = fetch_discussion_comment_state(
+        &client,
+        owner,
+        repository,
+        discussion_number,
+        mutation.comment_id(),
+    )
+    .await
+    .map_err(discussion_comment_minimize_postflight_error)?;
+    ensure_discussion_comment_minimized_result(&refreshed, mutation)
+}
+
+fn discussion_comment_client(token: &str) -> Result<octocrab::Octocrab, AppError> {
+    octocrab::Octocrab::builder()
+        .add_retry_config(octocrab::service::middleware::retry::RetryConfig::None)
+        .personal_token(token.to_string())
+        .build()
+        .map_err(|error| AppError::GitHub(error.to_string()))
+}
+
+async fn fetch_discussion_comment_state(
+    client: &octocrab::Octocrab,
+    owner: &str,
+    repository: &str,
+    discussion_number: u64,
+    comment_id: &str,
+) -> Result<ValidatedDiscussionCommentState, AppError> {
+    let payload = serde_json::json!({
+        "query": DISCUSSION_COMMENT_STATE_QUERY,
+        "variables": {
+            "owner": owner,
+            "repository": repository,
+            "number": i32::try_from(discussion_number).map_err(|_| {
+                AppError::Validation("discussion number exceeds GitHub's GraphQL range".into())
+            })?,
+            "commentId": comment_id,
+        }
+    });
+    let response: DiscussionCommentStateQuery =
+        client.graphql(&payload).await.map_err(github_error)?;
+    validate_discussion_comment_state(response, owner, repository, discussion_number, comment_id)
+}
+
+fn validate_discussion_comment_state(
+    response: DiscussionCommentStateQuery,
+    owner: &str,
+    repository: &str,
+    discussion_number: u64,
+    comment_id: &str,
+) -> Result<ValidatedDiscussionCommentState, AppError> {
+    let selected_repository = response
+        .repository
+        .ok_or_else(|| AppError::GitHub("GitHub did not return the selected repository".into()))?;
+    let repository_id = selected_repository.id;
+    if selected_repository.discussion.is_none() {
+        return Err(AppError::GitHub(
+            "GitHub did not return the selected discussion".into(),
+        ));
+    }
+    let node = response.node.ok_or_else(|| {
+        AppError::GitHub("GitHub did not return the requested discussion comment".into())
+    })?;
+    if node.type_name != "DiscussionComment" {
+        return Err(AppError::Validation(
+            "the selected node is not a discussion comment".to_string(),
+        ));
+    }
+    let id = node.id.ok_or_else(|| {
+        AppError::GitHub("GitHub did not return the discussion comment identity".into())
+    })?;
+    if id != comment_id {
+        return Err(AppError::GitHub(
+            "GitHub returned an unexpected discussion comment".into(),
+        ));
+    }
+    let discussion = node
+        .discussion
+        .ok_or_else(|| AppError::GitHub("GitHub did not return the comment's discussion".into()))?;
+    let expected_repository = format!("{owner}/{repository}");
+    if discussion.number != discussion_number
+        || discussion.repository.id != repository_id
+        || !discussion
+            .repository
+            .name_with_owner
+            .eq_ignore_ascii_case(&expected_repository)
+    {
+        return Err(AppError::Validation(
+            "the selected comment does not belong to this discussion".to_string(),
+        ));
+    }
+    if node.deleted_at.is_some() {
+        return Err(AppError::Validation(
+            "deleted discussion comments cannot be minimized".to_string(),
+        ));
+    }
+    Ok(ValidatedDiscussionCommentState {
+        id,
+        updated_at: node.updated_at.ok_or_else(|| {
+            AppError::GitHub("GitHub did not return the discussion comment revision".into())
+        })?,
+        is_minimized: node.is_minimized.ok_or_else(|| {
+            AppError::GitHub("GitHub did not return the discussion comment state".into())
+        })?,
+        minimized_reason: node.minimized_reason,
+        viewer_can_minimize: node.viewer_can_minimize.unwrap_or(false),
+        viewer_can_unminimize: node.viewer_can_unminimize.unwrap_or(false),
+    })
+}
+
+fn ensure_discussion_comment_mutation_allowed(
+    mutation: &GitHubDiscussionCommentMutation,
+    current: &ValidatedDiscussionCommentState,
+) -> Result<(), AppError> {
+    if mutation.comment_id() != current.id {
+        return Err(AppError::GitHub(
+            "GitHub returned an unexpected discussion comment".into(),
+        ));
+    }
+    let (expected_updated_at, expected_minimized, allowed, requested_minimized) = match mutation {
+        GitHubDiscussionCommentMutation::Minimize {
+            expected_updated_at,
+            expected_minimized,
+            ..
+        } => (
+            expected_updated_at,
+            *expected_minimized,
+            current.viewer_can_minimize,
+            true,
+        ),
+        GitHubDiscussionCommentMutation::Unminimize {
+            expected_updated_at,
+            expected_minimized,
+            ..
+        } => (
+            expected_updated_at,
+            *expected_minimized,
+            current.viewer_can_unminimize,
+            false,
+        ),
+    };
+    if !allowed {
+        return Err(AppError::GitHubPermission(
+            "GitHub does not allow the viewer to change this discussion comment".into(),
+        ));
+    }
+    if expected_updated_at != &current.updated_at {
+        return Err(AppError::GitHubCommentConflict(
+            "the discussion comment changed after it was loaded".into(),
+        ));
+    }
+    if expected_minimized != current.is_minimized || requested_minimized == current.is_minimized {
+        return Err(AppError::GitHubCommentConflict(
+            "the discussion comment minimize state changed after it was loaded".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn ensure_discussion_comment_minimized_result(
+    current: &ValidatedDiscussionCommentState,
+    mutation: &GitHubDiscussionCommentMutation,
+) -> Result<(), AppError> {
+    let matches = match mutation {
+        GitHubDiscussionCommentMutation::Minimize { classifier, .. } => {
+            current.is_minimized
+                && current.minimized_reason.as_deref() == Some(classifier.response_reason())
+        }
+        GitHubDiscussionCommentMutation::Unminimize { .. } => {
+            !current.is_minimized && current.minimized_reason.is_none()
+        }
+    };
+    if matches {
+        Ok(())
+    } else {
+        Err(AppError::GitHubCommentConflict(
+            "the discussion comment minimize state did not match the requested mutation".into(),
+        ))
+    }
+}
+
+fn discussion_comment_minimize_postflight_error(error: AppError) -> AppError {
+    AppError::GitHub(format!(
+        "the discussion comment minimize write may have persisted, but Harbor could not refresh it: {error}"
+    ))
+}
+
+#[derive(Deserialize)]
+struct DiscussionCommentStateQuery {
+    repository: Option<GraphQlDiscussionCommentStateRepository>,
+    node: Option<GraphQlDiscussionCommentStateNode>,
+}
+
+#[derive(Deserialize)]
+struct GraphQlDiscussionCommentStateRepository {
+    id: String,
+    discussion: Option<GraphQlNode>,
+}
+
+#[derive(Deserialize)]
+struct GraphQlNode {
+    #[allow(dead_code)]
+    id: String,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GraphQlDiscussionCommentStateNode {
+    #[serde(rename = "__typename")]
+    type_name: String,
+    id: Option<String>,
+    updated_at: Option<String>,
+    is_minimized: Option<bool>,
+    minimized_reason: Option<String>,
+    deleted_at: Option<String>,
+    viewer_can_minimize: Option<bool>,
+    viewer_can_unminimize: Option<bool>,
+    discussion: Option<GraphQlDiscussionCommentStateDiscussion>,
+}
+
+#[derive(Deserialize)]
+struct GraphQlDiscussionCommentStateDiscussion {
+    number: u64,
+    repository: GraphQlDiscussionCommentStateRepositoryDetails,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GraphQlDiscussionCommentStateRepositoryDetails {
+    id: String,
+    name_with_owner: String,
+}
+
+struct ValidatedDiscussionCommentState {
+    id: String,
+    updated_at: String,
+    is_minimized: bool,
+    minimized_reason: Option<String>,
+    viewer_can_minimize: bool,
+    viewer_can_unminimize: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn current() -> ValidatedDiscussionCommentState {
+        ValidatedDiscussionCommentState {
+            id: "DC_1".to_string(),
+            updated_at: "2026-08-28T10:00:00Z".to_string(),
+            is_minimized: false,
+            minimized_reason: None,
+            viewer_can_minimize: true,
+            viewer_can_unminimize: false,
+        }
+    }
+
+    #[test]
+    fn discussion_comment_minimize_guards_require_capability_and_fresh_state() {
+        let current = current();
+        let minimize = GitHubDiscussionCommentMutation::Minimize {
+            comment_id: "DC_1".to_string(),
+            expected_updated_at: current.updated_at.clone(),
+            expected_minimized: false,
+            classifier: GitHubCommentMinimizeClassifier::OffTopic,
+        };
+
+        assert!(ensure_discussion_comment_mutation_allowed(&minimize, &current).is_ok());
+        assert!(ensure_discussion_comment_mutation_allowed(
+            &GitHubDiscussionCommentMutation::Unminimize {
+                comment_id: "DC_1".to_string(),
+                expected_updated_at: current.updated_at.clone(),
+                expected_minimized: false,
+            },
+            &current,
+        )
+        .is_err());
+
+        let stale = GitHubDiscussionCommentMutation::Minimize {
+            comment_id: "DC_1".to_string(),
+            expected_updated_at: "2026-08-28T09:00:00Z".to_string(),
+            expected_minimized: false,
+            classifier: GitHubCommentMinimizeClassifier::OffTopic,
+        };
+        assert!(ensure_discussion_comment_mutation_allowed(&stale, &current).is_err());
+    }
+
+    #[test]
+    fn discussion_comment_state_query_requires_minimize_capabilities() {
+        assert!(DISCUSSION_COMMENT_STATE_QUERY.contains("viewerCanMinimize"));
+        assert!(DISCUSSION_COMMENT_STATE_QUERY.contains("viewerCanUnminimize"));
+        assert!(DISCUSSION_COMMENT_STATE_QUERY.contains("$number: Int!"));
+    }
+
+    #[test]
+    fn discussion_comment_state_validates_repository_and_discussion_scope() {
+        let response: DiscussionCommentStateQuery = serde_json::from_value(serde_json::json!({
+            "repository": { "id": "R_1", "discussion": { "id": "D_1" } },
+            "node": {
+                "__typename": "DiscussionComment",
+                "id": "DC_1",
+                "updatedAt": "2026-08-28T10:00:00Z",
+                "isMinimized": false,
+                "minimizedReason": null,
+                "deletedAt": null,
+                "viewerCanMinimize": true,
+                "viewerCanUnminimize": false,
+                "discussion": {
+                    "number": 42,
+                    "repository": { "id": "R_1", "nameWithOwner": "octocat/hello-world" }
+                }
+            }
+        }))
+        .expect("discussion comment state");
+        let state =
+            validate_discussion_comment_state(response, "octocat", "hello-world", 42, "DC_1")
+                .expect("validated discussion comment state");
+        assert!(state.viewer_can_minimize);
+        assert!(!state.is_minimized);
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -106,6 +106,7 @@ pub fn run() {
             commands::github_update_repository_discussion,
             commands::github_create_repository_discussion_comment,
             commands::github_update_repository_discussion_comment,
+            commands::github_mutate_repository_discussion_comment,
             commands::github_update_repository_discussion_state,
             commands::github_update_repository_discussion_upvote,
             commands::github_update_repository_discussion_answer,

--- a/src/features/github/github-data.ts
+++ b/src/features/github/github-data.ts
@@ -1185,6 +1185,8 @@ export type GitHubDiscussionComment = {
   viewerCanUnmarkAsAnswer: boolean;
   viewerCanUpdate: boolean;
   viewerCanUpvote: boolean;
+  viewerCanMinimize: boolean;
+  viewerCanUnminimize: boolean;
   viewerDidAuthor: boolean;
   viewerHasUpvoted: boolean;
   replies: GitHubDiscussionComment[];

--- a/src/features/github/github-discussion-comment-minimize.interaction.test.tsx
+++ b/src/features/github/github-discussion-comment-minimize.interaction.test.tsx
@@ -1,0 +1,130 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { invoke } from "@tauri-apps/api/core";
+import { GitHubDiscussionCommentMinimizeAction } from "./github-discussion-comment-minimize";
+
+vi.mock("@tauri-apps/api/core", () => ({ invoke: vi.fn() }));
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+beforeAll(() => {
+  class ResizeObserverMock implements ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  vi.stubGlobal("ResizeObserver", ResizeObserverMock);
+  Object.assign(HTMLElement.prototype, {
+    hasPointerCapture: () => false,
+    setPointerCapture: () => {},
+    releasePointerCapture: () => {},
+    scrollIntoView: () => {},
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+const target = {
+  owner: "octocat",
+  repository: "hello-world",
+  discussionNumber: 42,
+};
+
+function renderAction(overrides: Record<string, unknown> = {}) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <GitHubDiscussionCommentMinimizeAction
+        target={target}
+        comment={{
+          id: "DC_1",
+          body: "Please keep this focused.",
+          url: "https://github.com/octocat/hello-world/discussions/42#discussioncomment-1",
+          authorAssociation: "COLLABORATOR",
+          createdAt: "2026-08-30T08:00:00Z",
+          updatedAt: "2026-08-30T08:00:00Z",
+          isAnswer: false,
+          isMinimized: false,
+          upvoteCount: 0,
+          viewerCanDelete: false,
+          viewerCanMarkAsAnswer: false,
+          viewerCanUnmarkAsAnswer: false,
+          viewerCanUpdate: false,
+          viewerCanUpvote: false,
+          viewerCanMinimize: true,
+          viewerCanUnminimize: false,
+          viewerDidAuthor: false,
+          viewerHasUpvoted: false,
+          replies: [],
+          repliesHaveMore: false,
+          ...overrides,
+        }}
+      />
+    </QueryClientProvider>
+  );
+}
+
+describe("GitHub Discussion comment minimization", () => {
+  it("requires a reason and sends the guarded mutation", async () => {
+    const user = userEvent.setup();
+    vi.mocked(invoke).mockResolvedValue(null);
+    renderAction();
+
+    await user.click(
+      screen.getByRole("button", { name: "workspace.repositories.minimizeComment" })
+    );
+    await user.click(screen.getByRole("combobox"));
+    await user.click(
+      screen.getByRole("option", { name: "workspace.repositories.minimizeReasons.spam" })
+    );
+    await user.click(
+      screen.getByRole("button", { name: "workspace.repositories.confirmMinimizeComment" })
+    );
+
+    expect(invoke).toHaveBeenCalledWith("github_mutate_repository_discussion_comment", {
+      ...target,
+      mutation: {
+        action: "minimize",
+        commentId: "DC_1",
+        expectedUpdatedAt: "2026-08-30T08:00:00Z",
+        expectedMinimized: false,
+        classifier: "spam",
+      },
+    });
+  });
+
+  it("only offers unminimize when GitHub grants that capability", async () => {
+    const user = userEvent.setup();
+    vi.mocked(invoke).mockResolvedValue(null);
+    renderAction({
+      isMinimized: true,
+      viewerCanMinimize: false,
+      viewerCanUnminimize: true,
+      minimizedReason: "off-topic",
+    });
+
+    await user.click(
+      screen.getByRole("button", { name: "workspace.repositories.unminimizeComment" })
+    );
+
+    expect(invoke).toHaveBeenCalledWith("github_mutate_repository_discussion_comment", {
+      ...target,
+      mutation: {
+        action: "unminimize",
+        commentId: "DC_1",
+        expectedUpdatedAt: "2026-08-30T08:00:00Z",
+        expectedMinimized: true,
+      },
+    });
+  });
+});

--- a/src/features/github/github-discussion-comment-minimize.tsx
+++ b/src/features/github/github-discussion-comment-minimize.tsx
@@ -1,0 +1,209 @@
+import { useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { Eye, EyeOff } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import { Field, FieldLabel } from "@/components/ui/field";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Spinner } from "@/components/ui/spinner";
+import { parseIpcError } from "@/lib/ipc-error";
+import type { GitHubCommentMinimizeClassifier, GitHubDiscussionComment } from "./github-data";
+import {
+  invalidateRepositoryDiscussion,
+  mutateRepositoryDiscussionComment,
+  type GitHubDiscussionCommentMutation,
+  type GitHubDiscussionMutationTarget,
+} from "./github-discussion-mutations";
+
+const MINIMIZE_CLASSIFIERS: GitHubCommentMinimizeClassifier[] = [
+  "spam",
+  "abuse",
+  "offTopic",
+  "outdated",
+  "duplicate",
+  "resolved",
+  "lowQuality",
+];
+
+export function GitHubDiscussionCommentMinimizeAction({
+  comment,
+  target,
+}: {
+  comment: GitHubDiscussionComment;
+  target: GitHubDiscussionMutationTarget;
+}) {
+  const { t } = useTranslation();
+  const queryClient = useQueryClient();
+  const [minimizeOpen, setMinimizeOpen] = useState(false);
+  const [classifier, setClassifier] = useState<GitHubCommentMinimizeClassifier>("offTopic");
+  const mutation = useMutation({
+    mutationFn: (value: GitHubDiscussionCommentMutation) =>
+      mutateRepositoryDiscussionComment(target, value),
+    onSuccess: (_, value) => {
+      toast.success(
+        t(
+          value.action === "minimize"
+            ? "workspace.repositories.commentMinimizedSuccess"
+            : "workspace.repositories.commentUnminimizedSuccess"
+        )
+      );
+      setMinimizeOpen(false);
+      mutation.reset();
+      void invalidateRepositoryDiscussion(queryClient, target);
+    },
+    onError: (error) => {
+      const code = parseIpcError(error).code;
+      if (code === "github" || code === "unknown" || code === "githubCommentConflict") {
+        void invalidateRepositoryDiscussion(queryClient, target);
+      }
+    },
+  });
+
+  const canMinimize = comment.isMinimized
+    ? comment.viewerCanUnminimize === true
+    : comment.viewerCanMinimize === true;
+  if (!canMinimize) return null;
+
+  const error = mutation.error ? parseIpcError(mutation.error) : null;
+  const errorMessage = error
+    ? error.code === "githubPermission"
+      ? t("workspace.repositories.discussionWritePermissionDenied")
+      : error.code === "githubCommentConflict"
+        ? t("workspace.repositories.commentChanged")
+        : error.message
+    : null;
+  const minimizeMutation: GitHubDiscussionCommentMutation = {
+    action: "minimize",
+    commentId: comment.id,
+    expectedUpdatedAt: comment.updatedAt,
+    expectedMinimized: false,
+    classifier,
+  };
+  const unminimizeMutation: GitHubDiscussionCommentMutation = {
+    action: "unminimize",
+    commentId: comment.id,
+    expectedUpdatedAt: comment.updatedAt,
+    expectedMinimized: true,
+  };
+
+  return (
+    <>
+      <Button
+        type="button"
+        variant="ghost"
+        size="xs"
+        aria-label={t(
+          comment.isMinimized
+            ? "workspace.repositories.unminimizeComment"
+            : "workspace.repositories.minimizeComment"
+        )}
+        aria-busy={mutation.isPending}
+        disabled={mutation.isPending}
+        onClick={() => {
+          mutation.reset();
+          if (comment.isMinimized) mutation.mutate(unminimizeMutation);
+          else setMinimizeOpen(true);
+        }}
+      >
+        {mutation.isPending ? (
+          <Spinner data-icon="inline-start" />
+        ) : comment.isMinimized ? (
+          <Eye data-icon="inline-start" />
+        ) : (
+          <EyeOff data-icon="inline-start" />
+        )}
+        {t(
+          comment.isMinimized
+            ? "workspace.repositories.unminimizeComment"
+            : "workspace.repositories.minimizeComment"
+        )}
+      </Button>
+
+      {error && !minimizeOpen ? (
+        <Alert variant="destructive" role="alert" className="max-w-sm">
+          <AlertDescription>{errorMessage}</AlertDescription>
+        </Alert>
+      ) : null}
+
+      <AlertDialog
+        open={minimizeOpen}
+        onOpenChange={(open) => {
+          if (mutation.isPending) return;
+          setMinimizeOpen(open);
+          if (!open) mutation.reset();
+        }}
+      >
+        <AlertDialogContent aria-busy={mutation.isPending}>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t("workspace.repositories.minimizeCommentTitle")}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {t("workspace.repositories.minimizeCommentDescription")}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <Field data-disabled={mutation.isPending}>
+            <FieldLabel htmlFor={`github-discussion-comment-${comment.id}-classifier`}>
+              {t("workspace.repositories.minimizeCommentReason")}
+            </FieldLabel>
+            <Select
+              value={classifier}
+              onValueChange={(value) => setClassifier(value as GitHubCommentMinimizeClassifier)}
+              disabled={mutation.isPending}
+            >
+              <SelectTrigger id={`github-discussion-comment-${comment.id}-classifier`}>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectGroup>
+                  {MINIMIZE_CLASSIFIERS.map((value) => (
+                    <SelectItem key={value} value={value}>
+                      {t(`workspace.repositories.minimizeReasons.${value}`)}
+                    </SelectItem>
+                  ))}
+                </SelectGroup>
+              </SelectContent>
+            </Select>
+          </Field>
+          {error ? (
+            <Alert variant="destructive" role="alert">
+              <AlertDescription>{errorMessage}</AlertDescription>
+            </Alert>
+          ) : null}
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={mutation.isPending}>
+              {t("common.cancel")}
+            </AlertDialogCancel>
+            <AlertDialogAction
+              disabled={mutation.isPending}
+              onClick={(event) => {
+                event.preventDefault();
+                mutation.mutate(minimizeMutation);
+              }}
+            >
+              {mutation.isPending ? <Spinner data-icon="inline-start" /> : null}
+              {t("workspace.repositories.confirmMinimizeComment")}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/src/features/github/github-discussion-comment-minimize.tsx
+++ b/src/features/github/github-discussion-comment-minimize.tsx
@@ -89,7 +89,9 @@ export function GitHubDiscussionCommentMinimizeAction({
       ? t("workspace.repositories.discussionWritePermissionDenied")
       : error.code === "githubCommentConflict"
         ? t("workspace.repositories.commentChanged")
-        : error.message
+        : error.code === "github" || error.code === "unknown"
+          ? t("workspace.repositories.commentWriteUncertain")
+          : error.message
     : null;
   const minimizeMutation: GitHubDiscussionCommentMutation = {
     action: "minimize",

--- a/src/features/github/github-discussion-comment.tsx
+++ b/src/features/github/github-discussion-comment.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useState } from "react";
+import { lazy, Suspense, useEffect, useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   CheckCircle2,
@@ -51,6 +51,7 @@ import {
 import { formatIssueDate } from "./github-issue-shared";
 import { GitHubMarkdownEditor } from "./github-markdown-editor";
 import { GitHubReactionBar } from "./github-reaction-bar";
+import { GitHubDiscussionCommentMinimizeAction } from "./github-discussion-comment-minimize";
 
 const GitHubReadme = lazy(() => import("./github-readme"));
 
@@ -271,6 +272,7 @@ export function GitHubDiscussionCommentCard({
   const [replying, setReplying] = useState(false);
   const [editing, setEditing] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
+  const [commentOpen, setCommentOpen] = useState(!comment.isMinimized);
   const deleted = Boolean(comment.deletedAt);
   const voteMutation = useMutation({
     mutationFn: () => updateRepositoryDiscussionUpvote(comment.id, !comment.viewerHasUpvoted),
@@ -306,6 +308,10 @@ export function GitHubDiscussionCommentCard({
         reason: comment.minimizedReason,
       })
     : t("workspace.repositories.discussionCommentMinimized");
+
+  useEffect(() => {
+    setCommentOpen(!comment.isMinimized);
+  }, [comment.isMinimized]);
 
   return (
     <article
@@ -358,7 +364,7 @@ export function GitHubDiscussionCommentCard({
         ) : null}
       </header>
 
-      <Collapsible defaultOpen={!comment.isMinimized}>
+      <Collapsible open={commentOpen} onOpenChange={setCommentOpen}>
         {comment.isMinimized ? (
           <CollapsibleTrigger asChild>
             <Button type="button" variant="ghost" size="sm" className="m-2">
@@ -449,6 +455,9 @@ export function GitHubDiscussionCommentCard({
                 : "workspace.repositories.markDiscussionAnswer"
             )}
           </Button>
+        ) : null}
+        {!deleted ? (
+          <GitHubDiscussionCommentMinimizeAction comment={comment} target={target} />
         ) : null}
         {!deleted && comment.viewerCanDelete ? (
           <Button type="button" variant="ghost" size="xs" onClick={() => setDeleteOpen(true)}>

--- a/src/features/github/github-discussion-mutations.test.ts
+++ b/src/features/github/github-discussion-mutations.test.ts
@@ -88,6 +88,8 @@ const comment: GitHubDiscussionComment = {
   viewerCanUnmarkAsAnswer: false,
   viewerCanUpdate: true,
   viewerCanUpvote: true,
+  viewerCanMinimize: true,
+  viewerCanUnminimize: false,
   viewerDidAuthor: false,
   viewerHasUpvoted: false,
   replies: [],

--- a/src/features/github/github-discussion-mutations.ts
+++ b/src/features/github/github-discussion-mutations.ts
@@ -10,6 +10,7 @@ import type {
   GitHubDiscussionPoll,
   GitHubDiscussionState,
   GitHubDiscussionSummary,
+  GitHubCommentMinimizeClassifier,
   GitHubDiscussionVote,
 } from "./github-data";
 import { githubQueryKeys } from "./github-queries";
@@ -28,6 +29,21 @@ export type GitHubDiscussionContent = {
   title: string;
   body: string;
 };
+
+export type GitHubDiscussionCommentMutation =
+  | {
+      action: "minimize";
+      commentId: string;
+      expectedUpdatedAt: string;
+      expectedMinimized: false;
+      classifier: GitHubCommentMinimizeClassifier;
+    }
+  | {
+      action: "unminimize";
+      commentId: string;
+      expectedUpdatedAt: string;
+      expectedMinimized: true;
+    };
 
 export function createRepositoryDiscussion(
   target: GitHubDiscussionRepositoryTarget,
@@ -66,6 +82,16 @@ export function updateRepositoryDiscussionComment(commentId: string, body: strin
   return invoke<GitHubDiscussionComment>("github_update_repository_discussion_comment", {
     commentId,
     body,
+  });
+}
+
+export function mutateRepositoryDiscussionComment(
+  target: GitHubDiscussionMutationTarget,
+  mutation: GitHubDiscussionCommentMutation
+) {
+  return invoke<void>("github_mutate_repository_discussion_comment", {
+    ...target,
+    mutation,
   });
 }
 


### PR DESCRIPTION
## Summary
- add native minimize/unminimize controls for GitHub Discussion comments and nested replies
- guard writes with repository/discussion scope, current revision, current minimize state, and GitHub capability fields
- use the shared GraphQL minimize transport with a no-retry client and authoritative postflight refresh

## Verification
- `pnpm format:check`
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `cargo test --manifest-path src-tauri/Cargo.toml --no-default-features`
