### PR TITLE
feat: filter repository issues by milestone

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1552,6 +1552,7 @@ pub async fn github_list_repository_issues(
     assignment: GitHubIssueAssignment,
     query: String,
     label: String,
+    milestone: Option<String>,
     sort: GitHubIssueSort,
     close_reason: Option<GitHubIssueCloseReasonFilter>,
     page: u32,
@@ -1564,6 +1565,7 @@ pub async fn github_list_repository_issues(
         assignment,
         query: validate_issue_query(query)?,
         label: validate_issue_label(label)?,
+        milestone: validate_issue_milestone(milestone)?,
         sort,
         page: validate_issue_page(page)?,
         close_reason,
@@ -5146,6 +5148,22 @@ fn validate_issue_label(label: String) -> Result<String, AppError> {
     Ok(label)
 }
 
+fn validate_issue_milestone(milestone: Option<String>) -> Result<Option<String>, AppError> {
+    let Some(milestone) = milestone else {
+        return Ok(None);
+    };
+    let milestone = milestone.trim().to_string();
+    if milestone.is_empty() {
+        return Ok(None);
+    }
+    if milestone.chars().count() > 256 || milestone.chars().any(char::is_control) {
+        return Err(AppError::Validation(
+            "issue milestone is invalid".to_string(),
+        ));
+    }
+    Ok(Some(milestone))
+}
+
 fn validate_issue_title(title: String) -> Result<String, AppError> {
     let title = title.trim().to_string();
     if title.is_empty() || title.chars().any(char::is_control) {
@@ -5801,6 +5819,20 @@ mod tests {
             validate_issue_label("  good first issue  ".to_string()).expect("label"),
             "good first issue"
         );
+        assert_eq!(
+            validate_issue_milestone(Some("  Harbor 0.2  ".to_string())).expect("milestone"),
+            Some("Harbor 0.2".to_string())
+        );
+        assert_eq!(
+            validate_issue_milestone(Some("  ".to_string())).expect("empty milestone"),
+            None
+        );
+        assert_eq!(
+            validate_issue_milestone(Some("里".repeat(256))).expect("unicode milestone"),
+            Some("里".repeat(256))
+        );
+        assert!(validate_issue_milestone(Some("里".repeat(257))).is_err());
+        assert!(validate_issue_milestone(Some("bad\nname".to_string())).is_err());
         assert!(validate_page(0).is_err());
         assert!(validate_page(1_001).is_err());
         assert_eq!(validate_issue_page(34).expect("last search page"), 34);

--- a/src-tauri/src/github.rs
+++ b/src-tauri/src/github.rs
@@ -2857,6 +2857,7 @@ mod tests {
             assignment: GitHubIssueAssignment::All,
             query: String::new(),
             label: String::new(),
+            milestone: None,
             sort: GitHubIssueSort::Updated,
             page: 1,
             close_reason: None,

--- a/src-tauri/src/github/issue.rs
+++ b/src-tauri/src/github/issue.rs
@@ -88,6 +88,7 @@ pub struct GitHubIssueFilters {
     pub assignment: GitHubIssueAssignment,
     pub query: String,
     pub label: String,
+    pub milestone: Option<String>,
     pub sort: GitHubIssueSort,
     pub page: u32,
     pub close_reason: Option<GitHubIssueCloseReasonFilter>,
@@ -696,6 +697,10 @@ fn issue_search_query(owner: &str, repository: &str, filters: &GitHubIssueFilter
     if !filters.label.is_empty() {
         let label = filters.label.replace('\\', "\\\\").replace('"', "\\\"");
         query.push(format!("label:\"{label}\""));
+    }
+    if let Some(milestone) = &filters.milestone {
+        let milestone = milestone.replace('\\', "\\\\").replace('"', "\\\"");
+        query.push(format!("milestone:\"{milestone}\""));
     }
     if let Some(reason) = filters.close_reason {
         query.push(reason.search_qualifier().to_string());

--- a/src-tauri/src/github/issue/tests.rs
+++ b/src-tauri/src/github/issue/tests.rs
@@ -67,6 +67,7 @@ impl GitHubIssueClient for super::super::tests::FakeGitHubClient {
                     assignment: GitHubIssueAssignment::All,
                     query: filters.query.clone(),
                     label: String::new(),
+                    milestone: None,
                     sort: filters.sort,
                     page: filters.page,
                     close_reason: None,
@@ -168,6 +169,7 @@ impl GitHubIssueClient for super::super::tests::FakeGitHubClient {
                     assignment: GitHubIssueAssignment::All,
                     query: String::new(),
                     label: String::new(),
+                    milestone: None,
                     sort: GitHubIssueSort::Updated,
                     page: 1,
                     close_reason: None,
@@ -333,6 +335,7 @@ fn issue_search_is_scoped_to_real_issues_and_selected_filters() {
         assignment: GitHubIssueAssignment::Unassigned,
         query: "render crash".to_string(),
         label: "help wanted".to_string(),
+        milestone: Some("Harbor 0.2".to_string()),
         sort: GitHubIssueSort::Comments,
         page: 3,
         close_reason: None,
@@ -340,7 +343,26 @@ fn issue_search_is_scoped_to_real_issues_and_selected_filters() {
 
     assert_eq!(
         issue_search_query("octocat", "hello-world", &filters),
-        "render crash repo:octocat/hello-world is:issue is:closed no:assignee label:\"help wanted\""
+        "render crash repo:octocat/hello-world is:issue is:closed no:assignee label:\"help wanted\" milestone:\"Harbor 0.2\""
+    );
+}
+
+#[test]
+fn issue_search_escapes_milestone_titles() {
+    let filters = GitHubIssueFilters {
+        state: GitHubIssueState::Open,
+        assignment: GitHubIssueAssignment::All,
+        query: String::new(),
+        label: String::new(),
+        milestone: Some("Roadmap \\\"2026\\\"".to_string()),
+        sort: GitHubIssueSort::Updated,
+        page: 1,
+        close_reason: None,
+    };
+
+    assert_eq!(
+        issue_search_query("octocat", "hello-world", &filters),
+        "repo:octocat/hello-world is:issue is:open milestone:\"Roadmap \\\\\\\"2026\\\\\\\"\""
     );
 }
 
@@ -351,6 +373,7 @@ fn issue_search_filters_closed_issues_by_the_selected_reason() {
         assignment: GitHubIssueAssignment::All,
         query: String::new(),
         label: String::new(),
+        milestone: None,
         sort: GitHubIssueSort::Updated,
         page: 1,
         close_reason: Some(GitHubIssueCloseReasonFilter::NotPlanned),
@@ -379,6 +402,7 @@ fn issue_search_uses_github_reason_qualifiers_for_each_close_reason() {
             assignment: GitHubIssueAssignment::All,
             query: String::new(),
             label: String::new(),
+            milestone: None,
             sort: GitHubIssueSort::Updated,
             page: 1,
             close_reason: Some(close_reason),
@@ -394,6 +418,7 @@ fn issue_search_removes_scope_changing_user_qualifiers() {
         assignment: GitHubIssueAssignment::All,
         query: "repo:another/project crash".to_string(),
         label: String::new(),
+        milestone: None,
         sort: GitHubIssueSort::Updated,
         page: 1,
         close_reason: None,

--- a/src/features/github/github-issue-mutations.test.ts
+++ b/src/features/github/github-issue-mutations.test.ts
@@ -665,6 +665,57 @@ describe("GitHub Issue mutations", () => {
     ]);
   });
 
+  it("moves an Issue between milestone caches when its milestone changes", () => {
+    const queryClient = new QueryClient();
+    const previousMilestoneKey = githubQueryKeys.issues({
+      owner: target.owner,
+      repository: target.repository,
+      state: "open",
+      assignment: "all",
+      query: "",
+      label: "",
+      milestone: "Harbor 0.2",
+      sort: "updated",
+      page: 1,
+    });
+    const nextMilestoneKey = githubQueryKeys.issues({
+      owner: target.owner,
+      repository: target.repository,
+      state: "open",
+      assignment: "all",
+      query: "",
+      label: "",
+      milestone: "Harbor 0.3",
+      sort: "updated",
+      page: 1,
+    });
+    const previousIssue = { ...issue, milestone: "Harbor 0.2" };
+    const nextIssue = { ...previousIssue, milestone: "Harbor 0.3" };
+    queryClient.setQueryData<GitHubIssuePage>(previousMilestoneKey, {
+      issues: [previousIssue],
+      totalCount: 1,
+      page: 1,
+      hasPrevious: false,
+      hasMore: false,
+    });
+    queryClient.setQueryData<GitHubIssuePage>(nextMilestoneKey, {
+      issues: [],
+      totalCount: 0,
+      page: 1,
+      hasPrevious: false,
+      hasMore: false,
+    });
+
+    syncUpdatedIssue(queryClient, target, nextIssue);
+
+    expect(queryClient.getQueryData<GitHubIssuePage>(previousMilestoneKey)?.issues).toEqual([]);
+    expect(queryClient.getQueryData<GitHubIssuePage>(previousMilestoneKey)?.totalCount).toBe(0);
+    expect(queryClient.getQueryState(previousMilestoneKey)?.isInvalidated).toBe(true);
+    expect(queryClient.getQueryData<GitHubIssuePage>(nextMilestoneKey)?.issues).toEqual([
+      nextIssue,
+    ]);
+  });
+
   it("invalidates only Issue detail, list, and inbox roots", async () => {
     const queryClient = new QueryClient();
     const affected = [

--- a/src/features/github/github-issue-mutations.ts
+++ b/src/features/github/github-issue-mutations.ts
@@ -16,6 +16,7 @@ import type {
 import { githubQueryKeys } from "./github-queries";
 
 const GITHUB_ISSUE_PAGE_SIZE = 30;
+const REPOSITORY_ISSUE_MILESTONE_QUERY_KEY_INDEX = 12;
 
 function reconcileUpdatedPageItems<T>(
   items: T[],
@@ -278,9 +279,14 @@ function updateRepositoryIssuePages(
     const matches = page.issues.filter((item) => item.number === target.issueNumber);
     const cachedState = issueStateFromQueryKey(queryKey);
     const closeReasonMatches = repositoryIssueCloseReasonMatches(queryKey, issue);
+    const milestoneMatches = repositoryIssueMilestoneMatches(queryKey, issue);
     const exactDestination = repositoryIssuePageAccepts(queryKey, issue);
     const shouldInsert = !matches.length && cachedState === issue.state && exactDestination;
-    if (matches.length && cachedState === issue.state && !closeReasonMatches) {
+    if (
+      matches.length &&
+      cachedState === issue.state &&
+      (!closeReasonMatches || !milestoneMatches)
+    ) {
       queryClient.setQueryData<GitHubIssuePage>(queryKey, {
         ...page,
         issues: page.issues.filter((item) => item.number !== target.issueNumber),
@@ -353,13 +359,22 @@ function repositoryIssuePageAccepts(queryKey: QueryKey, issue: GitHubIssue) {
     (assignment === "all" || (assignment === "unassigned" && !issue.assignees.length)) &&
     query === "" &&
     (label === "" || issue.labels.some((item) => item.name === label)) &&
-    repositoryIssueCloseReasonMatches(queryKey, issue)
+    repositoryIssueCloseReasonMatches(queryKey, issue) &&
+    repositoryIssueMilestoneMatches(queryKey, issue)
   );
 }
 
 function repositoryIssueCloseReasonMatches(queryKey: QueryKey, issue: GitHubIssue) {
   const closeReason = queryKey[9] as GitHubIssueCloseReasonFilter | null | undefined;
   return closeReason === null || closeReason === undefined || closeReason === issue.stateReason;
+}
+
+function repositoryIssueMilestoneMatches(queryKey: QueryKey, issue: GitHubIssue) {
+  const milestone = queryKey[REPOSITORY_ISSUE_MILESTONE_QUERY_KEY_INDEX] as
+    | string
+    | null
+    | undefined;
+  return milestone === null || milestone === undefined || milestone === issue.milestone;
 }
 
 function matchesIssueSummary(summary: GitHubIssueSummary, target: GitHubIssueMutationTarget) {

--- a/src/features/github/github-issue-view.interaction.test.tsx
+++ b/src/features/github/github-issue-view.interaction.test.tsx
@@ -67,6 +67,26 @@ beforeEach(() => {
     if (command === "github_list_repository_issue_labels") {
       return Promise.resolve({ labels: [] });
     }
+    if (command === "github_list_repository_issue_milestones") {
+      return Promise.resolve({
+        milestones: [
+          {
+            number: 3,
+            title: "Harbor 0.2",
+            state: "open",
+            openIssues: 4,
+            closedIssues: 7,
+          },
+          {
+            number: 4,
+            title: "__all_milestones__",
+            state: "open",
+            openIssues: 1,
+            closedIssues: 0,
+          },
+        ],
+      });
+    }
     return Promise.reject(new Error(`unexpected command ${command}`));
   });
 });
@@ -151,6 +171,119 @@ describe("GitHub Issue close-reason filter", () => {
         .map(([, request]) => request as Record<string, unknown>);
       expect(issueRequests.length).toBeGreaterThan(0);
       expect(issueRequests[issueRequests.length - 1]).not.toHaveProperty("closeReason");
+    });
+  });
+});
+
+describe("GitHub Issue milestone filter", () => {
+  it("keeps the filter disabled while milestones load and exposes the empty state", async () => {
+    let resolveMilestones!: (value: { milestones: never[] }) => void;
+    const milestonesPromise = new Promise<{ milestones: never[] }>((resolve) => {
+      resolveMilestones = resolve;
+    });
+    vi.mocked(invoke).mockImplementation((command) => {
+      if (command === "github_list_repository_issues") {
+        return Promise.resolve({
+          issues: [],
+          totalCount: 0,
+          page: 1,
+          hasPrevious: false,
+          hasMore: false,
+        });
+      }
+      if (command === "github_list_repository_issue_labels") {
+        return Promise.resolve({ labels: [] });
+      }
+      if (command === "github_list_repository_issue_milestones") return milestonesPromise;
+      return Promise.reject(new Error(`unexpected command ${command}`));
+    });
+
+    renderView();
+    const milestoneTrigger = await screen.findByRole("combobox", {
+      name: "workspace.repositories.issueMilestoneFilter",
+    });
+    expect((milestoneTrigger as HTMLButtonElement).disabled).toBe(true);
+
+    resolveMilestones({ milestones: [] });
+    await waitFor(() => expect((milestoneTrigger as HTMLButtonElement).disabled).toBe(false));
+    await userEvent.setup().click(milestoneTrigger);
+    expect(
+      await screen.findByRole("option", { name: "workspace.repositories.allIssueMilestones" })
+    ).toBeDefined();
+  });
+
+  it("shows a permission error and retries the milestone query", async () => {
+    let milestoneAttempts = 0;
+    vi.mocked(invoke).mockImplementation((command) => {
+      if (command === "github_list_repository_issues") {
+        return Promise.resolve({
+          issues: [],
+          totalCount: 0,
+          page: 1,
+          hasPrevious: false,
+          hasMore: false,
+        });
+      }
+      if (command === "github_list_repository_issue_labels") {
+        return Promise.resolve({ labels: [] });
+      }
+      if (command === "github_list_repository_issue_milestones") {
+        milestoneAttempts += 1;
+        return milestoneAttempts === 1
+          ? Promise.reject({ code: "githubPermission", message: "milestone permission changed" })
+          : Promise.resolve({ milestones: [] });
+      }
+      return Promise.reject(new Error(`unexpected command ${command}`));
+    });
+
+    const user = userEvent.setup();
+    renderView();
+    expect(await screen.findByText("milestone permission changed")).toBeDefined();
+    await user.click(screen.getByRole("button", { name: "workspace.repositories.retry" }));
+    await waitFor(() => expect(milestoneAttempts).toBe(2));
+    await waitFor(() => expect(screen.queryByText("milestone permission changed")).toBeNull());
+  });
+
+  it("loads repository milestones and sends the selected title", async () => {
+    const user = userEvent.setup();
+    renderView();
+
+    const milestoneTrigger = await screen.findByRole("combobox", {
+      name: "workspace.repositories.issueMilestoneFilter",
+    });
+    await user.click(milestoneTrigger);
+    await user.click(await screen.findByRole("option", { name: "Harbor 0.2" }));
+
+    await waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith("github_list_repository_issues", {
+        owner: "octocat",
+        repository: "hello-world",
+        issueState: "open",
+        assignment: "all",
+        query: "",
+        label: "",
+        milestone: "Harbor 0.2",
+        sort: "updated",
+        page: 1,
+      });
+    });
+  });
+
+  it("can select a milestone whose title matches the clear sentinel", async () => {
+    const user = userEvent.setup();
+    renderView();
+
+    const milestoneTrigger = await screen.findByRole("combobox", {
+      name: "workspace.repositories.issueMilestoneFilter",
+    });
+    await user.click(milestoneTrigger);
+    await user.click(await screen.findByRole("option", { name: "__all_milestones__" }));
+
+    await waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith(
+        "github_list_repository_issues",
+        expect.objectContaining({ milestone: "__all_milestones__" })
+      );
     });
   });
 });

--- a/src/features/github/github-issue-view.tsx
+++ b/src/features/github/github-issue-view.tsx
@@ -49,11 +49,13 @@ import { GitHubPinnedIssues } from "./github-pinned-issues";
 import {
   repositoryIssueDetailQueryOptions,
   repositoryIssueLabelsQueryOptions,
+  repositoryIssueMilestonesQueryOptions,
   repositoryIssuesQueryOptions,
 } from "./github-queries";
 
 const ALL_LABELS = "__all__";
 const ALL_CLOSE_REASONS = "__all_close_reasons__";
+const ALL_MILESTONES = "__all_milestones__";
 
 const GitHubIssueTaxonomyView = lazy(() =>
   import("./github-issue-taxonomy-view").then((module) => ({
@@ -92,6 +94,7 @@ export function GitHubIssueView({ repository }: { repository: GitHubRepository }
   const [draftQuery, setDraftQuery] = useState("");
   const [query, setQuery] = useState("");
   const [label, setLabel] = useState("");
+  const [milestone, setMilestone] = useState<string | null>(null);
   const [closeReason, setCloseReason] = useState<GitHubIssueCloseReasonFilter | null>(null);
   const [sort, setSort] = useState<GitHubIssueSort>("updated");
   const [page, setPage] = useState(1);
@@ -106,6 +109,7 @@ export function GitHubIssueView({ repository }: { repository: GitHubRepository }
       assignment,
       query,
       label,
+      milestone,
       closeReason,
       sort,
       page,
@@ -115,6 +119,15 @@ export function GitHubIssueView({ repository }: { repository: GitHubRepository }
   const labelsResult = useQuery(
     repositoryIssueLabelsQueryOptions({ owner: repository.owner, repository: repository.name })
   );
+  const milestonesResult = useQuery(
+    repositoryIssueMilestonesQueryOptions({
+      owner: repository.owner,
+      repository: repository.name,
+    })
+  );
+  const selectedMilestoneNumber = milestonesResult.data?.milestones.find(
+    (item) => item.title === milestone
+  )?.number;
   const issuePage = issuesResult.data;
   const error = !issuePage && issuesResult.error ? parseIpcError(issuesResult.error) : null;
   const supplementalError =
@@ -122,7 +135,9 @@ export function GitHubIssueView({ repository }: { repository: GitHubRepository }
       ? { source: "issues" as const, error: parseIpcError(issuesResult.error) }
       : labelsResult.error
         ? { source: "labels" as const, error: parseIpcError(labelsResult.error) }
-        : null;
+        : milestonesResult.error
+          ? { source: "milestones" as const, error: parseIpcError(milestonesResult.error) }
+          : null;
 
   useEffect(() => {
     setState("open");
@@ -130,6 +145,7 @@ export function GitHubIssueView({ repository }: { repository: GitHubRepository }
     setDraftQuery("");
     setQuery("");
     setLabel("");
+    setMilestone(null);
     setCloseReason(null);
     setSort("updated");
     setPage(1);
@@ -137,6 +153,17 @@ export function GitHubIssueView({ repository }: { repository: GitHubRepository }
     setCreatingIssue(false);
     setManagingTaxonomy(false);
   }, [repository.id]);
+
+  useEffect(() => {
+    if (
+      milestone &&
+      milestonesResult.data &&
+      !milestonesResult.data.milestones.some((item) => item.title === milestone)
+    ) {
+      setMilestone(null);
+      setPage(1);
+    }
+  }, [milestone, milestonesResult.data]);
 
   if (managingTaxonomy) {
     return (
@@ -225,8 +252,8 @@ export function GitHubIssueView({ repository }: { repository: GitHubRepository }
           className={cn(
             "grid min-w-0 grid-cols-1 gap-2 @min-[480px]/issues:grid-cols-3",
             state === "closed"
-              ? "@min-[720px]/issues:grid-cols-[minmax(180px,1fr)_repeat(4,minmax(128px,144px))]"
-              : "@min-[720px]/issues:grid-cols-[minmax(180px,1fr)_repeat(3,minmax(128px,144px))]"
+              ? "@min-[720px]/issues:grid-cols-[minmax(180px,1fr)_repeat(5,minmax(128px,144px))]"
+              : "@min-[720px]/issues:grid-cols-[minmax(180px,1fr)_repeat(4,minmax(128px,144px))]"
           )}
           onSubmit={(event) => {
             event.preventDefault();
@@ -266,6 +293,41 @@ export function GitHubIssueView({ repository }: { repository: GitHubRepository }
                 <SelectItem value="unassigned">
                   {t("workspace.repositories.unassignedIssues")}
                 </SelectItem>
+              </SelectGroup>
+            </SelectContent>
+          </Select>
+          <Select
+            value={selectedMilestoneNumber?.toString() ?? ALL_MILESTONES}
+            onValueChange={(value) =>
+              resetPage(() =>
+                setMilestone(
+                  value === ALL_MILESTONES
+                    ? null
+                    : (milestonesResult.data?.milestones.find(
+                        (item) => item.number.toString() === value
+                      )?.title ?? null)
+                )
+              )
+            }
+          >
+            <SelectTrigger
+              size="sm"
+              className="w-full min-w-0"
+              aria-label={t("workspace.repositories.issueMilestoneFilter")}
+              disabled={milestonesResult.isPending}
+            >
+              <SelectValue placeholder={t("workspace.repositories.allIssueMilestones")} />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectGroup>
+                <SelectItem value={ALL_MILESTONES}>
+                  {t("workspace.repositories.allIssueMilestones")}
+                </SelectItem>
+                {(milestonesResult.data?.milestones ?? []).map((item) => (
+                  <SelectItem key={item.number} value={item.number.toString()}>
+                    {item.title}
+                  </SelectItem>
+                ))}
               </SelectGroup>
             </SelectContent>
           </Select>
@@ -352,7 +414,9 @@ export function GitHubIssueView({ repository }: { repository: GitHubRepository }
               onClick={() =>
                 void (supplementalError.source === "issues"
                   ? issuesResult.refetch()
-                  : labelsResult.refetch())
+                  : supplementalError.source === "labels"
+                    ? labelsResult.refetch()
+                    : milestonesResult.refetch())
               }
             >
               {t("workspace.repositories.retry")}

--- a/src/features/github/github-queries.test.ts
+++ b/src/features/github/github-queries.test.ts
@@ -949,6 +949,7 @@ describe("GitHub repository queries", () => {
       assignment: "unassigned",
       query: "render crash",
       label: "bug",
+      milestone: "Harbor 0.2",
       sort: "comments",
       page: 3,
       closeReason: "notPlanned",
@@ -969,6 +970,7 @@ describe("GitHub repository queries", () => {
       "notPlanned",
       "comments",
       3,
+      "Harbor 0.2",
     ]);
     expect(invoke).toHaveBeenCalledWith("github_list_repository_issues", {
       owner: "octocat",
@@ -977,6 +979,7 @@ describe("GitHub repository queries", () => {
       assignment: "unassigned",
       query: "render crash",
       label: "bug",
+      milestone: "Harbor 0.2",
       sort: "comments",
       page: 3,
       closeReason: "notPlanned",

--- a/src/features/github/github-queries.ts
+++ b/src/features/github/github-queries.ts
@@ -206,6 +206,7 @@ export type GitHubIssuesTarget = GitHubRepositoryTarget & {
   assignment: GitHubIssueAssignment;
   query: string;
   label: string;
+  milestone?: string | null;
   sort: GitHubIssueSort;
   closeReason?: GitHubIssueCloseReasonFilter | null;
   page: number;
@@ -667,6 +668,7 @@ export const githubQueryKeys = {
     assignment,
     query,
     label,
+    milestone,
     sort,
     closeReason,
     page,
@@ -684,6 +686,7 @@ export const githubQueryKeys = {
       closeReason ?? null,
       sort,
       page,
+      milestone ?? null,
     ] as const,
   issuesRoot: ({ owner, repository }: GitHubRepositoryTarget) =>
     ["github", "repository", owner, repository, "issues"] as const,
@@ -1629,6 +1632,7 @@ export function repositoryIssuesQueryOptions(target: GitHubIssuesTarget) {
         assignment: target.assignment,
         query: target.query,
         label: target.label,
+        ...(target.milestone ? { milestone: target.milestone } : {}),
         sort: target.sort,
         page: target.page,
         ...(target.closeReason ? { closeReason: target.closeReason } : {}),

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2585,6 +2585,8 @@
         "notPlanned": "Not planned",
         "duplicate": "Duplicate"
       },
+      "allIssueMilestones": "All milestones",
+      "issueMilestoneFilter": "Issue milestone",
       "allDiscussionCategories": "All categories",
       "discussionCount": "{{count}} discussions",
       "openDiscussions": "Open discussions",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -2578,6 +2578,8 @@
         "notPlanned": "不计划处理",
         "duplicate": "重复 Issue"
       },
+      "allIssueMilestones": "全部里程碑",
+      "issueMilestoneFilter": "Issue 里程碑",
       "allDiscussionCategories": "全部分类",
       "discussionCount": "{{count}} 条讨论",
       "openDiscussions": "开放的讨论",


### PR DESCRIPTION
## Summary
- add a native repository Issue milestone filter using the existing milestone query
- scope search with a bounded, escaped milestone title and preserve cache synchronization
- add localized UI, interaction/query/backend tests, and milestone cache migration coverage

## Verification
- `pnpm check`
- `cargo test --manifest-path src-tauri/Cargo.toml --lib`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `cargo clippy --manifest-path src-tauri/Cargo.toml --lib` (15 existing warnings)
- `cargo fmt --manifest-path src-tauri/Cargo.toml --check`
- `git diff --check`

Closes no issue; this is a bounded read-only GitHub Web parity slice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added milestone filtering to GitHub issue lists.
  * Added a milestone selector with loading, empty-state, error, and retry handling.
  * Added English and Chinese labels for milestone filtering.
  * Issue results and counts now update correctly when milestones change.

* **Bug Fixes**
  * Improved handling of milestone names containing special characters.
  * Invalid milestone selections are cleared when available milestone data changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->