### PR TITLE
feat: add pull request linked issue filter

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2594,6 +2594,7 @@ pub async fn github_list_repository_pull_requests(
     merge: Option<GitHubPullRequestMergeFilter>,
     status: Option<GitHubPullRequestStatusFilter>,
     draft: Option<GitHubPullRequestDraftFilter>,
+    linked_issue: Option<bool>,
     sort: GitHubPullRequestSort,
     page: u32,
     state: State<'_, AppState>,
@@ -2607,6 +2608,7 @@ pub async fn github_list_repository_pull_requests(
         merge,
         status,
         draft,
+        linked_issue: linked_issue.unwrap_or(false),
         sort,
         page: validate_issue_page(page)?,
     };

--- a/src-tauri/src/github.rs
+++ b/src-tauri/src/github.rs
@@ -376,6 +376,7 @@ pub struct GitHubPullRequestFilters {
     pub merge: Option<GitHubPullRequestMergeFilter>,
     pub status: Option<GitHubPullRequestStatusFilter>,
     pub draft: Option<GitHubPullRequestDraftFilter>,
+    pub linked_issue: bool,
     pub sort: GitHubPullRequestSort,
     pub page: u32,
 }
@@ -1892,7 +1893,12 @@ fn pull_request_search_query(
         GitHubPullRequestState::Closed => "closed",
     };
     let mut query = vec![
-        pull_request_search_terms(&filters.query, filters.review, filters.draft),
+        pull_request_search_terms(
+            &filters.query,
+            filters.review,
+            filters.draft,
+            filters.linked_issue,
+        ),
         format!("repo:{owner}/{repository}"),
         "is:pr".to_string(),
         format!("is:{state}"),
@@ -1912,6 +1918,9 @@ fn pull_request_search_query(
     }
     if let Some(draft) = filters.draft {
         query.push(draft.search_qualifier().to_string());
+    }
+    if filters.linked_issue {
+        query.push("linked:issue".to_string());
     }
     query
         .into_iter()
@@ -1976,6 +1985,7 @@ fn pull_request_search_terms(
     query: &str,
     selected_review: Option<GitHubPullRequestReviewFilter>,
     selected_draft: Option<GitHubPullRequestDraftFilter>,
+    selected_linked_issue: bool,
 ) -> String {
     query
         .split_whitespace()
@@ -1985,7 +1995,8 @@ fn pull_request_search_terms(
                 .iter()
                 .any(|prefix| term.starts_with(prefix))
                 || selected_review.is_some() && term.starts_with("review:")
-                || selected_draft.is_some() && term.starts_with("is:draft"))
+                || selected_draft.is_some() && term.starts_with("is:draft")
+                || selected_linked_issue && term.starts_with("linked:"))
         })
         .collect::<Vec<_>>()
         .join(" ")
@@ -4293,6 +4304,7 @@ mod tests {
             merge: Some(GitHubPullRequestMergeFilter::Merged),
             status: Some(GitHubPullRequestStatusFilter::Success),
             draft: None,
+            linked_issue: false,
             sort: GitHubPullRequestSort::Updated,
             page: 1,
         };
@@ -4306,7 +4318,7 @@ mod tests {
     #[test]
     fn pull_request_review_filters_use_github_search_values() {
         assert_eq!(
-            pull_request_search_terms("review:approved crash", None, None),
+            pull_request_search_terms("review:approved crash", None, None, false),
             "review:approved crash"
         );
         assert_eq!(
@@ -4342,14 +4354,15 @@ mod tests {
             "is:draft"
         );
         assert_eq!(
-            pull_request_search_terms("is:draft -is:draft crash", None, None),
+            pull_request_search_terms("is:draft -is:draft crash", None, None, false),
             "crash"
         );
         assert_eq!(
             pull_request_search_terms(
                 "is:draft -is:draft crash",
                 None,
-                Some(GitHubPullRequestDraftFilter::Draft)
+                Some(GitHubPullRequestDraftFilter::Draft),
+                false,
             ),
             "crash"
         );
@@ -4365,6 +4378,7 @@ mod tests {
             merge: None,
             status: None,
             draft: Some(GitHubPullRequestDraftFilter::Draft),
+            linked_issue: false,
             sort: GitHubPullRequestSort::Updated,
             page: 1,
         };
@@ -4372,6 +4386,27 @@ mod tests {
         assert_eq!(
             pull_request_search_query("octocat", "hello-world", &filters),
             "crash repo:octocat/hello-world is:pr is:open is:draft"
+        );
+    }
+
+    #[test]
+    fn selected_pull_request_linked_issue_filter_owns_the_linked_qualifier() {
+        let filters = GitHubPullRequestFilters {
+            state: GitHubPullRequestState::Open,
+            query: "linked:issue -linked:issue crash".to_string(),
+            label: String::new(),
+            review: None,
+            merge: None,
+            status: None,
+            draft: None,
+            linked_issue: true,
+            sort: GitHubPullRequestSort::Updated,
+            page: 1,
+        };
+
+        assert_eq!(
+            pull_request_search_query("octocat", "hello-world", &filters),
+            "crash repo:octocat/hello-world is:pr is:open linked:issue"
         );
     }
 
@@ -4417,6 +4452,7 @@ mod tests {
             merge: Some(GitHubPullRequestMergeFilter::Unmerged),
             status: None,
             draft: None,
+            linked_issue: false,
             sort: GitHubPullRequestSort::Updated,
             page: 1,
         };

--- a/src/features/github/github-pull-request-view.interaction.test.tsx
+++ b/src/features/github/github-pull-request-view.interaction.test.tsx
@@ -62,6 +62,39 @@ beforeEach(() => {
 afterEach(() => cleanup());
 
 describe("GitHub Pull Request list filters", () => {
+  it("sends the linked-to-Issue filter", async () => {
+    const user = userEvent.setup();
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    render(
+      <QueryClientProvider client={client}>
+        <GitHubPullRequestView repository={repository} />
+      </QueryClientProvider>
+    );
+
+    const linkedIssueTrigger = await screen.findByRole("combobox", {
+      name: "workspace.repositories.pullRequestLinkedIssueFilter",
+    });
+    await user.click(linkedIssueTrigger);
+    await user.click(
+      await screen.findByRole("option", {
+        name: "workspace.repositories.pullRequestLinkedIssue",
+      })
+    );
+
+    await waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith("github_list_repository_pull_requests", {
+        owner: "octocat",
+        repository: "hello-world",
+        pullRequestState: "open",
+        query: "",
+        label: "",
+        linkedIssue: true,
+        sort: "updated",
+        page: 1,
+      });
+    });
+  });
+
   it("sends the selected draft filter", async () => {
     const user = userEvent.setup();
     const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });

--- a/src/features/github/github-pull-request-view.tsx
+++ b/src/features/github/github-pull-request-view.tsx
@@ -47,6 +47,7 @@ import {
 
 const ALL_LABELS = "__all__";
 const ALL_DRAFTS = "__all_drafts__";
+const ALL_LINKED_ISSUES = "__all_linked_issues__";
 const ALL_REVIEWS = "__all_reviews__";
 const ALL_MERGES = "__all_merges__";
 const ALL_STATUSES = "__all_statuses__";
@@ -82,6 +83,7 @@ export function GitHubPullRequestView({ repository }: { repository: GitHubReposi
   const [query, setQuery] = useState("");
   const [label, setLabel] = useState("");
   const [draft, setDraft] = useState<GitHubPullRequestDraftFilter | null>(null);
+  const [linkedIssue, setLinkedIssue] = useState(false);
   const [review, setReview] = useState<GitHubPullRequestReviewFilter | null>(null);
   const [merge, setMerge] = useState<GitHubPullRequestMergeFilter | null>(null);
   const [status, setStatus] = useState<GitHubPullRequestStatusFilter | null>(null);
@@ -97,6 +99,7 @@ export function GitHubPullRequestView({ repository }: { repository: GitHubReposi
       query,
       label,
       draft,
+      linkedIssue,
       review,
       merge,
       status,
@@ -124,6 +127,7 @@ export function GitHubPullRequestView({ repository }: { repository: GitHubReposi
     setQuery("");
     setLabel("");
     setDraft(null);
+    setLinkedIssue(false);
     setReview(null);
     setMerge(null);
     setStatus(null);
@@ -202,13 +206,13 @@ export function GitHubPullRequestView({ repository }: { repository: GitHubReposi
           </div>
         </div>
         <form
-          className="grid min-w-0 grid-cols-1 gap-2 @min-[480px]/pulls:grid-cols-3 @min-[1120px]/pulls:grid-cols-[minmax(180px,1fr)_repeat(6,minmax(128px,144px))]"
+          className="grid min-w-0 grid-cols-1 gap-2 @min-[480px]/pulls:grid-cols-3 @min-[1280px]/pulls:grid-cols-[minmax(180px,1fr)_repeat(7,minmax(128px,144px))]"
           onSubmit={(event) => {
             event.preventDefault();
             resetPage(() => setQuery(draftQuery.trim()));
           }}
         >
-          <div className="relative min-w-0 @min-[480px]/pulls:col-span-3 @min-[1120px]/pulls:col-span-1">
+          <div className="relative min-w-0 @min-[480px]/pulls:col-span-3 @min-[1280px]/pulls:col-span-1">
             <Search className="text-muted-foreground pointer-events-none absolute top-1/2 left-2.5 size-3.5 -translate-y-1/2" />
             <Input
               value={draftQuery}
@@ -241,6 +245,28 @@ export function GitHubPullRequestView({ repository }: { repository: GitHubReposi
                     {item.name}
                   </SelectItem>
                 ))}
+              </SelectGroup>
+            </SelectContent>
+          </Select>
+          <Select
+            value={linkedIssue ? "linked" : ALL_LINKED_ISSUES}
+            onValueChange={(value) => resetPage(() => setLinkedIssue(value === "linked"))}
+          >
+            <SelectTrigger
+              size="sm"
+              className="w-full min-w-0"
+              aria-label={t("workspace.repositories.pullRequestLinkedIssueFilter")}
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectGroup>
+                <SelectItem value={ALL_LINKED_ISSUES}>
+                  {t("workspace.repositories.allPullRequestLinkedIssues")}
+                </SelectItem>
+                <SelectItem value="linked">
+                  {t("workspace.repositories.pullRequestLinkedIssue")}
+                </SelectItem>
               </SelectGroup>
             </SelectContent>
           </Select>

--- a/src/features/github/github-queries.test.ts
+++ b/src/features/github/github-queries.test.ts
@@ -1154,6 +1154,7 @@ describe("GitHub repository queries", () => {
       "merged",
       "success",
       null,
+      false,
       "comments",
       2,
     ]);

--- a/src/features/github/github-queries.ts
+++ b/src/features/github/github-queries.ts
@@ -244,6 +244,7 @@ export type GitHubPullRequestsTarget = GitHubRepositoryTarget & {
   merge?: GitHubPullRequestMergeFilter | null;
   status?: GitHubPullRequestStatusFilter | null;
   draft?: GitHubPullRequestDraftFilter | null;
+  linkedIssue?: boolean;
   sort: GitHubPullRequestSort;
   page: number;
 };
@@ -756,6 +757,7 @@ export const githubQueryKeys = {
     merge,
     status,
     draft,
+    linkedIssue,
     sort,
     page,
   }: GitHubPullRequestsTarget) =>
@@ -772,6 +774,7 @@ export const githubQueryKeys = {
       merge ?? null,
       status ?? null,
       draft ?? null,
+      linkedIssue ?? false,
       sort,
       page,
     ] as const,
@@ -1862,6 +1865,7 @@ export function repositoryPullRequestsQueryOptions(target: GitHubPullRequestsTar
         ...(target.merge ? { merge: target.merge } : {}),
         ...(target.status ? { status: target.status } : {}),
         ...(target.draft ? { draft: target.draft } : {}),
+        ...(target.linkedIssue ? { linkedIssue: true } : {}),
         sort: target.sort,
         page: target.page,
       }),

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1472,6 +1472,9 @@
       "pullRequestDraftFilters": {
         "draft": "Draft"
       },
+      "pullRequestLinkedIssueFilter": "Linked Issue",
+      "allPullRequestLinkedIssues": "All linked states",
+      "pullRequestLinkedIssue": "Linked to an Issue",
       "pullRequestReviewFilter": "Review status",
       "allPullRequestReviews": "All review statuses",
       "pullRequestReviewFilters": {

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -1466,6 +1466,9 @@
       "pullRequestDraftFilters": {
         "draft": "草稿"
       },
+      "pullRequestLinkedIssueFilter": "关联 Issue",
+      "allPullRequestLinkedIssues": "全部关联状态",
+      "pullRequestLinkedIssue": "已关联 Issue",
       "pullRequestReviewFilter": "评审状态",
       "allPullRequestReviews": "全部评审状态",
       "pullRequestReviewFilters": {


### PR DESCRIPTION
## Summary
- expose GitHub Web's `linked:issue` qualifier in the repository pull request list
- keep selected linked-state filtering authoritative over conflicting free-text qualifiers
- wire the filter through the Tauri command, query key, localized UI, responsive layout, and interaction tests

## Verification
- `pnpm check`
- `cargo test --manifest-path src-tauri/Cargo.toml --lib`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets`

Follow-up to the personal GitHub Web parity audit; organization/enterprise-only administration remains out of scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a linked-issue filter to the GitHub pull request view.
  - Users can show all pull requests or only those linked to an issue.
  - Added localized labels for the new filter in English and Chinese.

- **Tests**
  - Added coverage confirming linked-issue filtering is applied to pull request searches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->