### PR TITLE
feat: filter repository Issues by close reason

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -25,13 +25,13 @@ use crate::{
         GitHubGistFileInput, GitHubGistFileMutation, GitHubGistPage, GitHubGistRevisionDetail,
         GitHubGistRevisionPage, GitHubGistSource, GitHubGistUpdateInput,
         GitHubInsightsTrafficPeriod, GitHubIssue, GitHubIssueAssigneePage, GitHubIssueAssignment,
-        GitHubIssueClone, GitHubIssueCloneStatus, GitHubIssueCreateInput,
-        GitHubIssueCreationPolicy, GitHubIssueDependenciesPage, GitHubIssueDetailPage,
-        GitHubIssueDuplicateReference, GitHubIssueFilters, GitHubIssueInboxFilters,
-        GitHubIssueInboxPage, GitHubIssueInboxScope, GitHubIssueLabel, GitHubIssueLabelMutation,
-        GitHubIssueLabelPage, GitHubIssueLinkedPullRequestPage, GitHubIssueMilestone,
-        GitHubIssueMilestoneMutation, GitHubIssueMilestonePage, GitHubIssuePage,
-        GitHubIssueRelationshipsPage, GitHubIssueSort, GitHubIssueState,
+        GitHubIssueClone, GitHubIssueCloneStatus, GitHubIssueCloseReasonFilter,
+        GitHubIssueCreateInput, GitHubIssueCreationPolicy, GitHubIssueDependenciesPage,
+        GitHubIssueDetailPage, GitHubIssueDuplicateReference, GitHubIssueFilters,
+        GitHubIssueInboxFilters, GitHubIssueInboxPage, GitHubIssueInboxScope, GitHubIssueLabel,
+        GitHubIssueLabelMutation, GitHubIssueLabelPage, GitHubIssueLinkedPullRequestPage,
+        GitHubIssueMilestone, GitHubIssueMilestoneMutation, GitHubIssueMilestonePage,
+        GitHubIssuePage, GitHubIssueRelationshipsPage, GitHubIssueSort, GitHubIssueState,
         GitHubIssueStateCapabilities, GitHubIssueStateMutation, GitHubIssueSubIssueCreateInput,
         GitHubIssueSubIssuePriorityInput, GitHubIssueSummary, GitHubIssueTimelineItem,
         GitHubIssueTrackingDirection, GitHubIssueTrackingPage, GitHubIssueTypeStatus,
@@ -1553,10 +1553,12 @@ pub async fn github_list_repository_issues(
     query: String,
     label: String,
     sort: GitHubIssueSort,
+    close_reason: Option<GitHubIssueCloseReasonFilter>,
     page: u32,
     state: State<'_, AppState>,
 ) -> Result<GitHubIssuePage, AppError> {
     let repository = RepositoryRef::new(owner, repository)?;
+    validate_issue_close_reason_filter(issue_state, close_reason)?;
     let filters = GitHubIssueFilters {
         state: issue_state,
         assignment,
@@ -1564,6 +1566,7 @@ pub async fn github_list_repository_issues(
         label: validate_issue_label(label)?,
         sort,
         page: validate_issue_page(page)?,
+        close_reason,
     };
     state
         .github
@@ -4957,6 +4960,18 @@ fn validate_issue_query(query: String) -> Result<String, AppError> {
     Ok(query)
 }
 
+fn validate_issue_close_reason_filter(
+    state: GitHubIssueState,
+    close_reason: Option<GitHubIssueCloseReasonFilter>,
+) -> Result<(), AppError> {
+    if state == GitHubIssueState::Open && close_reason.is_some() {
+        return Err(AppError::Validation(
+            "a close-reason filter requires closed Issues".to_string(),
+        ));
+    }
+    Ok(())
+}
+
 fn validate_project_number(number: u32) -> Result<u32, AppError> {
     if number == 0 || number > i32::MAX as u32 {
         Err(AppError::Validation(
@@ -5790,6 +5805,21 @@ mod tests {
         assert!(validate_page(1_001).is_err());
         assert_eq!(validate_issue_page(34).expect("last search page"), 34);
         assert!(validate_issue_page(35).is_err());
+    }
+
+    #[test]
+    fn issue_close_reason_filters_only_apply_to_closed_issues() {
+        assert!(validate_issue_close_reason_filter(
+            GitHubIssueState::Closed,
+            Some(GitHubIssueCloseReasonFilter::Duplicate),
+        )
+        .is_ok());
+        assert!(validate_issue_close_reason_filter(GitHubIssueState::Open, None).is_ok());
+        assert!(validate_issue_close_reason_filter(
+            GitHubIssueState::Open,
+            Some(GitHubIssueCloseReasonFilter::Completed),
+        )
+        .is_err());
     }
 
     #[test]

--- a/src-tauri/src/github.rs
+++ b/src-tauri/src/github.rs
@@ -102,11 +102,11 @@ pub(crate) use issue::GitHubIssueCreateInput;
 #[cfg(test)]
 use issue::GitHubIssueTimelineKind;
 pub use issue::{
-    GitHubIssue, GitHubIssueAssigneePage, GitHubIssueAssignment, GitHubIssueCreationPolicy,
-    GitHubIssueDetailPage, GitHubIssueFilters, GitHubIssueInboxFilters, GitHubIssueInboxPage,
-    GitHubIssueInboxScope, GitHubIssueLabel, GitHubIssueLabelPage, GitHubIssueMilestone,
-    GitHubIssueMilestonePage, GitHubIssuePage, GitHubIssueSort, GitHubIssueState,
-    GitHubIssueStateCapabilities, GitHubIssueStateMutation, GitHubIssueSummary,
+    GitHubIssue, GitHubIssueAssigneePage, GitHubIssueAssignment, GitHubIssueCloseReasonFilter,
+    GitHubIssueCreationPolicy, GitHubIssueDetailPage, GitHubIssueFilters, GitHubIssueInboxFilters,
+    GitHubIssueInboxPage, GitHubIssueInboxScope, GitHubIssueLabel, GitHubIssueLabelPage,
+    GitHubIssueMilestone, GitHubIssueMilestonePage, GitHubIssuePage, GitHubIssueSort,
+    GitHubIssueState, GitHubIssueStateCapabilities, GitHubIssueStateMutation, GitHubIssueSummary,
     GitHubIssueTimelineItem,
 };
 pub(crate) use issue_clone::IssueCloneMutation;
@@ -2859,6 +2859,7 @@ mod tests {
             label: String::new(),
             sort: GitHubIssueSort::Updated,
             page: 1,
+            close_reason: None,
         };
         let issues = service
             .issues("octocat", "hello-world", &issue_filters)

--- a/src-tauri/src/github/issue.rs
+++ b/src-tauri/src/github/issue.rs
@@ -64,6 +64,24 @@ pub enum GitHubIssueSort {
     Comments,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum GitHubIssueCloseReasonFilter {
+    Completed,
+    NotPlanned,
+    Duplicate,
+}
+
+impl GitHubIssueCloseReasonFilter {
+    fn search_qualifier(self) -> &'static str {
+        match self {
+            Self::Completed => "reason:completed",
+            Self::NotPlanned => "reason:\"not planned\"",
+            Self::Duplicate => "reason:duplicate",
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct GitHubIssueFilters {
     pub state: GitHubIssueState,
@@ -72,6 +90,7 @@ pub struct GitHubIssueFilters {
     pub label: String,
     pub sort: GitHubIssueSort,
     pub page: u32,
+    pub close_reason: Option<GitHubIssueCloseReasonFilter>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize)]
@@ -677,6 +696,9 @@ fn issue_search_query(owner: &str, repository: &str, filters: &GitHubIssueFilter
     if !filters.label.is_empty() {
         let label = filters.label.replace('\\', "\\\\").replace('"', "\\\"");
         query.push(format!("label:\"{label}\""));
+    }
+    if let Some(reason) = filters.close_reason {
+        query.push(reason.search_qualifier().to_string());
     }
     query
         .into_iter()

--- a/src-tauri/src/github/issue/tests.rs
+++ b/src-tauri/src/github/issue/tests.rs
@@ -69,6 +69,7 @@ impl GitHubIssueClient for super::super::tests::FakeGitHubClient {
                     label: String::new(),
                     sort: filters.sort,
                     page: filters.page,
+                    close_reason: None,
                 },
             )
             .await?
@@ -169,6 +170,7 @@ impl GitHubIssueClient for super::super::tests::FakeGitHubClient {
                     label: String::new(),
                     sort: GitHubIssueSort::Updated,
                     page: 1,
+                    close_reason: None,
                 },
             )
             .await?;
@@ -333,12 +335,56 @@ fn issue_search_is_scoped_to_real_issues_and_selected_filters() {
         label: "help wanted".to_string(),
         sort: GitHubIssueSort::Comments,
         page: 3,
+        close_reason: None,
     };
 
     assert_eq!(
         issue_search_query("octocat", "hello-world", &filters),
         "render crash repo:octocat/hello-world is:issue is:closed no:assignee label:\"help wanted\""
     );
+}
+
+#[test]
+fn issue_search_filters_closed_issues_by_the_selected_reason() {
+    let filters = GitHubIssueFilters {
+        state: GitHubIssueState::Closed,
+        assignment: GitHubIssueAssignment::All,
+        query: String::new(),
+        label: String::new(),
+        sort: GitHubIssueSort::Updated,
+        page: 1,
+        close_reason: Some(GitHubIssueCloseReasonFilter::NotPlanned),
+    };
+
+    assert_eq!(
+        issue_search_query("octocat", "hello-world", &filters),
+        "repo:octocat/hello-world is:issue is:closed reason:\"not planned\""
+    );
+}
+
+#[test]
+fn issue_search_uses_github_reason_qualifiers_for_each_close_reason() {
+    let cases = [
+        (GitHubIssueCloseReasonFilter::Completed, "reason:completed"),
+        (
+            GitHubIssueCloseReasonFilter::NotPlanned,
+            "reason:\"not planned\"",
+        ),
+        (GitHubIssueCloseReasonFilter::Duplicate, "reason:duplicate"),
+    ];
+
+    for (close_reason, qualifier) in cases {
+        let filters = GitHubIssueFilters {
+            state: GitHubIssueState::Closed,
+            assignment: GitHubIssueAssignment::All,
+            query: String::new(),
+            label: String::new(),
+            sort: GitHubIssueSort::Updated,
+            page: 1,
+            close_reason: Some(close_reason),
+        };
+        assert!(issue_search_query("octocat", "hello-world", &filters).ends_with(qualifier));
+    }
 }
 
 #[test]
@@ -350,6 +396,7 @@ fn issue_search_removes_scope_changing_user_qualifiers() {
         label: String::new(),
         sort: GitHubIssueSort::Updated,
         page: 1,
+        close_reason: None,
     };
 
     assert_eq!(

--- a/src/features/github/github-data.ts
+++ b/src/features/github/github-data.ts
@@ -1334,6 +1334,7 @@ export type GitHubItemMetadataValue = {
 
 export type GitHubIssueState = "open" | "closed";
 export type GitHubIssueCloseReason = "completed" | "notPlanned";
+export type GitHubIssueCloseReasonFilter = "completed" | "notPlanned" | "duplicate";
 export type GitHubIssueStateReason =
   | "completed"
   | "notPlanned"

--- a/src/features/github/github-issue-mutations.test.ts
+++ b/src/features/github/github-issue-mutations.test.ts
@@ -570,6 +570,50 @@ describe("GitHub Issue mutations", () => {
     );
   });
 
+  it("keeps closed Issue lists scoped to their selected close reason", () => {
+    const queryClient = new QueryClient();
+    const completedListKey = githubQueryKeys.issues({
+      owner: target.owner,
+      repository: target.repository,
+      state: "closed",
+      assignment: "all",
+      query: "",
+      label: "",
+      closeReason: "completed",
+      sort: "updated",
+      page: 1,
+    });
+    const notPlannedListKey = githubQueryKeys.issues({
+      owner: target.owner,
+      repository: target.repository,
+      state: "closed",
+      assignment: "all",
+      query: "",
+      label: "",
+      closeReason: "notPlanned",
+      sort: "updated",
+      page: 1,
+    });
+    const closedIssue = { ...issue, state: "closed" as const, stateReason: "completed" };
+    for (const key of [completedListKey, notPlannedListKey]) {
+      queryClient.setQueryData<GitHubIssuePage>(key, {
+        issues: [],
+        totalCount: 0,
+        page: 1,
+        hasPrevious: false,
+        hasMore: false,
+      });
+    }
+
+    syncUpdatedIssue(queryClient, target, closedIssue);
+
+    expect(queryClient.getQueryData<GitHubIssuePage>(completedListKey)?.issues).toEqual([
+      closedIssue,
+    ]);
+    expect(queryClient.getQueryData<GitHubIssuePage>(notPlannedListKey)?.issues).toEqual([]);
+    expect(queryClient.getQueryState(notPlannedListKey)?.isInvalidated).toBe(true);
+  });
+
   it("invalidates only Issue detail, list, and inbox roots", async () => {
     const queryClient = new QueryClient();
     const affected = [

--- a/src/features/github/github-issue-mutations.test.ts
+++ b/src/features/github/github-issue-mutations.test.ts
@@ -614,6 +614,57 @@ describe("GitHub Issue mutations", () => {
     expect(queryClient.getQueryState(notPlannedListKey)?.isInvalidated).toBe(true);
   });
 
+  it("moves an Issue between close-reason caches when its reason changes", () => {
+    const queryClient = new QueryClient();
+    const completedListKey = githubQueryKeys.issues({
+      owner: target.owner,
+      repository: target.repository,
+      state: "closed",
+      assignment: "all",
+      query: "",
+      label: "",
+      closeReason: "completed",
+      sort: "updated",
+      page: 1,
+    });
+    const notPlannedListKey = githubQueryKeys.issues({
+      owner: target.owner,
+      repository: target.repository,
+      state: "closed",
+      assignment: "all",
+      query: "",
+      label: "",
+      closeReason: "notPlanned",
+      sort: "updated",
+      page: 1,
+    });
+    const completedIssue = { ...issue, state: "closed" as const, stateReason: "completed" };
+    const notPlannedIssue = { ...completedIssue, stateReason: "notPlanned" };
+    queryClient.setQueryData<GitHubIssuePage>(completedListKey, {
+      issues: [completedIssue],
+      totalCount: 1,
+      page: 1,
+      hasPrevious: false,
+      hasMore: false,
+    });
+    queryClient.setQueryData<GitHubIssuePage>(notPlannedListKey, {
+      issues: [],
+      totalCount: 0,
+      page: 1,
+      hasPrevious: false,
+      hasMore: false,
+    });
+
+    syncUpdatedIssue(queryClient, target, notPlannedIssue);
+
+    expect(queryClient.getQueryData<GitHubIssuePage>(completedListKey)?.issues).toEqual([]);
+    expect(queryClient.getQueryData<GitHubIssuePage>(completedListKey)?.totalCount).toBe(0);
+    expect(queryClient.getQueryState(completedListKey)?.isInvalidated).toBe(true);
+    expect(queryClient.getQueryData<GitHubIssuePage>(notPlannedListKey)?.issues).toEqual([
+      notPlannedIssue,
+    ]);
+  });
+
   it("invalidates only Issue detail, list, and inbox roots", async () => {
     const queryClient = new QueryClient();
     const affected = [

--- a/src/features/github/github-issue-mutations.ts
+++ b/src/features/github/github-issue-mutations.ts
@@ -277,8 +277,18 @@ function updateRepositoryIssuePages(
     if (!page) continue;
     const matches = page.issues.filter((item) => item.number === target.issueNumber);
     const cachedState = issueStateFromQueryKey(queryKey);
+    const closeReasonMatches = repositoryIssueCloseReasonMatches(queryKey, issue);
     const exactDestination = repositoryIssuePageAccepts(queryKey, issue);
     const shouldInsert = !matches.length && cachedState === issue.state && exactDestination;
+    if (matches.length && cachedState === issue.state && !closeReasonMatches) {
+      queryClient.setQueryData<GitHubIssuePage>(queryKey, {
+        ...page,
+        issues: page.issues.filter((item) => item.number !== target.issueNumber),
+        totalCount: Math.max(0, page.totalCount - matches.length),
+      });
+      void queryClient.invalidateQueries({ queryKey, exact: true });
+      continue;
+    }
     if (!matches.length && !shouldInsert) {
       if (cachedState === issue.state) {
         void queryClient.invalidateQueries({ queryKey, exact: true });
@@ -335,7 +345,6 @@ function repositoryIssuePageAccepts(queryKey: QueryKey, issue: GitHubIssue) {
   const assignment = queryKey[6];
   const query = queryKey[7];
   const label = queryKey[8];
-  const closeReason = queryKey[9] as GitHubIssueCloseReasonFilter | null;
   const sort = queryKey[10];
   const page = queryKey[11];
   return (
@@ -344,8 +353,13 @@ function repositoryIssuePageAccepts(queryKey: QueryKey, issue: GitHubIssue) {
     (assignment === "all" || (assignment === "unassigned" && !issue.assignees.length)) &&
     query === "" &&
     (label === "" || issue.labels.some((item) => item.name === label)) &&
-    (closeReason === null || closeReason === issue.stateReason)
+    repositoryIssueCloseReasonMatches(queryKey, issue)
   );
+}
+
+function repositoryIssueCloseReasonMatches(queryKey: QueryKey, issue: GitHubIssue) {
+  const closeReason = queryKey[9] as GitHubIssueCloseReasonFilter | null | undefined;
+  return closeReason === null || closeReason === undefined || closeReason === issue.stateReason;
 }
 
 function matchesIssueSummary(summary: GitHubIssueSummary, target: GitHubIssueMutationTarget) {

--- a/src/features/github/github-issue-mutations.ts
+++ b/src/features/github/github-issue-mutations.ts
@@ -2,6 +2,7 @@ import type { QueryClient, QueryKey } from "@tanstack/react-query";
 import { invoke } from "@tauri-apps/api/core";
 import type {
   GitHubIssue,
+  GitHubIssueCloseReasonFilter,
   GitHubIssueCloseReason,
   GitHubIssueDetailPage,
   GitHubIssueInboxPage,
@@ -291,7 +292,7 @@ function updateRepositoryIssuePages(
       page.hasMore
     );
     const staleUpdatedPage =
-      cachedState === issue.state && queryKey[9] === "updated" && queryKey[10] !== 1;
+      cachedState === issue.state && queryKey[10] === "updated" && queryKey[11] !== 1;
     if (staleUpdatedPage) {
       queryClient.setQueryData<GitHubIssuePage>(queryKey, {
         ...page,
@@ -300,7 +301,7 @@ function updateRepositoryIssuePages(
       void queryClient.invalidateQueries({ queryKey, exact: true });
       continue;
     }
-    const moveToFront = queryKey[9] === "updated" && queryKey[10] === 1;
+    const moveToFront = queryKey[10] === "updated" && queryKey[11] === 1;
     queryClient.setQueryData<GitHubIssuePage>(
       queryKey,
       cachedState && cachedState !== issue.state
@@ -334,14 +335,16 @@ function repositoryIssuePageAccepts(queryKey: QueryKey, issue: GitHubIssue) {
   const assignment = queryKey[6];
   const query = queryKey[7];
   const label = queryKey[8];
-  const sort = queryKey[9];
-  const page = queryKey[10];
+  const closeReason = queryKey[9] as GitHubIssueCloseReasonFilter | null;
+  const sort = queryKey[10];
+  const page = queryKey[11];
   return (
     page === 1 &&
     sort === "updated" &&
     (assignment === "all" || (assignment === "unassigned" && !issue.assignees.length)) &&
     query === "" &&
-    (label === "" || issue.labels.some((item) => item.name === label))
+    (label === "" || issue.labels.some((item) => item.name === label)) &&
+    (closeReason === null || closeReason === issue.stateReason)
   );
 }
 

--- a/src/features/github/github-issue-view.interaction.test.tsx
+++ b/src/features/github/github-issue-view.interaction.test.tsx
@@ -6,6 +6,7 @@ import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { GitHubIssueView } from "./github-issue-view";
+import { githubQueryKeys } from "./github-queries";
 
 vi.mock("@tauri-apps/api/core", () => ({ invoke: vi.fn(), isTauri: () => false }));
 vi.mock("react-i18next", () => ({
@@ -29,13 +30,13 @@ const repository = {
 };
 
 function renderView() {
-  return render(
-    <QueryClientProvider
-      client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}
-    >
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const view = render(
+    <QueryClientProvider client={client}>
       <GitHubIssueView repository={repository} />
     </QueryClientProvider>
   );
+  return { ...view, client };
 }
 
 beforeAll(() => {
@@ -78,7 +79,9 @@ describe("GitHub Issue close-reason filter", () => {
     renderView();
 
     await user.click(screen.getByRole("tab", { name: "workspace.repositories.closedIssues" }));
-    const reasonTrigger = (await screen.findAllByRole("combobox"))[1];
+    const reasonTrigger = await screen.findByRole("combobox", {
+      name: "workspace.repositories.issueCloseReasonFilter",
+    });
     await user.click(reasonTrigger);
     await user.click(
       await screen.findByRole("option", {
@@ -103,20 +106,49 @@ describe("GitHub Issue close-reason filter", () => {
 
   it("clears the reason when returning to open Issues", async () => {
     const user = userEvent.setup();
-    renderView();
+    const { client } = renderView();
 
     await user.click(screen.getByRole("tab", { name: "workspace.repositories.closedIssues" }));
-    expect(
-      (await screen.findAllByText("workspace.repositories.allIssueCloseReasons"))[0]
-    ).toBeDefined();
+    const reasonTrigger = await screen.findByRole("combobox", {
+      name: "workspace.repositories.issueCloseReasonFilter",
+    });
+    await user.click(reasonTrigger);
+    await user.click(
+      await screen.findByRole("option", {
+        name: "workspace.repositories.issueCloseReasons.notPlanned",
+      })
+    );
+    await waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith(
+        "github_list_repository_issues",
+        expect.objectContaining({ closeReason: "notPlanned" })
+      );
+    });
+    vi.mocked(invoke).mockClear();
+    client.removeQueries({
+      queryKey: githubQueryKeys.issues({
+        owner: repository.owner,
+        repository: repository.name,
+        state: "open",
+        assignment: "all",
+        query: "",
+        label: "",
+        closeReason: null,
+        sort: "updated",
+        page: 1,
+      }),
+      exact: true,
+    });
     await user.click(screen.getByRole("tab", { name: "workspace.repositories.openIssues" }));
 
     await waitFor(() =>
       expect(screen.queryByText("workspace.repositories.allIssueCloseReasons")).toBeNull()
     );
-    expect(invoke).not.toHaveBeenCalledWith(
-      "github_list_repository_issues",
-      expect.objectContaining({ closeReason: "notPlanned" })
-    );
+    await waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith(
+        "github_list_repository_issues",
+        expect.not.objectContaining({ closeReason: expect.anything() })
+      );
+    });
   });
 });

--- a/src/features/github/github-issue-view.interaction.test.tsx
+++ b/src/features/github/github-issue-view.interaction.test.tsx
@@ -1,0 +1,122 @@
+// @vitest-environment jsdom
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { invoke } from "@tauri-apps/api/core";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { GitHubIssueView } from "./github-issue-view";
+
+vi.mock("@tauri-apps/api/core", () => ({ invoke: vi.fn(), isTauri: () => false }));
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: "en" } }),
+}));
+vi.mock("./github-pinned-issues", () => ({ GitHubPinnedIssues: () => null }));
+
+const repository = {
+  id: 1,
+  owner: "octocat",
+  name: "hello-world",
+  fullName: "octocat/hello-world",
+  url: "https://github.com/octocat/hello-world",
+  stars: 0,
+  forks: 0,
+  openIssues: 0,
+  defaultBranch: "main",
+  isPrivate: false,
+  isFork: false,
+  isArchived: false,
+};
+
+function renderView() {
+  return render(
+    <QueryClientProvider
+      client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}
+    >
+      <GitHubIssueView repository={repository} />
+    </QueryClientProvider>
+  );
+}
+
+beforeAll(() => {
+  class ResizeObserverMock implements ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  vi.stubGlobal("ResizeObserver", ResizeObserverMock);
+  HTMLElement.prototype.hasPointerCapture = () => false;
+  HTMLElement.prototype.setPointerCapture = () => {};
+  HTMLElement.prototype.releasePointerCapture = () => {};
+  HTMLElement.prototype.scrollIntoView = () => {};
+});
+
+beforeEach(() => {
+  vi.mocked(invoke).mockReset();
+  vi.mocked(invoke).mockImplementation((command) => {
+    if (command === "github_list_repository_issues") {
+      return Promise.resolve({
+        issues: [],
+        totalCount: 0,
+        page: 1,
+        hasPrevious: false,
+        hasMore: false,
+      });
+    }
+    if (command === "github_list_repository_issue_labels") {
+      return Promise.resolve({ labels: [] });
+    }
+    return Promise.reject(new Error(`unexpected command ${command}`));
+  });
+});
+
+afterEach(() => cleanup());
+
+describe("GitHub Issue close-reason filter", () => {
+  it("shows the filter for closed Issues and sends the selected reason", async () => {
+    const user = userEvent.setup();
+    renderView();
+
+    await user.click(screen.getByRole("tab", { name: "workspace.repositories.closedIssues" }));
+    const reasonTrigger = (await screen.findAllByRole("combobox"))[1];
+    await user.click(reasonTrigger);
+    await user.click(
+      await screen.findByRole("option", {
+        name: "workspace.repositories.issueCloseReasons.notPlanned",
+      })
+    );
+
+    await waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith("github_list_repository_issues", {
+        owner: "octocat",
+        repository: "hello-world",
+        issueState: "closed",
+        assignment: "all",
+        query: "",
+        label: "",
+        closeReason: "notPlanned",
+        sort: "updated",
+        page: 1,
+      });
+    });
+  });
+
+  it("clears the reason when returning to open Issues", async () => {
+    const user = userEvent.setup();
+    renderView();
+
+    await user.click(screen.getByRole("tab", { name: "workspace.repositories.closedIssues" }));
+    expect(
+      (await screen.findAllByText("workspace.repositories.allIssueCloseReasons"))[0]
+    ).toBeDefined();
+    await user.click(screen.getByRole("tab", { name: "workspace.repositories.openIssues" }));
+
+    await waitFor(() =>
+      expect(screen.queryByText("workspace.repositories.allIssueCloseReasons")).toBeNull()
+    );
+    expect(invoke).not.toHaveBeenCalledWith(
+      "github_list_repository_issues",
+      expect.objectContaining({ closeReason: "notPlanned" })
+    );
+  });
+});

--- a/src/features/github/github-issue-view.interaction.test.tsx
+++ b/src/features/github/github-issue-view.interaction.test.tsx
@@ -145,10 +145,12 @@ describe("GitHub Issue close-reason filter", () => {
       expect(screen.queryByText("workspace.repositories.allIssueCloseReasons")).toBeNull()
     );
     await waitFor(() => {
-      expect(invoke).toHaveBeenCalledWith(
-        "github_list_repository_issues",
-        expect.not.objectContaining({ closeReason: expect.anything() })
-      );
+      const issueRequests = vi
+        .mocked(invoke)
+        .mock.calls.filter(([command]) => command === "github_list_repository_issues")
+        .map(([, request]) => request as Record<string, unknown>);
+      expect(issueRequests.length).toBeGreaterThan(0);
+      expect(issueRequests[issueRequests.length - 1]).not.toHaveProperty("closeReason");
     });
   });
 });

--- a/src/features/github/github-issue-view.tsx
+++ b/src/features/github/github-issue-view.tsx
@@ -280,7 +280,11 @@ export function GitHubIssueView({ repository }: { repository: GitHubRepository }
                 )
               }
             >
-              <SelectTrigger size="sm" className="w-full min-w-0">
+              <SelectTrigger
+                size="sm"
+                className="w-full min-w-0"
+                aria-label={t("workspace.repositories.issueCloseReasonFilter")}
+              >
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>

--- a/src/features/github/github-issue-view.tsx
+++ b/src/features/github/github-issue-view.tsx
@@ -36,6 +36,7 @@ import { parseIpcError } from "@/lib/ipc-error";
 import { cn } from "@/lib/utils";
 import type {
   GitHubIssueAssignment,
+  GitHubIssueCloseReasonFilter,
   GitHubIssueSort,
   GitHubIssueState,
   GitHubRepository,
@@ -52,6 +53,7 @@ import {
 } from "./github-queries";
 
 const ALL_LABELS = "__all__";
+const ALL_CLOSE_REASONS = "__all_close_reasons__";
 
 const GitHubIssueTaxonomyView = lazy(() =>
   import("./github-issue-taxonomy-view").then((module) => ({
@@ -90,6 +92,7 @@ export function GitHubIssueView({ repository }: { repository: GitHubRepository }
   const [draftQuery, setDraftQuery] = useState("");
   const [query, setQuery] = useState("");
   const [label, setLabel] = useState("");
+  const [closeReason, setCloseReason] = useState<GitHubIssueCloseReasonFilter | null>(null);
   const [sort, setSort] = useState<GitHubIssueSort>("updated");
   const [page, setPage] = useState(1);
   const [selectedIssueNumber, setSelectedIssueNumber] = useState<number | null>(null);
@@ -103,6 +106,7 @@ export function GitHubIssueView({ repository }: { repository: GitHubRepository }
       assignment,
       query,
       label,
+      closeReason,
       sort,
       page,
     }),
@@ -126,6 +130,7 @@ export function GitHubIssueView({ repository }: { repository: GitHubRepository }
     setDraftQuery("");
     setQuery("");
     setLabel("");
+    setCloseReason(null);
     setSort("updated");
     setPage(1);
     setSelectedIssueNumber(null);
@@ -178,7 +183,12 @@ export function GitHubIssueView({ repository }: { repository: GitHubRepository }
         <div className="flex min-w-0 flex-wrap items-center justify-between gap-2">
           <Tabs
             value={state}
-            onValueChange={(value) => resetPage(() => setState(value as GitHubIssueState))}
+            onValueChange={(value) =>
+              resetPage(() => {
+                setState(value as GitHubIssueState);
+                if (value === "open") setCloseReason(null);
+              })
+            }
           >
             <TabsList className="h-8">
               <TabsTrigger value="open" className="text-xs">
@@ -212,7 +222,12 @@ export function GitHubIssueView({ repository }: { repository: GitHubRepository }
           </div>
         </div>
         <form
-          className="grid min-w-0 grid-cols-1 gap-2 @min-[480px]/issues:grid-cols-3 @min-[720px]/issues:grid-cols-[minmax(180px,1fr)_repeat(3,minmax(128px,144px))]"
+          className={cn(
+            "grid min-w-0 grid-cols-1 gap-2 @min-[480px]/issues:grid-cols-3",
+            state === "closed"
+              ? "@min-[720px]/issues:grid-cols-[minmax(180px,1fr)_repeat(4,minmax(128px,144px))]"
+              : "@min-[720px]/issues:grid-cols-[minmax(180px,1fr)_repeat(3,minmax(128px,144px))]"
+          )}
           onSubmit={(event) => {
             event.preventDefault();
             resetPage(() => setQuery(draftQuery.trim()));
@@ -254,6 +269,38 @@ export function GitHubIssueView({ repository }: { repository: GitHubRepository }
               </SelectGroup>
             </SelectContent>
           </Select>
+          {state === "closed" ? (
+            <Select
+              value={closeReason ?? ALL_CLOSE_REASONS}
+              onValueChange={(value) =>
+                resetPage(() =>
+                  setCloseReason(
+                    value === ALL_CLOSE_REASONS ? null : (value as GitHubIssueCloseReasonFilter)
+                  )
+                )
+              }
+            >
+              <SelectTrigger size="sm" className="w-full min-w-0">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectGroup>
+                  <SelectItem value={ALL_CLOSE_REASONS}>
+                    {t("workspace.repositories.allIssueCloseReasons")}
+                  </SelectItem>
+                  <SelectItem value="completed">
+                    {t("workspace.repositories.issueCloseReasons.completed")}
+                  </SelectItem>
+                  <SelectItem value="notPlanned">
+                    {t("workspace.repositories.issueCloseReasons.notPlanned")}
+                  </SelectItem>
+                  <SelectItem value="duplicate">
+                    {t("workspace.repositories.issueCloseReasons.duplicate")}
+                  </SelectItem>
+                </SelectGroup>
+              </SelectContent>
+            </Select>
+          ) : null}
           <Select
             value={label || ALL_LABELS}
             onValueChange={(value) => resetPage(() => setLabel(value === ALL_LABELS ? "" : value))}

--- a/src/features/github/github-queries.test.ts
+++ b/src/features/github/github-queries.test.ts
@@ -951,6 +951,7 @@ describe("GitHub repository queries", () => {
       label: "bug",
       sort: "comments",
       page: 3,
+      closeReason: "notPlanned",
     });
 
     await client.fetchQuery(options);
@@ -965,6 +966,7 @@ describe("GitHub repository queries", () => {
       "unassigned",
       "render crash",
       "bug",
+      "notPlanned",
       "comments",
       3,
     ]);
@@ -977,6 +979,7 @@ describe("GitHub repository queries", () => {
       label: "bug",
       sort: "comments",
       page: 3,
+      closeReason: "notPlanned",
     });
   });
 

--- a/src/features/github/github-queries.ts
+++ b/src/features/github/github-queries.ts
@@ -1629,9 +1629,9 @@ export function repositoryIssuesQueryOptions(target: GitHubIssuesTarget) {
         assignment: target.assignment,
         query: target.query,
         label: target.label,
-        closeReason: target.closeReason ?? null,
         sort: target.sort,
         page: target.page,
+        ...(target.closeReason ? { closeReason: target.closeReason } : {}),
       }),
     staleTime: GITHUB_QUERY_STALE_TIME,
   });

--- a/src/features/github/github-queries.ts
+++ b/src/features/github/github-queries.ts
@@ -30,6 +30,7 @@ import type {
   GitHubGistSource,
   GitHubIssueAssignment,
   GitHubIssueAssigneePage,
+  GitHubIssueCloseReasonFilter,
   GitHubIssueDetailPage,
   GitHubIssueInboxPage,
   GitHubIssueInboxScope,
@@ -206,6 +207,7 @@ export type GitHubIssuesTarget = GitHubRepositoryTarget & {
   query: string;
   label: string;
   sort: GitHubIssueSort;
+  closeReason?: GitHubIssueCloseReasonFilter | null;
   page: number;
 };
 
@@ -666,6 +668,7 @@ export const githubQueryKeys = {
     query,
     label,
     sort,
+    closeReason,
     page,
   }: GitHubIssuesTarget) =>
     [
@@ -678,6 +681,7 @@ export const githubQueryKeys = {
       assignment,
       query,
       label,
+      closeReason ?? null,
       sort,
       page,
     ] as const,
@@ -1625,6 +1629,7 @@ export function repositoryIssuesQueryOptions(target: GitHubIssuesTarget) {
         assignment: target.assignment,
         query: target.query,
         label: target.label,
+        closeReason: target.closeReason ?? null,
         sort: target.sort,
         page: target.page,
       }),

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2578,6 +2578,12 @@
         "notPlanned": "Closed as not planned",
         "duplicate": "Closed as duplicate"
       },
+      "allIssueCloseReasons": "All close reasons",
+      "issueCloseReasons": {
+        "completed": "Completed",
+        "notPlanned": "Not planned",
+        "duplicate": "Duplicate"
+      },
       "allDiscussionCategories": "All categories",
       "discussionCount": "{{count}} discussions",
       "openDiscussions": "Open discussions",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2579,6 +2579,7 @@
         "duplicate": "Closed as duplicate"
       },
       "allIssueCloseReasons": "All close reasons",
+      "issueCloseReasonFilter": "Issue close reason",
       "issueCloseReasons": {
         "completed": "Completed",
         "notPlanned": "Not planned",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -2572,6 +2572,7 @@
         "duplicate": "已按重复 Issue 关闭"
       },
       "allIssueCloseReasons": "全部关闭理由",
+      "issueCloseReasonFilter": "Issue 关闭理由",
       "issueCloseReasons": {
         "completed": "已完成",
         "notPlanned": "不计划处理",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -2571,6 +2571,12 @@
         "notPlanned": "已按不计划处理关闭",
         "duplicate": "已按重复 Issue 关闭"
       },
+      "allIssueCloseReasons": "全部关闭理由",
+      "issueCloseReasons": {
+        "completed": "已完成",
+        "notPlanned": "不计划处理",
+        "duplicate": "重复 Issue"
+      },
       "allDiscussionCategories": "全部分类",
       "discussionCount": "{{count}} 条讨论",
       "openDiscussions": "开放的讨论",


### PR DESCRIPTION
## Summary
- add a closed-Issue close-reason filter for completed, not planned, and duplicate Issues
- map the filter through the existing GitHub Search API and Tauri query/cache contracts
- add English/Simplified Chinese labels plus Rust, query, UI, and cache regression tests

## Scope
- read-only repository Issue workflow; no new OAuth scopes or write/admin APIs
- close-reason selection is available only on the closed Issues tab

## Verification
- `pnpm check`
- `cargo test --manifest-path src-tauri/Cargo.toml --lib`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `cargo clippy --manifest-path src-tauri/Cargo.toml --lib` (existing warnings only)
- `cargo fmt --manifest-path src-tauri/Cargo.toml --check`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added close-reason filtering for closed GitHub issues.
  * Choose Completed, Not planned, or Duplicate reasons.
  * Filters reset when switching repositories or returning to open issues.
  * Added English and Chinese translations for the new filter options.

* **Bug Fixes**
  * Close-reason filters are now restricted to closed issues.
  * Improved issue synchronization so results match the selected reason.
  * Pagination and filtering update correctly when selections change.
  * Updated issue counts and cached results when close reasons change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->