### PR TITLE
feat: filter repository issues by type

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -34,11 +34,12 @@ use crate::{
         GitHubIssuePage, GitHubIssueRelationshipsPage, GitHubIssueSort, GitHubIssueState,
         GitHubIssueStateCapabilities, GitHubIssueStateMutation, GitHubIssueSubIssueCreateInput,
         GitHubIssueSubIssuePriorityInput, GitHubIssueSummary, GitHubIssueTimelineItem,
-        GitHubIssueTrackingDirection, GitHubIssueTrackingPage, GitHubIssueTypeStatus,
-        GitHubLoginAvailability, GitHubNotificationAction, GitHubNotificationPage, GitHubPackage,
-        GitHubPackagePage, GitHubPackageType, GitHubPackageVersionMutationInput,
-        GitHubPackageVersionMutationResult, GitHubPackageVersionPage, GitHubPackageVersionState,
-        GitHubPackageVisibility, GitHubPagesHealth, GitHubPagesMutation, GitHubPagesWorkspace,
+        GitHubIssueTrackingDirection, GitHubIssueTrackingPage, GitHubIssueType,
+        GitHubIssueTypeStatus, GitHubLoginAvailability, GitHubNotificationAction,
+        GitHubNotificationPage, GitHubPackage, GitHubPackagePage, GitHubPackageType,
+        GitHubPackageVersionMutationInput, GitHubPackageVersionMutationResult,
+        GitHubPackageVersionPage, GitHubPackageVersionState, GitHubPackageVisibility,
+        GitHubPagesHealth, GitHubPagesMutation, GitHubPagesWorkspace,
         GitHubPendingPullRequestReview, GitHubProfileActivityPage, GitHubProfileConnectionKind,
         GitHubProjectDetail, GitHubProjectFilters, GitHubProjectItem, GitHubProjectItemAction,
         GitHubProjectItemAddition, GitHubProjectItemFilters, GitHubProjectItemUpdate,
@@ -1554,6 +1555,7 @@ pub async fn github_list_repository_issues(
     label: String,
     milestone: Option<String>,
     linked_pull_request: Option<bool>,
+    issue_type: Option<String>,
     sort: GitHubIssueSort,
     close_reason: Option<GitHubIssueCloseReasonFilter>,
     page: u32,
@@ -1568,6 +1570,7 @@ pub async fn github_list_repository_issues(
         label: validate_issue_label(label)?,
         milestone: validate_issue_milestone(milestone)?,
         linked_pull_request: linked_pull_request.unwrap_or(false),
+        issue_type: validate_issue_type_filter(issue_type)?,
         sort,
         page: validate_issue_page(page)?,
         close_reason,
@@ -2436,6 +2439,19 @@ pub async fn github_update_repository_issue_metadata(
             &assignees,
             milestone_number,
         )
+        .await
+}
+
+#[tauri::command]
+pub async fn github_list_repository_issue_types(
+    owner: String,
+    repository: String,
+    state: State<'_, AppState>,
+) -> Result<Vec<GitHubIssueType>, AppError> {
+    let repository = RepositoryRef::new(owner, repository)?;
+    state
+        .github
+        .issue_types(repository.owner(), repository.name())
         .await
 }
 
@@ -5166,6 +5182,20 @@ fn validate_issue_milestone(milestone: Option<String>) -> Result<Option<String>,
     Ok(Some(milestone))
 }
 
+fn validate_issue_type_filter(issue_type: Option<String>) -> Result<Option<String>, AppError> {
+    let Some(issue_type) = issue_type else {
+        return Ok(None);
+    };
+    let issue_type = issue_type.trim().to_string();
+    if issue_type.is_empty() {
+        return Ok(None);
+    }
+    if issue_type.chars().count() > 256 || issue_type.chars().any(char::is_control) {
+        return Err(AppError::Validation("issue type is invalid".to_string()));
+    }
+    Ok(Some(issue_type))
+}
+
 fn validate_issue_title(title: String) -> Result<String, AppError> {
     let title = title.trim().to_string();
     if title.is_empty() || title.chars().any(char::is_control) {
@@ -5835,6 +5865,15 @@ mod tests {
         );
         assert!(validate_issue_milestone(Some("里".repeat(257))).is_err());
         assert!(validate_issue_milestone(Some("bad\nname".to_string())).is_err());
+        assert_eq!(
+            validate_issue_type_filter(Some("  Bug  ".to_string())).expect("issue type"),
+            Some("Bug".to_string())
+        );
+        assert_eq!(
+            validate_issue_type_filter(Some("  ".to_string())).expect("empty type"),
+            None
+        );
+        assert!(validate_issue_type_filter(Some("bad\nname".to_string())).is_err());
         assert!(validate_page(0).is_err());
         assert!(validate_page(1_001).is_err());
         assert_eq!(validate_issue_page(34).expect("last search page"), 34);

--- a/src-tauri/src/github.rs
+++ b/src-tauri/src/github.rs
@@ -132,8 +132,8 @@ pub use issue_taxonomy::{GitHubIssueLabelMutation, GitHubIssueMilestoneMutation}
 pub use issue_tracking::{GitHubIssueTrackingDirection, GitHubIssueTrackingPage};
 pub(crate) use issue_transfer::IssueTransferMutation;
 pub use issue_transfer::{GitHubIssueTransfer, GitHubIssueTransferStatus};
-pub use issue_type::GitHubIssueTypeStatus;
 pub(crate) use issue_type::IssueTypeMutation;
+pub use issue_type::{GitHubIssueType, GitHubIssueTypeStatus};
 pub use notification::{GitHubNotificationAction, GitHubNotificationPage};
 #[cfg(test)]
 use packages::GitHubPackageVersionAction;
@@ -2859,6 +2859,7 @@ mod tests {
             label: String::new(),
             milestone: None,
             linked_pull_request: false,
+            issue_type: None,
             sort: GitHubIssueSort::Updated,
             page: 1,
             close_reason: None,

--- a/src-tauri/src/github/issue.rs
+++ b/src-tauri/src/github/issue.rs
@@ -90,6 +90,7 @@ pub struct GitHubIssueFilters {
     pub label: String,
     pub milestone: Option<String>,
     pub linked_pull_request: bool,
+    pub issue_type: Option<String>,
     pub sort: GitHubIssueSort,
     pub page: u32,
     pub close_reason: Option<GitHubIssueCloseReasonFilter>,
@@ -705,6 +706,10 @@ fn issue_search_query(owner: &str, repository: &str, filters: &GitHubIssueFilter
     }
     if filters.linked_pull_request {
         query.push("linked:pr".to_string());
+    }
+    if let Some(issue_type) = &filters.issue_type {
+        let issue_type = issue_type.replace('\\', "\\\\").replace('"', "\\\"");
+        query.push(format!("type:\"{issue_type}\""));
     }
     if let Some(reason) = filters.close_reason {
         query.push(reason.search_qualifier().to_string());

--- a/src-tauri/src/github/issue/tests.rs
+++ b/src-tauri/src/github/issue/tests.rs
@@ -69,6 +69,7 @@ impl GitHubIssueClient for super::super::tests::FakeGitHubClient {
                     label: String::new(),
                     milestone: None,
                     linked_pull_request: false,
+                    issue_type: None,
                     sort: filters.sort,
                     page: filters.page,
                     close_reason: None,
@@ -172,6 +173,7 @@ impl GitHubIssueClient for super::super::tests::FakeGitHubClient {
                     label: String::new(),
                     milestone: None,
                     linked_pull_request: false,
+                    issue_type: None,
                     sort: GitHubIssueSort::Updated,
                     page: 1,
                     close_reason: None,
@@ -339,6 +341,7 @@ fn issue_search_is_scoped_to_real_issues_and_selected_filters() {
         label: "help wanted".to_string(),
         milestone: Some("Harbor 0.2".to_string()),
         linked_pull_request: true,
+        issue_type: Some("Bug \"next\"".to_string()),
         sort: GitHubIssueSort::Comments,
         page: 3,
         close_reason: None,
@@ -346,7 +349,7 @@ fn issue_search_is_scoped_to_real_issues_and_selected_filters() {
 
     assert_eq!(
         issue_search_query("octocat", "hello-world", &filters),
-        "render crash repo:octocat/hello-world is:issue is:closed no:assignee label:\"help wanted\" milestone:\"Harbor 0.2\" linked:pr"
+        "render crash repo:octocat/hello-world is:issue is:closed no:assignee label:\"help wanted\" milestone:\"Harbor 0.2\" linked:pr type:\"Bug \\\"next\\\"\""
     );
 }
 
@@ -359,6 +362,7 @@ fn issue_search_escapes_milestone_titles() {
         label: String::new(),
         milestone: Some("Roadmap \\\"2026\\\"".to_string()),
         linked_pull_request: false,
+        issue_type: None,
         sort: GitHubIssueSort::Updated,
         page: 1,
         close_reason: None,
@@ -379,6 +383,7 @@ fn issue_search_filters_closed_issues_by_the_selected_reason() {
         label: String::new(),
         milestone: None,
         linked_pull_request: false,
+        issue_type: None,
         sort: GitHubIssueSort::Updated,
         page: 1,
         close_reason: Some(GitHubIssueCloseReasonFilter::NotPlanned),
@@ -409,6 +414,7 @@ fn issue_search_uses_github_reason_qualifiers_for_each_close_reason() {
             label: String::new(),
             milestone: None,
             linked_pull_request: false,
+            issue_type: None,
             sort: GitHubIssueSort::Updated,
             page: 1,
             close_reason: Some(close_reason),
@@ -426,6 +432,7 @@ fn issue_search_removes_scope_changing_user_qualifiers() {
         label: String::new(),
         milestone: None,
         linked_pull_request: false,
+        issue_type: None,
         sort: GitHubIssueSort::Updated,
         page: 1,
         close_reason: None,

--- a/src-tauri/src/github/issue_type.rs
+++ b/src-tauri/src/github/issue_type.rs
@@ -5,7 +5,7 @@ use octocrab::FromResponse;
 use serde::{Deserialize, Serialize};
 
 use super::{
-    authenticated_client, github_error,
+    authenticated_client, github_error, is_not_found,
     issue_related::{api_request, graphql_node_id_is_valid},
     GitHubService, OctocrabGitHubClient,
 };
@@ -86,6 +86,13 @@ pub(crate) struct IssueTypeMutation<'a> {
 
 #[async_trait]
 pub(crate) trait GitHubIssueTypeClient: Send + Sync {
+    async fn issue_types(
+        &self,
+        token: &str,
+        owner: &str,
+        repository: &str,
+    ) -> Result<Vec<GitHubIssueType>, AppError>;
+
     async fn issue_type_status(
         &self,
         token: &str,
@@ -102,6 +109,15 @@ pub(crate) trait GitHubIssueTypeClient: Send + Sync {
 }
 
 impl GitHubService {
+    pub async fn issue_types(
+        &self,
+        owner: &str,
+        repository: &str,
+    ) -> Result<Vec<GitHubIssueType>, AppError> {
+        let token = self.load_access_token().await?;
+        self.client.issue_types(&token, owner, repository).await
+    }
+
     pub async fn issue_type_status(
         &self,
         owner: &str,
@@ -125,6 +141,16 @@ impl GitHubService {
 
 #[async_trait]
 impl GitHubIssueTypeClient for OctocrabGitHubClient {
+    async fn issue_types(
+        &self,
+        token: &str,
+        owner: &str,
+        repository: &str,
+    ) -> Result<Vec<GitHubIssueType>, AppError> {
+        let client = authenticated_client(token)?;
+        load_issue_types_with_client(&client, owner, repository).await
+    }
+
     async fn issue_type_status(
         &self,
         token: &str,
@@ -220,9 +246,11 @@ async fn load_issue_types_with_client(
         .replace("{repository}", repository);
     let request = api_request(client, route)?;
     let response = client.execute(request).await.map_err(github_error)?;
-    let response = octocrab::map_github_error(response)
-        .await
-        .map_err(github_error)?;
+    let response = match octocrab::map_github_error(response).await {
+        Ok(response) => response,
+        Err(error) if is_not_found(&error) => return Ok(Vec::new()),
+        Err(error) => return Err(github_error(error)),
+    };
     let values = serde_json::Value::from_response(response)
         .await
         .map_err(|error| {

--- a/src-tauri/src/github/issue_type/tests.rs
+++ b/src-tauri/src/github/issue_type/tests.rs
@@ -4,6 +4,17 @@ use crate::github::issue_related::test_support::{assert_rest_request, mock_githu
 
 #[async_trait::async_trait]
 impl GitHubIssueTypeClient for super::super::tests::FakeGitHubClient {
+    async fn issue_types(
+        &self,
+        token: &str,
+        owner: &str,
+        repository: &str,
+    ) -> Result<Vec<GitHubIssueType>, AppError> {
+        assert_eq!(token, "github-user-access-token");
+        assert_eq!((owner, repository), ("octocat", "hello-world"));
+        Ok(status(None, true).available_issue_types)
+    }
+
     async fn issue_type_status(
         &self,
         token: &str,
@@ -304,6 +315,26 @@ async fn transport_updates_type_and_confirms_the_postflight_state() {
     assert!(requests[2].contains("HarborUpdateIssueType"));
     assert!(requests[3].contains("HarborIssueTypeStatus"));
     assert_rest_request(&requests[4], "/repos/octocat/hello-world/issue-types");
+}
+
+#[tokio::test]
+async fn missing_issue_type_catalog_is_empty_for_personal_repositories() {
+    let (client, requests, server) = mock_github(vec![MockResponse {
+        status: "404 Not Found",
+        headers: vec![],
+        body: serde_json::json!({"message": "Not Found"}).to_string(),
+    }])
+    .await;
+
+    let types = load_issue_types_with_client(&client, "octocat", "hello-world")
+        .await
+        .expect("unsupported issue types are empty");
+    assert!(types.is_empty());
+    server.await.expect("mock server");
+
+    let requests = requests.lock().expect("requests");
+    assert_eq!(requests.len(), 1);
+    assert_rest_request(&requests[0], "/repos/octocat/hello-world/issue-types");
 }
 
 #[tokio::test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -165,6 +165,7 @@ pub fn run() {
             commands::github_clone_repository_issue,
             commands::github_update_repository_issue,
             commands::github_update_repository_issue_metadata,
+            commands::github_list_repository_issue_types,
             commands::github_get_repository_issue_type_status,
             commands::github_update_repository_issue_type,
             commands::github_create_repository_issue_comment,

--- a/src/features/github/github-issue-mutations.test.ts
+++ b/src/features/github/github-issue-mutations.test.ts
@@ -744,6 +744,33 @@ describe("GitHub Issue mutations", () => {
     expect(queryClient.getQueryState(linkedListKey)?.isInvalidated).toBe(true);
   });
 
+  it("invalidates Issue-type caches when an Issue changes", () => {
+    const queryClient = new QueryClient();
+    const typeListKey = githubQueryKeys.issues({
+      owner: target.owner,
+      repository: target.repository,
+      state: "open",
+      assignment: "all",
+      query: "",
+      label: "",
+      issueType: "Bug",
+      sort: "updated",
+      page: 1,
+    });
+    queryClient.setQueryData<GitHubIssuePage>(typeListKey, {
+      issues: [issue],
+      totalCount: 1,
+      page: 1,
+      hasPrevious: false,
+      hasMore: false,
+    });
+
+    syncUpdatedIssue(queryClient, target, { ...issue, title: "Updated title" });
+
+    expect(queryClient.getQueryData<GitHubIssuePage>(typeListKey)?.issues).toEqual([issue]);
+    expect(queryClient.getQueryState(typeListKey)?.isInvalidated).toBe(true);
+  });
+
   it("invalidates only Issue detail, list, and inbox roots", async () => {
     const queryClient = new QueryClient();
     const affected = [

--- a/src/features/github/github-issue-mutations.ts
+++ b/src/features/github/github-issue-mutations.ts
@@ -25,6 +25,7 @@ const REPOSITORY_ISSUE_QUERY_KEY_INDEX = {
   page: 11,
   milestone: 12,
   linkedPullRequest: 13,
+  issueType: 14,
 } as const;
 
 function reconcileUpdatedPageItems<T>(
@@ -290,9 +291,14 @@ function updateRepositoryIssuePages(
     const closeReasonMatches = repositoryIssueCloseReasonMatches(queryKey, issue);
     const milestoneMatches = repositoryIssueMilestoneMatches(queryKey, issue);
     const linkedPullRequestFilter = repositoryIssueLinkedPullRequestEnabled(queryKey);
+    const issueTypeFilter = repositoryIssueTypeEnabled(queryKey);
     const exactDestination = repositoryIssuePageAccepts(queryKey, issue);
     const shouldInsert = !matches.length && cachedState === issue.state && exactDestination;
-    if (matches.length && cachedState === issue.state && linkedPullRequestFilter) {
+    if (
+      matches.length &&
+      cachedState === issue.state &&
+      (linkedPullRequestFilter || issueTypeFilter)
+    ) {
       void queryClient.invalidateQueries({ queryKey, exact: true });
       continue;
     }
@@ -379,7 +385,8 @@ function repositoryIssuePageAccepts(queryKey: QueryKey, issue: GitHubIssue) {
     (label === "" || issue.labels.some((item) => item.name === label)) &&
     repositoryIssueCloseReasonMatches(queryKey, issue) &&
     repositoryIssueMilestoneMatches(queryKey, issue) &&
-    !repositoryIssueLinkedPullRequestEnabled(queryKey)
+    !repositoryIssueLinkedPullRequestEnabled(queryKey) &&
+    !repositoryIssueTypeEnabled(queryKey)
   );
 }
 
@@ -401,6 +408,11 @@ function repositoryIssueMilestoneMatches(queryKey: QueryKey, issue: GitHubIssue)
 
 function repositoryIssueLinkedPullRequestEnabled(queryKey: QueryKey) {
   return queryKey[REPOSITORY_ISSUE_QUERY_KEY_INDEX.linkedPullRequest] === true;
+}
+
+function repositoryIssueTypeEnabled(queryKey: QueryKey) {
+  const issueType = queryKey[REPOSITORY_ISSUE_QUERY_KEY_INDEX.issueType];
+  return typeof issueType === "string" && issueType.length > 0;
 }
 
 function matchesIssueSummary(summary: GitHubIssueSummary, target: GitHubIssueMutationTarget) {

--- a/src/features/github/github-issue-type-action.interaction.test.tsx
+++ b/src/features/github/github-issue-type-action.interaction.test.tsx
@@ -128,6 +128,9 @@ describe("GitHub Issue type action", () => {
       expect(invalidateQueries).toHaveBeenCalledWith({
         queryKey: ["github", "repository", "octocat", "hello-world", "issue", 7, "issue-type"],
       });
+      expect(invalidateQueries).toHaveBeenCalledWith({
+        queryKey: ["github", "repository", "octocat", "hello-world", "issues"],
+      });
     });
     expect(
       vi

--- a/src/features/github/github-issue-type-mutations.ts
+++ b/src/features/github/github-issue-type-mutations.ts
@@ -34,5 +34,6 @@ export async function invalidateRepositoryIssueType(
   await Promise.all([
     queryClient.invalidateQueries({ queryKey: githubQueryKeys.issueTypeStatus(target) }),
     queryClient.invalidateQueries({ queryKey: githubQueryKeys.issueRoot(target) }),
+    queryClient.invalidateQueries({ queryKey: githubQueryKeys.issuesRoot(target) }),
   ]);
 }

--- a/src/features/github/github-issue-view.interaction.test.tsx
+++ b/src/features/github/github-issue-view.interaction.test.tsx
@@ -87,6 +87,11 @@ beforeEach(() => {
         ],
       });
     }
+    if (command === "github_list_repository_issue_types") {
+      return Promise.resolve([
+        { id: 410, nodeId: "IT_bug", name: "Bug", description: "An unexpected problem" },
+      ]);
+    }
     return Promise.reject(new Error(`unexpected command ${command}`));
   });
 });
@@ -195,6 +200,7 @@ describe("GitHub Issue milestone filter", () => {
         return Promise.resolve({ labels: [] });
       }
       if (command === "github_list_repository_issue_milestones") return milestonesPromise;
+      if (command === "github_list_repository_issue_types") return Promise.resolve([]);
       return Promise.reject(new Error(`unexpected command ${command}`));
     });
 
@@ -233,6 +239,7 @@ describe("GitHub Issue milestone filter", () => {
           ? Promise.reject({ code: "githubPermission", message: "milestone permission changed" })
           : Promise.resolve({ milestones: [] });
       }
+      if (command === "github_list_repository_issue_types") return Promise.resolve([]);
       return Promise.reject(new Error(`unexpected command ${command}`));
     });
 
@@ -310,6 +317,33 @@ describe("GitHub Issue linked pull request filter", () => {
         query: "",
         label: "",
         linkedPullRequest: true,
+        sort: "updated",
+        page: 1,
+      });
+    });
+  });
+});
+
+describe("GitHub Issue type filter", () => {
+  it("loads repository Issue types and sends the selected name", async () => {
+    const user = userEvent.setup();
+    renderView();
+
+    const typeTrigger = await screen.findByRole("combobox", {
+      name: "workspace.repositories.issueTypeFilter",
+    });
+    await user.click(typeTrigger);
+    await user.click(await screen.findByRole("option", { name: "Bug" }));
+
+    await waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith("github_list_repository_issues", {
+        owner: "octocat",
+        repository: "hello-world",
+        issueState: "open",
+        assignment: "all",
+        query: "",
+        label: "",
+        issueType: "Bug",
         sort: "updated",
         page: 1,
       });

--- a/src/features/github/github-issue-view.tsx
+++ b/src/features/github/github-issue-view.tsx
@@ -50,6 +50,7 @@ import {
   repositoryIssueDetailQueryOptions,
   repositoryIssueLabelsQueryOptions,
   repositoryIssueMilestonesQueryOptions,
+  repositoryIssueTypesQueryOptions,
   repositoryIssuesQueryOptions,
 } from "./github-queries";
 
@@ -57,6 +58,7 @@ const ALL_LABELS = "__all__";
 const ALL_CLOSE_REASONS = "__all_close_reasons__";
 const ALL_MILESTONES = "__all_milestones__";
 const ALL_LINKED_PULL_REQUESTS = "__all_linked_pull_requests__";
+const ALL_ISSUE_TYPES = "__all_issue_types__";
 
 const GitHubIssueTaxonomyView = lazy(() =>
   import("./github-issue-taxonomy-view").then((module) => ({
@@ -97,6 +99,7 @@ export function GitHubIssueView({ repository }: { repository: GitHubRepository }
   const [label, setLabel] = useState("");
   const [milestone, setMilestone] = useState<string | null>(null);
   const [linkedPullRequest, setLinkedPullRequest] = useState(false);
+  const [issueType, setIssueType] = useState<string | null>(null);
   const [closeReason, setCloseReason] = useState<GitHubIssueCloseReasonFilter | null>(null);
   const [sort, setSort] = useState<GitHubIssueSort>("updated");
   const [page, setPage] = useState(1);
@@ -113,6 +116,7 @@ export function GitHubIssueView({ repository }: { repository: GitHubRepository }
       label,
       milestone,
       linkedPullRequest,
+      issueType,
       closeReason,
       sort,
       page,
@@ -128,6 +132,12 @@ export function GitHubIssueView({ repository }: { repository: GitHubRepository }
       repository: repository.name,
     })
   );
+  const issueTypesResult = useQuery(
+    repositoryIssueTypesQueryOptions({ owner: repository.owner, repository: repository.name })
+  );
+  const selectedIssueTypeNodeId = issueTypesResult.data?.find(
+    (item) => item.name === issueType
+  )?.nodeId;
   const selectedMilestoneNumber = milestonesResult.data?.milestones.find(
     (item) => item.title === milestone
   )?.number;
@@ -140,7 +150,9 @@ export function GitHubIssueView({ repository }: { repository: GitHubRepository }
         ? { source: "labels" as const, error: parseIpcError(labelsResult.error) }
         : milestonesResult.error
           ? { source: "milestones" as const, error: parseIpcError(milestonesResult.error) }
-          : null;
+          : issueTypesResult.error
+            ? { source: "issueTypes" as const, error: parseIpcError(issueTypesResult.error) }
+            : null;
 
   useEffect(() => {
     setState("open");
@@ -150,6 +162,7 @@ export function GitHubIssueView({ repository }: { repository: GitHubRepository }
     setLabel("");
     setMilestone(null);
     setLinkedPullRequest(false);
+    setIssueType(null);
     setCloseReason(null);
     setSort("updated");
     setPage(1);
@@ -157,6 +170,17 @@ export function GitHubIssueView({ repository }: { repository: GitHubRepository }
     setCreatingIssue(false);
     setManagingTaxonomy(false);
   }, [repository.id]);
+
+  useEffect(() => {
+    if (
+      issueType &&
+      issueTypesResult.data &&
+      !issueTypesResult.data.some((item) => item.name === issueType)
+    ) {
+      setIssueType(null);
+      setPage(1);
+    }
+  }, [issueType, issueTypesResult.data]);
 
   useEffect(() => {
     if (
@@ -256,8 +280,8 @@ export function GitHubIssueView({ repository }: { repository: GitHubRepository }
           className={cn(
             "grid min-w-0 grid-cols-1 gap-2 @min-[480px]/issues:grid-cols-3",
             state === "closed"
-              ? "@min-[1040px]/issues:grid-cols-[minmax(180px,1fr)_repeat(6,minmax(128px,144px))]"
-              : "@min-[900px]/issues:grid-cols-[minmax(180px,1fr)_repeat(5,minmax(128px,144px))]"
+              ? "@min-[1180px]/issues:grid-cols-[minmax(180px,1fr)_repeat(7,minmax(128px,144px))]"
+              : "@min-[1040px]/issues:grid-cols-[minmax(180px,1fr)_repeat(6,minmax(128px,144px))]"
           )}
           onSubmit={(event) => {
             event.preventDefault();
@@ -297,6 +321,39 @@ export function GitHubIssueView({ repository }: { repository: GitHubRepository }
                 <SelectItem value="unassigned">
                   {t("workspace.repositories.unassignedIssues")}
                 </SelectItem>
+              </SelectGroup>
+            </SelectContent>
+          </Select>
+          <Select
+            value={selectedIssueTypeNodeId ?? ALL_ISSUE_TYPES}
+            onValueChange={(value) =>
+              resetPage(() =>
+                setIssueType(
+                  value === ALL_ISSUE_TYPES
+                    ? null
+                    : (issueTypesResult.data?.find((item) => item.nodeId === value)?.name ?? null)
+                )
+              )
+            }
+          >
+            <SelectTrigger
+              size="sm"
+              className="w-full min-w-0"
+              aria-label={t("workspace.repositories.issueTypeFilter")}
+              disabled={issueTypesResult.isPending}
+            >
+              <SelectValue placeholder={t("workspace.repositories.allIssueTypes")} />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectGroup>
+                <SelectItem value={ALL_ISSUE_TYPES}>
+                  {t("workspace.repositories.allIssueTypes")}
+                </SelectItem>
+                {(issueTypesResult.data ?? []).map((item) => (
+                  <SelectItem key={item.nodeId} value={item.nodeId}>
+                    {item.name}
+                  </SelectItem>
+                ))}
               </SelectGroup>
             </SelectContent>
           </Select>
@@ -442,7 +499,9 @@ export function GitHubIssueView({ repository }: { repository: GitHubRepository }
                   ? issuesResult.refetch()
                   : supplementalError.source === "labels"
                     ? labelsResult.refetch()
-                    : milestonesResult.refetch())
+                    : supplementalError.source === "milestones"
+                      ? milestonesResult.refetch()
+                      : issueTypesResult.refetch())
               }
             >
               {t("workspace.repositories.retry")}

--- a/src/features/github/github-queries.test.ts
+++ b/src/features/github/github-queries.test.ts
@@ -25,6 +25,7 @@ import {
   repositoryIssueAssigneesQueryOptions,
   repositoryIssueLabelsQueryOptions,
   repositoryIssueMilestonesQueryOptions,
+  repositoryIssueTypesQueryOptions,
   repositoryInsightsContributorsQueryOptions,
   repositoryInsightsOverviewQueryOptions,
   repositoryInsightsTrafficQueryOptions,
@@ -951,6 +952,7 @@ describe("GitHub repository queries", () => {
       label: "bug",
       milestone: "Harbor 0.2",
       linkedPullRequest: true,
+      issueType: "Bug",
       sort: "comments",
       page: 3,
       closeReason: "notPlanned",
@@ -973,6 +975,7 @@ describe("GitHub repository queries", () => {
       3,
       "Harbor 0.2",
       true,
+      "Bug",
     ]);
     expect(invoke).toHaveBeenCalledWith("github_list_repository_issues", {
       owner: "octocat",
@@ -983,6 +986,7 @@ describe("GitHub repository queries", () => {
       label: "bug",
       milestone: "Harbor 0.2",
       linkedPullRequest: true,
+      issueType: "Bug",
       sort: "comments",
       page: 3,
       closeReason: "notPlanned",
@@ -1091,20 +1095,26 @@ describe("GitHub repository queries", () => {
     vi.mocked(invoke)
       .mockResolvedValueOnce({ labels: [] })
       .mockResolvedValueOnce({ assignees: [] })
-      .mockResolvedValueOnce({ milestones: [] });
+      .mockResolvedValueOnce({ milestones: [] })
+      .mockResolvedValueOnce([]);
     const target = { owner: "octocat", repository: "hello-world" };
     const labels = repositoryIssueLabelsQueryOptions(target);
     const assignees = repositoryIssueAssigneesQueryOptions(target);
     const milestones = repositoryIssueMilestonesQueryOptions(target);
+    const types = repositoryIssueTypesQueryOptions(target);
 
     await client.fetchQuery(labels);
     await client.fetchQuery(assignees);
     await client.fetchQuery(milestones);
+    await client.fetchQuery(types);
 
     expect(invoke).toHaveBeenNthCalledWith(1, "github_list_repository_issue_labels", target);
     expect(invoke).toHaveBeenNthCalledWith(2, "github_list_repository_issue_assignees", target);
     expect(invoke).toHaveBeenNthCalledWith(3, "github_list_repository_issue_milestones", target);
-    expect(new Set([labels.queryKey, assignees.queryKey, milestones.queryKey]).size).toBe(3);
+    expect(invoke).toHaveBeenNthCalledWith(4, "github_list_repository_issue_types", target);
+    expect(
+      new Set([labels.queryKey, assignees.queryKey, milestones.queryKey, types.queryKey]).size
+    ).toBe(4);
   });
 
   it("keys and invokes pull request pages with repository filters", async () => {

--- a/src/features/github/github-queries.ts
+++ b/src/features/github/github-queries.ts
@@ -39,6 +39,7 @@ import type {
   GitHubIssuePage,
   GitHubIssueSort,
   GitHubIssueState,
+  GitHubIssueType,
   GitHubIssueTypeStatus,
   GitHubInsightsTrafficPeriod,
   GitHubNotificationPage,
@@ -208,6 +209,7 @@ export type GitHubIssuesTarget = GitHubRepositoryTarget & {
   label: string;
   milestone?: string | null;
   linkedPullRequest?: boolean;
+  issueType?: string | null;
   sort: GitHubIssueSort;
   closeReason?: GitHubIssueCloseReasonFilter | null;
   page: number;
@@ -671,6 +673,7 @@ export const githubQueryKeys = {
     label,
     milestone,
     linkedPullRequest,
+    issueType,
     sort,
     closeReason,
     page,
@@ -690,6 +693,7 @@ export const githubQueryKeys = {
       page,
       milestone ?? null,
       linkedPullRequest ?? false,
+      issueType ?? null,
     ] as const,
   issuesRoot: ({ owner, repository }: GitHubRepositoryTarget) =>
     ["github", "repository", owner, repository, "issues"] as const,
@@ -730,6 +734,8 @@ export const githubQueryKeys = {
     ["github", "repository", owner, repository, "issue-assignees"] as const,
   issueMilestones: ({ owner, repository }: GitHubRepositoryTarget) =>
     ["github", "repository", owner, repository, "issue-milestones"] as const,
+  issueTypes: ({ owner, repository }: GitHubRepositoryTarget) =>
+    ["github", "repository", owner, repository, "issue-types"] as const,
   issueTypeStatus: ({ owner, repository, issueNumber }: GitHubIssueTypeTarget) =>
     ["github", "repository", owner, repository, "issue", issueNumber, "issue-type"] as const,
   pullRequests: ({
@@ -1637,6 +1643,7 @@ export function repositoryIssuesQueryOptions(target: GitHubIssuesTarget) {
         label: target.label,
         ...(target.milestone ? { milestone: target.milestone } : {}),
         ...(target.linkedPullRequest ? { linkedPullRequest: true } : {}),
+        ...(target.issueType ? { issueType: target.issueType } : {}),
         sort: target.sort,
         page: target.page,
         ...(target.closeReason ? { closeReason: target.closeReason } : {}),
@@ -1810,6 +1817,18 @@ export function repositoryIssueTypeStatusQueryOptions(target: GitHubIssueTypeTar
         issueNumber: target.issueNumber,
       }),
     staleTime: GITHUB_QUERY_STALE_TIME,
+  });
+}
+
+export function repositoryIssueTypesQueryOptions(target: GitHubRepositoryTarget) {
+  return queryOptions({
+    queryKey: githubQueryKeys.issueTypes(target),
+    queryFn: () =>
+      invoke<GitHubIssueType[]>("github_list_repository_issue_types", {
+        owner: target.owner,
+        repository: target.repository,
+      }),
+    staleTime: 5 * GITHUB_QUERY_STALE_TIME,
   });
 }
 

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2336,6 +2336,8 @@
       "labels": "Labels",
       "milestone": "Milestone",
       "issueType": "Issue type",
+      "issueTypeFilter": "Issue type",
+      "allIssueTypes": "All Issue types",
       "noIssueType": "No type",
       "issueTypeLoadFailed": "Harbor could not load Issue types",
       "issueTypeUpdateFailed": "Harbor could not update the Issue type",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -2329,6 +2329,8 @@
       "labels": "标签",
       "milestone": "里程碑",
       "issueType": "Issue 类型",
+      "issueTypeFilter": "Issue 类型",
+      "allIssueTypes": "全部 Issue 类型",
       "noIssueType": "不设置类型",
       "issueTypeLoadFailed": "Issue 类型没有加载成功",
       "issueTypeUpdateFailed": "Issue 类型没有更新成功",


### PR DESCRIPTION
## Summary
- expose the repository Issue type catalog through the existing personal GitHub service boundary
- add the `type:"…"` Issue search qualifier with bounded, escaped input
- add a localized Issue type filter to the repository Issues view
- invalidate Issue lists when an Issue type mutation changes membership

## Verification
- `pnpm check`
- `cargo test --manifest-path src-tauri/Cargo.toml --lib`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`
- `cargo clippy --manifest-path src-tauri/Cargo.toml --lib` (existing warnings only)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added GitHub issue-type filtering to repository issue lists.
  - Added an issue-type selector with repository-provided options, including “All issue types.”
  - Added English and Chinese translations for the filtering controls.

- **Bug Fixes**
  - Updated issue and issue-type changes to refresh affected repository issue lists.
  - Improved handling of invalid selections and repositories without available issue types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->