### PR TITLE
feat: support minimizing commit comments

### DIFF
--- a/src-tauri/src/github/comment.rs
+++ b/src-tauri/src/github/comment.rs
@@ -788,13 +788,13 @@ pub(crate) async fn run_minimize_mutation(
     ensure_mutation_identity(response.client_mutation_id.as_deref(), &client_mutation_id)
 }
 
-fn minimize_postflight_error(error: AppError) -> AppError {
+pub(crate) fn minimize_postflight_error(error: AppError) -> AppError {
     AppError::GitHub(format!(
         "the comment minimize write may have persisted, but Harbor could not refresh it: {error}"
     ))
 }
 
-fn ensure_minimized_result(
+pub(crate) fn ensure_minimized_result(
     is_minimized: bool,
     minimized_reason: Option<&str>,
     mutation: &GitHubCommentMutation,

--- a/src-tauri/src/github/comment/minimize.rs
+++ b/src-tauri/src/github/comment/minimize.rs
@@ -1,6 +1,6 @@
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub enum GitHubCommentMinimizeClassifier {
     Spam,

--- a/src-tauri/src/github/commit_comment.rs
+++ b/src-tauri/src/github/commit_comment.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 
+use super::comment::GitHubCommentMinimizeClassifier;
 use super::{authenticated_client, GitHubService, OctocrabGitHubClient};
 use crate::error::AppError;
 
@@ -30,6 +31,10 @@ pub struct GitHubCommitComment {
     pub updated_at: String,
     pub viewer_can_update: bool,
     pub viewer_can_delete: bool,
+    pub is_minimized: bool,
+    pub minimized_reason: Option<String>,
+    pub viewer_can_minimize: bool,
+    pub viewer_can_unminimize: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
@@ -75,6 +80,17 @@ pub enum GitHubCommitCommentMutation {
     Delete {
         #[serde(flatten)]
         guard: GitHubCommitCommentGuard,
+    },
+    Minimize {
+        #[serde(flatten)]
+        guard: GitHubCommitCommentGuard,
+        expected_minimized: bool,
+        classifier: GitHubCommentMinimizeClassifier,
+    },
+    Unminimize {
+        #[serde(flatten)]
+        guard: GitHubCommitCommentGuard,
+        expected_minimized: bool,
     },
 }
 
@@ -155,11 +171,25 @@ impl GitHubCommitCommentClient for OctocrabGitHubClient {
         mutation: &GitHubCommitCommentMutation,
     ) -> Result<Option<GitHubCommitComment>, AppError> {
         let client = authenticated_client(token)?;
-        transport::mutate_commit_comment_with_client(
-            &client, owner, repository, commit_sha, mutation,
+        let write_client = no_retry_authenticated_client(token)?;
+        transport::mutate_commit_comment_with_clients(
+            &client,
+            &write_client,
+            owner,
+            repository,
+            commit_sha,
+            mutation,
         )
         .await
     }
+}
+
+fn no_retry_authenticated_client(token: &str) -> Result<octocrab::Octocrab, AppError> {
+    octocrab::Octocrab::builder()
+        .add_retry_config(octocrab::service::middleware::retry::RetryConfig::None)
+        .personal_token(token.to_string())
+        .build()
+        .map_err(|error| AppError::GitHub(error.to_string()))
 }
 
 fn normalize_commit_comment_sha(value: &str) -> Result<String, AppError> {
@@ -199,6 +229,22 @@ fn normalize_commit_comment_mutation(
         }
         GitHubCommitCommentMutation::Delete { guard } => Ok(GitHubCommitCommentMutation::Delete {
             guard: normalize_comment_guard(guard)?,
+        }),
+        GitHubCommitCommentMutation::Minimize {
+            guard,
+            expected_minimized,
+            classifier,
+        } => Ok(GitHubCommitCommentMutation::Minimize {
+            guard: normalize_comment_guard(guard)?,
+            expected_minimized,
+            classifier,
+        }),
+        GitHubCommitCommentMutation::Unminimize {
+            guard,
+            expected_minimized,
+        } => Ok(GitHubCommitCommentMutation::Unminimize {
+            guard: normalize_comment_guard(guard)?,
+            expected_minimized,
         }),
     }
 }
@@ -327,6 +373,10 @@ impl GitHubCommitCommentClient for super::tests::FakeGitHubClient {
             updated_at: "2026-08-30T01:00:00Z".to_string(),
             viewer_can_update: true,
             viewer_can_delete: true,
+            is_minimized: false,
+            minimized_reason: None,
+            viewer_can_minimize: true,
+            viewer_can_unminimize: false,
         }))
     }
 }

--- a/src-tauri/src/github/commit_comment/tests.rs
+++ b/src-tauri/src/github/commit_comment/tests.rs
@@ -1,8 +1,12 @@
-use std::sync::{Arc, Mutex};
+use std::{
+    sync::{Arc, Mutex},
+    time::Duration,
+};
 
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
     net::TcpListener,
+    time::timeout,
 };
 
 use crate::github_oauth::GitHubOAuthCredentials;
@@ -11,12 +15,14 @@ use super::super::{CredentialStore, GitHubService};
 use super::transport::{
     commit_comment_page_from_raw, commit_comment_route, commit_comments_route,
     create_commit_comment_with_client, list_commit_comments_with_client,
-    mutate_commit_comment_with_client, CommitCommentCapabilitiesQuery, RawCommitComment,
+    mutate_commit_comment_with_client, mutate_commit_comment_with_clients,
+    CommitCommentCapabilitiesQuery, RawCommitComment,
 };
 use super::{
     normalize_commit_comment_mutation, normalize_commit_comment_page, normalize_commit_comment_sha,
     GitHubCommitCommentGuard, GitHubCommitCommentMutation, GitHubCommitCommentPlacement,
 };
+use crate::github::GitHubCommentMinimizeClassifier;
 
 struct SavedCredentialStore;
 
@@ -110,6 +116,39 @@ fn capability_api_json(sha: &str, updated_at: &str, can_update: bool, can_delete
                 "updatedAt": updated_at,
                 "viewerCanUpdate": can_update,
                 "viewerCanDelete": can_delete,
+                "isMinimized": false,
+                "minimizedReason": null,
+                "viewerCanMinimize": false,
+                "viewerCanUnminimize": false,
+                "repository": { "id": "R_1" },
+                "commit": { "oid": sha }
+            }]
+        }
+    })
+    .to_string()
+}
+
+fn capability_api_json_with_minimize(
+    sha: &str,
+    updated_at: &str,
+    is_minimized: bool,
+    minimized_reason: Option<&str>,
+    can_minimize: bool,
+    can_unminimize: bool,
+) -> String {
+    serde_json::json!({
+        "data": {
+            "repository": { "id": "R_1" },
+            "nodes": [{
+                "__typename": "CommitComment",
+                "id": "CC_42",
+                "updatedAt": updated_at,
+                "viewerCanUpdate": true,
+                "viewerCanDelete": true,
+                "isMinimized": is_minimized,
+                "minimizedReason": minimized_reason,
+                "viewerCanMinimize": can_minimize,
+                "viewerCanUnminimize": can_unminimize,
                 "repository": { "id": "R_1" },
                 "commit": { "oid": sha }
             }]
@@ -127,6 +166,10 @@ fn capability_fixture(sha: &str) -> CommitCommentCapabilitiesQuery {
             "updatedAt": "2026-08-30T01:01:00Z",
             "viewerCanUpdate": true,
             "viewerCanDelete": false,
+            "isMinimized": false,
+            "minimizedReason": null,
+            "viewerCanMinimize": true,
+            "viewerCanUnminimize": false,
             "repository": { "id": "R_1" },
             "commit": { "oid": sha }
         }]
@@ -162,6 +205,58 @@ async fn mock_github(
     Arc<Mutex<Vec<String>>>,
     tokio::task::JoinHandle<()>,
 ) {
+    mock_github_with_retry_config(
+        responses,
+        octocrab::service::middleware::retry::RetryConfig::Simple(3),
+    )
+    .await
+}
+
+async fn mock_github_with_retry_config(
+    responses: Vec<MockResponse>,
+    retry_config: octocrab::service::middleware::retry::RetryConfig,
+) -> (
+    octocrab::Octocrab,
+    Arc<Mutex<Vec<String>>>,
+    tokio::task::JoinHandle<()>,
+) {
+    let (client, requests, server, _) =
+        mock_github_with_retry_config_and_address(responses, retry_config).await;
+    (client, requests, server)
+}
+
+async fn mock_github_pair(
+    responses: Vec<MockResponse>,
+) -> (
+    octocrab::Octocrab,
+    octocrab::Octocrab,
+    Arc<Mutex<Vec<String>>>,
+    tokio::task::JoinHandle<()>,
+) {
+    let (read_client, requests, server, base_uri) = mock_github_with_retry_config_and_address(
+        responses,
+        octocrab::service::middleware::retry::RetryConfig::Simple(3),
+    )
+    .await;
+    let write_client = octocrab::Octocrab::builder()
+        .base_uri(base_uri)
+        .expect("no-retry mock base uri")
+        .add_retry_config(octocrab::service::middleware::retry::RetryConfig::None)
+        .personal_token("github-user-access-token".to_string())
+        .build()
+        .expect("no-retry mock client");
+    (read_client, write_client, requests, server)
+}
+
+async fn mock_github_with_retry_config_and_address(
+    responses: Vec<MockResponse>,
+    retry_config: octocrab::service::middleware::retry::RetryConfig,
+) -> (
+    octocrab::Octocrab,
+    Arc<Mutex<Vec<String>>>,
+    tokio::task::JoinHandle<()>,
+    String,
+) {
     let listener = TcpListener::bind("127.0.0.1:0").await.expect("mock bind");
     let address = listener.local_addr().expect("mock address");
     let requests = Arc::new(Mutex::new(Vec::new()));
@@ -193,10 +288,30 @@ async fn mock_github(
                     }
                 }
             }
-            captured
-                .lock()
-                .expect("request lock")
-                .push(String::from_utf8(buffer).expect("request utf8"));
+            let request = String::from_utf8(buffer).expect("request utf8");
+            captured.lock().expect("request lock").push(request.clone());
+            let response_body = if response.body == "__ECHO_MINIMIZE_MUTATION__" {
+                let request_body = request.split("\r\n\r\n").nth(1).expect("request body");
+                let request_json = serde_json::from_str::<serde_json::Value>(request_body)
+                    .expect("GraphQL request JSON");
+                let client_mutation_id = request_json["variables"]["clientMutationId"]
+                    .as_str()
+                    .expect("client mutation ID");
+                let mutation_name = request_json["query"]
+                    .as_str()
+                    .expect("GraphQL query")
+                    .contains("unminimizeComment")
+                    .then_some("unminimizeComment")
+                    .unwrap_or("minimizeComment");
+                let mut data = serde_json::Map::new();
+                data.insert(
+                    mutation_name.to_string(),
+                    serde_json::json!({ "clientMutationId": client_mutation_id }),
+                );
+                serde_json::json!({ "data": data }).to_string()
+            } else {
+                response.body
+            };
             let extra_headers = response
                 .headers
                 .into_iter()
@@ -206,8 +321,8 @@ async fn mock_github(
                 "HTTP/1.1 {}\r\nContent-Type: application/json\r\n{}Content-Length: {}\r\nConnection: close\r\n\r\n{}",
                 response.status,
                 extra_headers,
-                response.body.len(),
-                response.body
+                response_body.len(),
+                response_body
             );
             stream
                 .write_all(payload.as_bytes())
@@ -218,10 +333,11 @@ async fn mock_github(
     let client = octocrab::Octocrab::builder()
         .base_uri(format!("http://{address}"))
         .expect("mock base uri")
+        .add_retry_config(retry_config)
         .personal_token("github-user-access-token".to_string())
         .build()
         .expect("mock client");
-    (client, requests, server)
+    (client, requests, server, format!("http://{address}"))
 }
 
 #[test]
@@ -248,6 +364,9 @@ fn comment_pages_keep_placement_deleted_authors_and_capabilities() {
     assert!(comment.author.is_none());
     assert!(comment.viewer_can_update);
     assert!(!comment.viewer_can_delete);
+    assert!(!comment.is_minimized);
+    assert!(comment.viewer_can_minimize);
+    assert!(!comment.viewer_can_unminimize);
 }
 
 #[test]
@@ -594,6 +713,87 @@ fn mutation_guard_keeps_the_flat_tauri_contract() {
     );
 }
 
+#[test]
+fn minimize_mutation_keeps_the_flat_tauri_contract() {
+    let value = serde_json::json!({
+        "action": "minimize",
+        "commentId": 42,
+        "commentNodeId": "CC_42",
+        "expectedUpdatedAt": "2026-08-30T01:01:00Z",
+        "expectedMinimized": false,
+        "classifier": "offTopic"
+    });
+    let mutation: GitHubCommitCommentMutation =
+        serde_json::from_value(value.clone()).expect("flat minimize mutation");
+    assert!(matches!(
+        &mutation,
+        GitHubCommitCommentMutation::Minimize {
+            guard,
+            expected_minimized: false,
+            classifier: GitHubCommentMinimizeClassifier::OffTopic,
+        } if guard == &comment_guard(42)
+    ));
+    assert_eq!(
+        serde_json::to_value(mutation).expect("flat mutation JSON"),
+        value
+    );
+}
+
+#[test]
+fn minimize_mutation_requires_the_expected_current_state_and_capability() {
+    let sha = "a".repeat(40);
+    let mutation = GitHubCommitCommentMutation::Minimize {
+        guard: comment_guard(42),
+        expected_minimized: false,
+        classifier: GitHubCommentMinimizeClassifier::OffTopic,
+    };
+    let mut capabilities = capability_fixture(&sha);
+    capabilities.nodes[0]
+        .as_mut()
+        .expect("comment capability")
+        .viewer_can_minimize = false;
+    let comment =
+        commit_comment_page_from_raw(vec![comment_fixture(&sha)], capabilities, &sha, 1, false)
+            .expect("comment page")
+            .comments
+            .into_iter()
+            .next()
+            .expect("comment");
+    assert!(matches!(
+        super::transport::ensure_comment_mutation_allowed_for_test(&comment, &mutation),
+        Err(crate::error::AppError::GitHubPermission(_))
+    ));
+
+    capabilities = serde_json::from_value(serde_json::json!({
+        "repository": { "id": "R_1" },
+        "nodes": [{
+            "__typename": "CommitComment",
+            "id": "CC_42",
+            "updatedAt": "2026-08-30T01:01:00Z",
+            "viewerCanUpdate": true,
+            "viewerCanDelete": true,
+            "isMinimized": true,
+            "minimizedReason": "off-topic",
+            "viewerCanMinimize": true,
+            "viewerCanUnminimize": true,
+            "repository": { "id": "R_1" },
+            "commit": { "oid": sha }
+        }]
+    }))
+    .expect("minimized capability fixture");
+    let comment =
+        commit_comment_page_from_raw(vec![comment_fixture(&sha)], capabilities, &sha, 1, false)
+            .expect("comment page")
+            .comments
+            .into_iter()
+            .next()
+            .expect("comment");
+    assert!(matches!(
+        super::transport::ensure_comment_mutation_allowed_for_test(&comment, &mutation),
+        Err(crate::error::AppError::GitHubCommentConflict(_))
+    ));
+}
+
 #[tokio::test]
 async fn update_transport_preflights_scope_capability_and_revision() {
     let sha = "a".repeat(40);
@@ -646,6 +846,148 @@ async fn update_transport_preflights_scope_capability_and_revision() {
         serde_json::from_str::<serde_json::Value>(body).expect("request JSON"),
         serde_json::json!({ "body": "New body" })
     );
+}
+
+#[tokio::test]
+async fn minimize_transport_writes_once_and_confirms_the_postflight_state() {
+    let sha = "a".repeat(40);
+    let (read_client, write_client, requests, server) = mock_github_pair(vec![
+        MockResponse {
+            status: "200 OK",
+            headers: vec![],
+            body: comment_api_json(&sha, "Old body", "2026-08-30T01:01:00Z"),
+        },
+        MockResponse {
+            status: "200 OK",
+            headers: vec![],
+            body: capability_api_json_with_minimize(
+                &sha,
+                "2026-08-30T01:01:00Z",
+                false,
+                None,
+                true,
+                false,
+            ),
+        },
+        MockResponse {
+            status: "200 OK",
+            headers: vec![],
+            body: "__ECHO_MINIMIZE_MUTATION__".to_string(),
+        },
+        MockResponse {
+            status: "200 OK",
+            headers: vec![],
+            body: comment_api_json(&sha, "Old body", "2026-08-30T01:01:00Z"),
+        },
+        MockResponse {
+            status: "200 OK",
+            headers: vec![],
+            body: capability_api_json_with_minimize(
+                &sha,
+                "2026-08-30T01:01:00Z",
+                true,
+                Some("off-topic"),
+                false,
+                true,
+            ),
+        },
+    ])
+    .await;
+    let mutation = GitHubCommitCommentMutation::Minimize {
+        guard: comment_guard(42),
+        expected_minimized: false,
+        classifier: GitHubCommentMinimizeClassifier::OffTopic,
+    };
+
+    let minimized = mutate_commit_comment_with_clients(
+        &read_client,
+        &write_client,
+        "octocat",
+        "hello-world",
+        &sha,
+        &mutation,
+    )
+    .await
+    .expect("minimized comment")
+    .expect("comment response");
+    server.await.expect("mock server");
+
+    assert!(minimized.is_minimized);
+    assert_eq!(minimized.minimized_reason.as_deref(), Some("off-topic"));
+    let requests = requests.lock().expect("requests");
+    assert_eq!(requests.len(), 5);
+    assert!(requests[2].starts_with("POST /graphql HTTP/1.1"));
+    let request_body = requests[2].split("\r\n\r\n").nth(1).expect("request body");
+    let request_json = serde_json::from_str::<serde_json::Value>(request_body).expect("JSON");
+    assert_eq!(request_json["variables"]["id"], "CC_42");
+    assert_eq!(request_json["variables"]["classifier"], "OFF_TOPIC");
+}
+
+#[tokio::test]
+async fn minimize_transport_does_not_retry_an_ambiguous_graphql_write() {
+    let sha = "a".repeat(40);
+    let (read_client, write_client, requests, server) = mock_github_pair(vec![
+        MockResponse {
+            status: "200 OK",
+            headers: vec![],
+            body: comment_api_json(&sha, "Old body", "2026-08-30T01:01:00Z"),
+        },
+        MockResponse {
+            status: "200 OK",
+            headers: vec![],
+            body: capability_api_json_with_minimize(
+                &sha,
+                "2026-08-30T01:01:00Z",
+                false,
+                None,
+                true,
+                false,
+            ),
+        },
+        MockResponse {
+            status: "503 Service Unavailable",
+            headers: vec![],
+            body: serde_json::json!({ "message": "temporarily unavailable" }).to_string(),
+        },
+        MockResponse {
+            status: "503 Service Unavailable",
+            headers: vec![],
+            body: serde_json::json!({ "message": "retry probe" }).to_string(),
+        },
+        MockResponse {
+            status: "503 Service Unavailable",
+            headers: vec![],
+            body: serde_json::json!({ "message": "retry probe" }).to_string(),
+        },
+    ])
+    .await;
+    let mutation = GitHubCommitCommentMutation::Minimize {
+        guard: comment_guard(42),
+        expected_minimized: false,
+        classifier: GitHubCommentMinimizeClassifier::Spam,
+    };
+
+    let error = mutate_commit_comment_with_clients(
+        &read_client,
+        &write_client,
+        "octocat",
+        "hello-world",
+        &sha,
+        &mutation,
+    )
+    .await
+    .expect_err("ambiguous write");
+    let mut server = server;
+    if timeout(Duration::from_millis(250), &mut server)
+        .await
+        .is_err()
+    {
+        server.abort();
+    }
+    let _ = server.await;
+
+    assert!(matches!(error, crate::error::AppError::GitHub(_)));
+    assert_eq!(requests.lock().expect("requests").len(), 3);
 }
 
 #[tokio::test]

--- a/src-tauri/src/github/commit_comment/transport.rs
+++ b/src-tauri/src/github/commit_comment/transport.rs
@@ -3,6 +3,9 @@ use std::collections::BTreeMap;
 use http_body_util::BodyExt;
 use serde::{Deserialize, Serialize};
 
+use super::super::comment::{
+    ensure_minimized_result, run_minimize_mutation, GitHubCommentMutation,
+};
 use super::super::github_error;
 use super::{
     GitHubCommitComment, GitHubCommitCommentAuthor, GitHubCommitCommentMutation,
@@ -27,6 +30,10 @@ query HarborCommitCommentCapabilities(
       updatedAt
       viewerCanUpdate
       viewerCanDelete
+      isMinimized
+      minimizedReason
+      viewerCanMinimize
+      viewerCanUnminimize
       repository { id }
       commit { oid }
     }
@@ -80,6 +87,13 @@ pub(super) struct CommitCommentCapabilityNode {
     pub(super) updated_at: String,
     viewer_can_update: bool,
     viewer_can_delete: bool,
+    #[serde(default)]
+    pub(super) is_minimized: bool,
+    pub(super) minimized_reason: Option<String>,
+    #[serde(default)]
+    pub(super) viewer_can_minimize: bool,
+    #[serde(default)]
+    pub(super) viewer_can_unminimize: bool,
     pub(super) repository: CommitCommentRepositoryNode,
     commit: Option<CommitCommentCommitNode>,
 }
@@ -192,6 +206,7 @@ pub(super) async fn create_commit_comment_with_client(
     verify_created_comment(comment, commit_sha, body, placement.as_ref())
 }
 
+#[cfg(test)]
 pub(super) async fn mutate_commit_comment_with_client(
     client: &octocrab::Octocrab,
     owner: &str,
@@ -199,14 +214,34 @@ pub(super) async fn mutate_commit_comment_with_client(
     commit_sha: &str,
     mutation: &GitHubCommitCommentMutation,
 ) -> Result<Option<GitHubCommitComment>, AppError> {
+    mutate_commit_comment_with_clients(client, client, owner, repository, commit_sha, mutation)
+        .await
+}
+
+pub(super) async fn mutate_commit_comment_with_clients(
+    client: &octocrab::Octocrab,
+    write_client: &octocrab::Octocrab,
+    owner: &str,
+    repository: &str,
+    commit_sha: &str,
+    mutation: &GitHubCommitCommentMutation,
+) -> Result<Option<GitHubCommitComment>, AppError> {
     if matches!(mutation, GitHubCommitCommentMutation::Create { .. }) {
-        return create_commit_comment_with_client(client, owner, repository, commit_sha, mutation)
-            .await
-            .map(Some);
+        return create_commit_comment_with_client(
+            write_client,
+            owner,
+            repository,
+            commit_sha,
+            mutation,
+        )
+        .await
+        .map(Some);
     }
     let guard = match mutation {
         GitHubCommitCommentMutation::Update { guard, .. }
-        | GitHubCommitCommentMutation::Delete { guard } => guard,
+        | GitHubCommitCommentMutation::Delete { guard }
+        | GitHubCommitCommentMutation::Minimize { guard, .. }
+        | GitHubCommitCommentMutation::Unminimize { guard, .. } => guard,
         GitHubCommitCommentMutation::Create { .. } => unreachable!(),
     };
     let current = get_commit_comment(client, owner, repository, guard.comment_id).await?;
@@ -218,13 +253,7 @@ pub(super) async fn mutate_commit_comment_with_client(
         .into_iter()
         .next()
         .ok_or_else(|| AppError::GitHub("GitHub did not return the commit comment".to_string()))?;
-    ensure_comment_mutation_allowed(
-        &current,
-        guard.comment_id,
-        &guard.comment_node_id,
-        &guard.expected_updated_at,
-        matches!(mutation, GitHubCommitCommentMutation::Update { .. }),
-    )?;
+    ensure_comment_mutation_allowed(&current, guard, mutation)?;
 
     match mutation {
         GitHubCommitCommentMutation::Update { body, .. } => {
@@ -235,7 +264,7 @@ pub(super) async fn mutate_commit_comment_with_client(
                 commit_comment_route(owner, repository, guard.comment_id),
                 Some(&payload),
             )?;
-            let response = client.execute(request).await.map_err(github_error)?;
+            let response = write_client.execute(request).await.map_err(github_error)?;
             let status = response.status();
             let response = octocrab::map_github_error(response)
                 .await
@@ -265,7 +294,7 @@ pub(super) async fn mutate_commit_comment_with_client(
                 commit_comment_route(owner, repository, guard.comment_id),
                 None::<&()>,
             )?;
-            let response = client.execute(request).await.map_err(github_error)?;
+            let response = write_client.execute(request).await.map_err(github_error)?;
             let status = response.status();
             octocrab::map_github_error(response)
                 .await
@@ -276,6 +305,21 @@ pub(super) async fn mutate_commit_comment_with_client(
                 )));
             }
             Ok(None)
+        }
+        GitHubCommitCommentMutation::Minimize { .. }
+        | GitHubCommitCommentMutation::Unminimize { .. } => {
+            let generic_mutation = generic_minimize_mutation(mutation)?;
+            run_minimize_mutation(write_client, &generic_mutation).await?;
+            let refreshed =
+                refreshed_commit_comment(client, owner, repository, commit_sha, guard.comment_id)
+                    .await
+                    .map_err(super::super::comment::minimize_postflight_error)?;
+            ensure_minimized_result(
+                refreshed.is_minimized,
+                refreshed.minimized_reason.as_deref(),
+                &generic_mutation,
+            )?;
+            Ok(Some(refreshed))
         }
         GitHubCommitCommentMutation::Create { .. } => unreachable!(),
     }
@@ -363,6 +407,10 @@ pub(super) fn commit_comment_page_from_raw(
             updated_at: comment.updated_at,
             viewer_can_update: capability.viewer_can_update,
             viewer_can_delete: capability.viewer_can_delete,
+            is_minimized: capability.is_minimized,
+            minimized_reason: capability.minimized_reason,
+            viewer_can_minimize: capability.viewer_can_minimize,
+            viewer_can_unminimize: capability.viewer_can_unminimize,
         });
     }
     if !capabilities_by_id.is_empty() {
@@ -410,30 +458,115 @@ async fn get_commit_comment(
 
 fn ensure_comment_mutation_allowed(
     current: &GitHubCommitComment,
-    comment_id: u64,
-    comment_node_id: &str,
-    expected_updated_at: &str,
-    updating: bool,
+    guard: &super::GitHubCommitCommentGuard,
+    mutation: &GitHubCommitCommentMutation,
 ) -> Result<(), AppError> {
-    if current.database_id != comment_id
-        || current.id != comment_node_id
-        || current.updated_at != expected_updated_at
+    if current.database_id != guard.comment_id
+        || current.id != guard.comment_node_id
+        || current.updated_at != guard.expected_updated_at
     {
         return Err(AppError::GitHubCommentConflict(
             "the comment identity or revision changed on GitHub".to_string(),
         ));
     }
-    let allowed = if updating {
-        current.viewer_can_update
-    } else {
-        current.viewer_can_delete
+    let allowed = match mutation {
+        GitHubCommitCommentMutation::Update { .. } => current.viewer_can_update,
+        GitHubCommitCommentMutation::Delete { .. } => current.viewer_can_delete,
+        GitHubCommitCommentMutation::Minimize { .. } => current.viewer_can_minimize,
+        GitHubCommitCommentMutation::Unminimize { .. } => current.viewer_can_unminimize,
+        GitHubCommitCommentMutation::Create { .. } => false,
     };
     if !allowed {
         return Err(AppError::GitHubPermission(
             "GitHub does not allow the viewer to modify this commit comment".to_string(),
         ));
     }
+    let expected_minimized = match mutation {
+        GitHubCommitCommentMutation::Minimize {
+            expected_minimized, ..
+        }
+        | GitHubCommitCommentMutation::Unminimize {
+            expected_minimized, ..
+        } => Some(*expected_minimized),
+        _ => None,
+    };
+    if let Some(expected_minimized) = expected_minimized {
+        let requested_minimized = matches!(mutation, GitHubCommitCommentMutation::Minimize { .. });
+        if expected_minimized != current.is_minimized || requested_minimized == current.is_minimized
+        {
+            return Err(AppError::GitHubCommentConflict(
+                "the comment minimize state changed after it was loaded".to_string(),
+            ));
+        }
+    }
     Ok(())
+}
+
+#[cfg(test)]
+pub(super) fn ensure_comment_mutation_allowed_for_test(
+    current: &GitHubCommitComment,
+    mutation: &GitHubCommitCommentMutation,
+) -> Result<(), AppError> {
+    let guard = match mutation {
+        GitHubCommitCommentMutation::Update { guard, .. }
+        | GitHubCommitCommentMutation::Delete { guard }
+        | GitHubCommitCommentMutation::Minimize { guard, .. }
+        | GitHubCommitCommentMutation::Unminimize { guard, .. } => guard,
+        GitHubCommitCommentMutation::Create { .. } => {
+            return Err(AppError::Validation(
+                "a guarded commit-comment mutation is required".to_string(),
+            ));
+        }
+    };
+    ensure_comment_mutation_allowed(current, guard, mutation)
+}
+
+fn generic_minimize_mutation(
+    mutation: &GitHubCommitCommentMutation,
+) -> Result<GitHubCommentMutation, AppError> {
+    match mutation {
+        GitHubCommitCommentMutation::Minimize {
+            guard,
+            expected_minimized,
+            classifier,
+        } => Ok(GitHubCommentMutation::Minimize {
+            comment_id: guard.comment_node_id.clone(),
+            expected_updated_at: guard.expected_updated_at.clone(),
+            expected_minimized: *expected_minimized,
+            classifier: *classifier,
+        }),
+        GitHubCommitCommentMutation::Unminimize {
+            guard,
+            expected_minimized,
+        } => Ok(GitHubCommentMutation::Unminimize {
+            comment_id: guard.comment_node_id.clone(),
+            expected_updated_at: guard.expected_updated_at.clone(),
+            expected_minimized: *expected_minimized,
+        }),
+        _ => Err(AppError::Validation(
+            "the selected commit-comment mutation is not a minimize operation".to_string(),
+        )),
+    }
+}
+
+async fn refreshed_commit_comment(
+    client: &octocrab::Octocrab,
+    owner: &str,
+    repository: &str,
+    commit_sha: &str,
+    comment_id: u64,
+) -> Result<GitHubCommitComment, AppError> {
+    let raw = get_commit_comment(client, owner, repository, comment_id).await?;
+    let node_id = raw.node_id.clone();
+    let capabilities =
+        commit_comment_capabilities(client, owner, repository, vec![node_id.as_str()]).await?;
+    commit_comment_page_from_raw(vec![raw], capabilities, commit_sha, 1, false)?
+        .comments
+        .into_iter()
+        .next()
+        .ok_or_else(|| {
+            AppError::GitHub("GitHub did not return the minimized commit comment".to_string())
+        })
 }
 
 fn verify_created_comment(
@@ -453,7 +586,9 @@ fn verify_created_comment(
             "GitHub returned a different created commit comment".to_string(),
         ));
     }
-    Ok(commit_comment_from_raw(comment, false, false))
+    Ok(commit_comment_from_raw(
+        comment, false, false, false, None, false, false,
+    ))
 }
 
 fn verify_updated_comment(
@@ -477,6 +612,10 @@ fn verify_updated_comment(
         updated,
         current.viewer_can_update,
         current.viewer_can_delete,
+        current.is_minimized,
+        current.minimized_reason.clone(),
+        current.viewer_can_minimize,
+        current.viewer_can_unminimize,
     ))
 }
 
@@ -484,6 +623,10 @@ fn commit_comment_from_raw(
     comment: RawCommitComment,
     viewer_can_update: bool,
     viewer_can_delete: bool,
+    is_minimized: bool,
+    minimized_reason: Option<String>,
+    viewer_can_minimize: bool,
+    viewer_can_unminimize: bool,
 ) -> GitHubCommitComment {
     GitHubCommitComment {
         id: comment.node_id,
@@ -503,6 +646,10 @@ fn commit_comment_from_raw(
         updated_at: comment.updated_at,
         viewer_can_update,
         viewer_can_delete,
+        is_minimized,
+        minimized_reason,
+        viewer_can_minimize,
+        viewer_can_unminimize,
     }
 }
 

--- a/src/features/github/github-commit-comment-card.interaction.test.tsx
+++ b/src/features/github/github-commit-comment-card.interaction.test.tsx
@@ -52,6 +52,10 @@ function comment(body = "Old body"): GitHubCommitComment {
     updatedAt: body === "Old body" ? "2026-08-30T01:01:00Z" : "2026-08-30T01:02:00Z",
     viewerCanUpdate: true,
     viewerCanDelete: true,
+    isMinimized: false,
+    minimizedReason: null,
+    viewerCanMinimize: true,
+    viewerCanUnminimize: false,
   };
 }
 
@@ -155,6 +159,44 @@ describe("GitHub commit comment card", () => {
         pages: Array<{ comments: GitHubCommitComment[] }>;
       }>(githubQueryKeys.commitComments(target))?.pages[0].comments[0].body
     ).toBe("New body");
+  });
+
+  it("minimizes a commit comment with its numeric and Node ID guards", async () => {
+    vi.mocked(invoke).mockResolvedValueOnce({
+      ...comment(),
+      isMinimized: true,
+      minimizedReason: "off-topic",
+      viewerCanMinimize: false,
+      viewerCanUnminimize: true,
+    });
+    const client = createQueryClient();
+    const user = userEvent.setup();
+    renderCard(client);
+
+    await user.click(
+      screen.getByRole("button", { name: "workspace.repositories.minimizeComment" })
+    );
+    await user.click(
+      screen.getByRole("button", { name: "workspace.repositories.confirmMinimizeComment" })
+    );
+
+    await waitFor(() => expect(invoke).toHaveBeenCalledTimes(1));
+    expect(invoke).toHaveBeenCalledWith("github_mutate_repository_commit_comment", {
+      ...target,
+      mutation: {
+        action: "minimize",
+        commentId: 42,
+        commentNodeId: "CC_42",
+        expectedUpdatedAt: "2026-08-30T01:01:00Z",
+        expectedMinimized: false,
+        classifier: "offTopic",
+      },
+    });
+    expect(
+      client.getQueryData<{
+        pages: Array<{ comments: GitHubCommitComment[] }>;
+      }>(githubQueryKeys.commitComments(target))?.pages[0].comments[0]
+    ).toMatchObject({ isMinimized: true, minimizedReason: "off-topic" });
   });
 
   it("removes the focused comment only after confirmed deletion succeeds", async () => {

--- a/src/features/github/github-commit-comment-card.tsx
+++ b/src/features/github/github-commit-comment-card.tsx
@@ -1,11 +1,12 @@
-import { lazy, Suspense } from "react";
+import { lazy, Suspense, useEffect, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
-import { ExternalLink, UserRound } from "lucide-react";
+import { ChevronDown, ExternalLink, UserRound } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useAppTranslation } from "@/hooks/use-app-translation";
@@ -43,29 +44,41 @@ export function GitHubCommitCommentCard({
   const { t, i18n } = useTranslation();
   const { t: appT } = useAppTranslation();
   const queryClient = useQueryClient();
+  const [commentOpen, setCommentOpen] = useState(!comment.isMinimized);
+  useEffect(() => setCommentOpen(!comment.isMinimized), [comment.isMinimized]);
   const author = comment.author?.login ?? t("workspace.repositories.unknownActor");
   const mutateComment = (mutation: GitHubCommentMutation) => {
-    if (mutation.action !== "update" && mutation.action !== "delete") {
-      return Promise.reject(new Error("pinning commit comments is unsupported"));
-    }
     const guard = {
       commentId: comment.databaseId,
       commentNodeId: comment.id,
       expectedUpdatedAt: mutation.expectedUpdatedAt,
     };
-    return mutateRepositoryCommitComment(
-      target,
-      mutation.action === "update"
-        ? {
-            action: "update",
-            ...guard,
-            body: mutation.body,
-          }
-        : {
-            action: "delete",
-            ...guard,
-          }
-    );
+    if (mutation.action === "update") {
+      return mutateRepositoryCommitComment(target, {
+        action: "update",
+        ...guard,
+        body: mutation.body,
+      });
+    }
+    if (mutation.action === "delete") {
+      return mutateRepositoryCommitComment(target, { action: "delete", ...guard });
+    }
+    if (mutation.action === "minimize") {
+      return mutateRepositoryCommitComment(target, {
+        action: "minimize",
+        ...guard,
+        expectedMinimized: mutation.expectedMinimized,
+        classifier: mutation.classifier,
+      });
+    }
+    if (mutation.action === "unminimize") {
+      return mutateRepositoryCommitComment(target, {
+        action: "unminimize",
+        ...guard,
+        expectedMinimized: mutation.expectedMinimized,
+      });
+    }
+    return Promise.reject(new Error("pinning commit comments is unsupported"));
   };
 
   return (
@@ -98,6 +111,9 @@ export function GitHubCommitCommentCard({
               updatedAt: comment.updatedAt,
               viewerCanUpdate: comment.viewerCanUpdate,
               viewerCanDelete: comment.viewerCanDelete,
+              isMinimized: comment.isMinimized,
+              viewerCanMinimize: comment.viewerCanMinimize,
+              viewerCanUnminimize: comment.viewerCanUnminimize,
             }}
             repository={repository}
             reference={target.commitSha}
@@ -109,9 +125,22 @@ export function GitHubCommitCommentCard({
             onConflict={() => invalidateRepositoryCommitComments(queryClient, target)}
             onUncertainError={() => invalidateRepositoryCommitComments(queryClient, target)}
             onSuccess={(result, mutation) => {
-              if (mutation.action === "update" && result) {
-                syncRepositoryCommitComment(queryClient, target, result, "update");
-                toast.success(appT("workspace.repositories.commentUpdated"));
+              if (
+                (mutation.action === "update" ||
+                  mutation.action === "minimize" ||
+                  mutation.action === "unminimize") &&
+                result
+              ) {
+                syncRepositoryCommitComment(queryClient, target, result, mutation.action);
+                toast.success(
+                  appT(
+                    mutation.action === "update"
+                      ? "workspace.repositories.commentUpdated"
+                      : mutation.action === "minimize"
+                        ? "workspace.repositories.commentMinimizedSuccess"
+                        : "workspace.repositories.commentUnminimizedSuccess"
+                  )
+                );
               } else if (mutation.action === "delete") {
                 syncRepositoryCommitComment(queryClient, target, comment, "delete");
                 toast.success(appT("workspace.repositories.commentDeleted"));
@@ -147,19 +176,35 @@ export function GitHubCommitCommentCard({
           </Badge>
         </div>
       ) : null}
-      <div className={compact ? "px-3 py-3" : "px-4 py-4"}>
-        <div className="harbor-markdown text-[12px]">
-          <Suspense fallback={<Skeleton className="h-14 w-full" />}>
-            <GitHubReadme
-              content={comment.body}
-              path=""
-              reference={target.commitSha}
-              repository={repository}
-              onOpenExternal={(url) => void openExternalUrl(url)}
-            />
-          </Suspense>
-        </div>
-      </div>
+      <Collapsible open={commentOpen} onOpenChange={setCommentOpen}>
+        {comment.isMinimized ? (
+          <CollapsibleTrigger asChild>
+            <Button type="button" variant="ghost" size="sm" className="m-2">
+              <ChevronDown data-icon="inline-start" />
+              {comment.minimizedReason
+                ? t("workspace.repositories.commentMinimizedReason", {
+                    reason: comment.minimizedReason,
+                  })
+                : t("workspace.repositories.commentMinimized")}
+            </Button>
+          </CollapsibleTrigger>
+        ) : null}
+        <CollapsibleContent>
+          <div className={compact ? "px-3 py-3" : "px-4 py-4"}>
+            <div className="harbor-markdown text-[12px]">
+              <Suspense fallback={<Skeleton className="h-14 w-full" />}>
+                <GitHubReadme
+                  content={comment.body}
+                  path=""
+                  reference={target.commitSha}
+                  repository={repository}
+                  onOpenExternal={(url) => void openExternalUrl(url)}
+                />
+              </Suspense>
+            </div>
+          </div>
+        </CollapsibleContent>
+      </Collapsible>
       <footer className="flex min-h-10 items-center border-t px-3 py-1.5">
         <GitHubReactionBar subject={{ id: comment.id, kind: "commitComment" }} />
       </footer>

--- a/src/features/github/github-commit-comment-composer.interaction.test.tsx
+++ b/src/features/github/github-commit-comment-composer.interaction.test.tsx
@@ -43,6 +43,10 @@ function createdComment(): GitHubCommitComment {
     updatedAt: "2026-08-30T01:00:00Z",
     viewerCanUpdate: false,
     viewerCanDelete: false,
+    isMinimized: false,
+    minimizedReason: null,
+    viewerCanMinimize: false,
+    viewerCanUnminimize: false,
   };
 }
 

--- a/src/features/github/github-commit-comment-diff.interaction.test.tsx
+++ b/src/features/github/github-commit-comment-diff.interaction.test.tsx
@@ -94,6 +94,10 @@ describe("GitHub commit comment diff", () => {
       updatedAt: "2026-08-30T01:00:00Z",
       viewerCanUpdate: false,
       viewerCanDelete: false,
+      isMinimized: false,
+      minimizedReason: null,
+      viewerCanMinimize: false,
+      viewerCanUnminimize: false,
     };
     render(
       <TooltipProvider>

--- a/src/features/github/github-commit-comments-workspace.interaction.test.tsx
+++ b/src/features/github/github-commit-comments-workspace.interaction.test.tsx
@@ -72,6 +72,10 @@ function comment(overrides: Partial<GitHubCommitComment> = {}): GitHubCommitComm
     updatedAt: "2026-08-30T01:00:00Z",
     viewerCanUpdate: false,
     viewerCanDelete: false,
+    isMinimized: false,
+    minimizedReason: null,
+    viewerCanMinimize: false,
+    viewerCanUnminimize: false,
     ...overrides,
   };
 }

--- a/src/features/github/github-commit-comments.test.ts
+++ b/src/features/github/github-commit-comments.test.ts
@@ -26,6 +26,10 @@ function comment(databaseId: number, body = "Body"): GitHubCommitComment {
     updatedAt: "2026-08-30T01:00:00Z",
     viewerCanUpdate: true,
     viewerCanDelete: true,
+    isMinimized: false,
+    minimizedReason: null,
+    viewerCanMinimize: true,
+    viewerCanUnminimize: false,
   };
 }
 

--- a/src/features/github/github-data.ts
+++ b/src/features/github/github-data.ts
@@ -2037,6 +2037,10 @@ export type GitHubCommitComment = {
   updatedAt: string;
   viewerCanUpdate: boolean;
   viewerCanDelete: boolean;
+  isMinimized: boolean;
+  minimizedReason: string | null;
+  viewerCanMinimize: boolean;
+  viewerCanUnminimize: boolean;
 };
 
 export type GitHubCommitCommentPage = {
@@ -2069,6 +2073,15 @@ export type GitHubCommitCommentMutation =
     } & GitHubCommitCommentGuard)
   | ({
       action: "delete";
+    } & GitHubCommitCommentGuard)
+  | ({
+      action: "minimize";
+      expectedMinimized: boolean;
+      classifier: GitHubCommentMinimizeClassifier;
+    } & GitHubCommitCommentGuard)
+  | ({
+      action: "unminimize";
+      expectedMinimized: boolean;
     } & GitHubCommitCommentGuard);
 
 export type GitHubPullRequestCommit = GitHubCommit;


### PR DESCRIPTION
## Summary
- expose CommitComment minimization capabilities from GitHub GraphQL
- add guarded minimize/unminimize mutations with postflight refresh
- wire the shared comment action UI and regression tests

## Verification
- pnpm check
- cargo test --manifest-path src-tauri/Cargo.toml --lib
- cargo check --manifest-path src-tauri/Cargo.toml
- cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check
- cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets (existing warnings only)

Closes the native CommitComment minimization gap identified in the GitHub Web parity audit.