### PR TITLE
test: simplify commit comment retry probe

### DIFF
--- a/src-tauri/src/github/commit_comment/tests.rs
+++ b/src-tauri/src/github/commit_comment/tests.rs
@@ -297,12 +297,15 @@ async fn mock_github_with_retry_config_and_address(
                 let client_mutation_id = request_json["variables"]["clientMutationId"]
                     .as_str()
                     .expect("client mutation ID");
-                let mutation_name = request_json["query"]
+                let mutation_name = if request_json["query"]
                     .as_str()
                     .expect("GraphQL query")
                     .contains("unminimizeComment")
-                    .then_some("unminimizeComment")
-                    .unwrap_or("minimizeComment");
+                {
+                    "unminimizeComment"
+                } else {
+                    "minimizeComment"
+                };
                 let mut data = serde_json::Map::new();
                 data.insert(
                     mutation_name.to_string(),


### PR DESCRIPTION
## Summary
- simplify the dynamic mutation-name fixture branch
- keep merged-main Clippy output at the existing warning baseline

## Verification
- cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check
- cargo test --manifest-path src-tauri/Cargo.toml github::commit_comment --lib
- cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets (existing warnings only)