### PR TITLE
feat: add pull request review requested filter

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2595,6 +2595,7 @@ pub async fn github_list_repository_pull_requests(
     status: Option<GitHubPullRequestStatusFilter>,
     draft: Option<GitHubPullRequestDraftFilter>,
     linked_issue: Option<bool>,
+    review_requested: Option<bool>,
     sort: GitHubPullRequestSort,
     page: u32,
     state: State<'_, AppState>,
@@ -2609,6 +2610,7 @@ pub async fn github_list_repository_pull_requests(
         status,
         draft,
         linked_issue: linked_issue.unwrap_or(false),
+        review_requested: review_requested.unwrap_or(false),
         sort,
         page: validate_issue_page(page)?,
     };

--- a/src-tauri/src/github.rs
+++ b/src-tauri/src/github.rs
@@ -377,6 +377,7 @@ pub struct GitHubPullRequestFilters {
     pub status: Option<GitHubPullRequestStatusFilter>,
     pub draft: Option<GitHubPullRequestDraftFilter>,
     pub linked_issue: bool,
+    pub review_requested: bool,
     pub sort: GitHubPullRequestSort,
     pub page: u32,
 }
@@ -1898,6 +1899,7 @@ fn pull_request_search_query(
             filters.review,
             filters.draft,
             filters.linked_issue,
+            filters.review_requested,
         ),
         format!("repo:{owner}/{repository}"),
         "is:pr".to_string(),
@@ -1921,6 +1923,9 @@ fn pull_request_search_query(
     }
     if filters.linked_issue {
         query.push("linked:issue".to_string());
+    }
+    if filters.review_requested {
+        query.push("user-review-requested:@me".to_string());
     }
     query
         .into_iter()
@@ -1986,6 +1991,7 @@ fn pull_request_search_terms(
     selected_review: Option<GitHubPullRequestReviewFilter>,
     selected_draft: Option<GitHubPullRequestDraftFilter>,
     selected_linked_issue: bool,
+    selected_review_requested: bool,
 ) -> String {
     query
         .split_whitespace()
@@ -1996,7 +2002,15 @@ fn pull_request_search_terms(
                 .any(|prefix| term.starts_with(prefix))
                 || selected_review.is_some() && term.starts_with("review:")
                 || selected_draft.is_some() && term.starts_with("is:draft")
-                || selected_linked_issue && term.starts_with("linked:"))
+                || selected_linked_issue && term.starts_with("linked:")
+                || selected_review_requested
+                    && [
+                        "review-requested:",
+                        "user-review-requested:",
+                        "team-review-requested:",
+                    ]
+                    .iter()
+                    .any(|prefix| term.starts_with(prefix)))
         })
         .collect::<Vec<_>>()
         .join(" ")
@@ -4305,6 +4319,7 @@ mod tests {
             status: Some(GitHubPullRequestStatusFilter::Success),
             draft: None,
             linked_issue: false,
+            review_requested: false,
             sort: GitHubPullRequestSort::Updated,
             page: 1,
         };
@@ -4318,7 +4333,7 @@ mod tests {
     #[test]
     fn pull_request_review_filters_use_github_search_values() {
         assert_eq!(
-            pull_request_search_terms("review:approved crash", None, None, false),
+            pull_request_search_terms("review:approved crash", None, None, false, false),
             "review:approved crash"
         );
         assert_eq!(
@@ -4354,7 +4369,7 @@ mod tests {
             "is:draft"
         );
         assert_eq!(
-            pull_request_search_terms("is:draft -is:draft crash", None, None, false),
+            pull_request_search_terms("is:draft -is:draft crash", None, None, false, false),
             "crash"
         );
         assert_eq!(
@@ -4362,6 +4377,7 @@ mod tests {
                 "is:draft -is:draft crash",
                 None,
                 Some(GitHubPullRequestDraftFilter::Draft),
+                false,
                 false,
             ),
             "crash"
@@ -4379,6 +4395,7 @@ mod tests {
             status: None,
             draft: Some(GitHubPullRequestDraftFilter::Draft),
             linked_issue: false,
+            review_requested: false,
             sort: GitHubPullRequestSort::Updated,
             page: 1,
         };
@@ -4400,6 +4417,7 @@ mod tests {
             status: None,
             draft: None,
             linked_issue: true,
+            review_requested: false,
             sort: GitHubPullRequestSort::Updated,
             page: 1,
         };
@@ -4407,6 +4425,28 @@ mod tests {
         assert_eq!(
             pull_request_search_query("octocat", "hello-world", &filters),
             "crash repo:octocat/hello-world is:pr is:open linked:issue"
+        );
+    }
+
+    #[test]
+    fn selected_pull_request_review_requested_filter_owns_review_request_qualifiers() {
+        let filters = GitHubPullRequestFilters {
+            state: GitHubPullRequestState::Open,
+            query: "review-requested:octocat -user-review-requested:hubot crash".to_string(),
+            label: String::new(),
+            review: None,
+            merge: None,
+            status: None,
+            draft: None,
+            linked_issue: false,
+            review_requested: true,
+            sort: GitHubPullRequestSort::Updated,
+            page: 1,
+        };
+
+        assert_eq!(
+            pull_request_search_query("octocat", "hello-world", &filters),
+            "crash repo:octocat/hello-world is:pr is:open user-review-requested:@me"
         );
     }
 
@@ -4453,6 +4493,7 @@ mod tests {
             status: None,
             draft: None,
             linked_issue: false,
+            review_requested: false,
             sort: GitHubPullRequestSort::Updated,
             page: 1,
         };

--- a/src/features/github/github-pull-request-view.interaction.test.tsx
+++ b/src/features/github/github-pull-request-view.interaction.test.tsx
@@ -62,6 +62,39 @@ beforeEach(() => {
 afterEach(() => cleanup());
 
 describe("GitHub Pull Request list filters", () => {
+  it("sends the direct review-requested filter", async () => {
+    const user = userEvent.setup();
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    render(
+      <QueryClientProvider client={client}>
+        <GitHubPullRequestView repository={repository} />
+      </QueryClientProvider>
+    );
+
+    const reviewRequestedTrigger = await screen.findByRole("combobox", {
+      name: "workspace.repositories.pullRequestReviewRequestedFilter",
+    });
+    await user.click(reviewRequestedTrigger);
+    await user.click(
+      await screen.findByRole("option", {
+        name: "workspace.repositories.pullRequestReviewRequested",
+      })
+    );
+
+    await waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith("github_list_repository_pull_requests", {
+        owner: "octocat",
+        repository: "hello-world",
+        pullRequestState: "open",
+        query: "",
+        label: "",
+        reviewRequested: true,
+        sort: "updated",
+        page: 1,
+      });
+    });
+  });
+
   it("sends the linked-to-Issue filter", async () => {
     const user = userEvent.setup();
     const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });

--- a/src/features/github/github-pull-request-view.tsx
+++ b/src/features/github/github-pull-request-view.tsx
@@ -48,6 +48,7 @@ import {
 const ALL_LABELS = "__all__";
 const ALL_DRAFTS = "__all_drafts__";
 const ALL_LINKED_ISSUES = "__all_linked_issues__";
+const ALL_REVIEW_REQUESTS = "__all_review_requests__";
 const ALL_REVIEWS = "__all_reviews__";
 const ALL_MERGES = "__all_merges__";
 const ALL_STATUSES = "__all_statuses__";
@@ -84,6 +85,7 @@ export function GitHubPullRequestView({ repository }: { repository: GitHubReposi
   const [label, setLabel] = useState("");
   const [draft, setDraft] = useState<GitHubPullRequestDraftFilter | null>(null);
   const [linkedIssue, setLinkedIssue] = useState(false);
+  const [reviewRequested, setReviewRequested] = useState(false);
   const [review, setReview] = useState<GitHubPullRequestReviewFilter | null>(null);
   const [merge, setMerge] = useState<GitHubPullRequestMergeFilter | null>(null);
   const [status, setStatus] = useState<GitHubPullRequestStatusFilter | null>(null);
@@ -100,6 +102,7 @@ export function GitHubPullRequestView({ repository }: { repository: GitHubReposi
       label,
       draft,
       linkedIssue,
+      reviewRequested,
       review,
       merge,
       status,
@@ -128,6 +131,7 @@ export function GitHubPullRequestView({ repository }: { repository: GitHubReposi
     setLabel("");
     setDraft(null);
     setLinkedIssue(false);
+    setReviewRequested(false);
     setReview(null);
     setMerge(null);
     setStatus(null);
@@ -206,13 +210,13 @@ export function GitHubPullRequestView({ repository }: { repository: GitHubReposi
           </div>
         </div>
         <form
-          className="grid min-w-0 grid-cols-1 gap-2 @min-[480px]/pulls:grid-cols-3 @min-[1280px]/pulls:grid-cols-[minmax(180px,1fr)_repeat(7,minmax(128px,144px))]"
+          className="grid min-w-0 grid-cols-1 gap-2 @min-[480px]/pulls:grid-cols-3 @min-[1440px]/pulls:grid-cols-[minmax(180px,1fr)_repeat(8,minmax(128px,144px))]"
           onSubmit={(event) => {
             event.preventDefault();
             resetPage(() => setQuery(draftQuery.trim()));
           }}
         >
-          <div className="relative min-w-0 @min-[480px]/pulls:col-span-3 @min-[1280px]/pulls:col-span-1">
+          <div className="relative min-w-0 @min-[480px]/pulls:col-span-3 @min-[1440px]/pulls:col-span-1">
             <Search className="text-muted-foreground pointer-events-none absolute top-1/2 left-2.5 size-3.5 -translate-y-1/2" />
             <Input
               value={draftQuery}
@@ -393,6 +397,28 @@ export function GitHubPullRequestView({ repository }: { repository: GitHubReposi
                 </SelectItem>
                 <SelectItem value="changesRequested">
                   {t("workspace.repositories.pullRequestReviewFilters.changesRequested")}
+                </SelectItem>
+              </SelectGroup>
+            </SelectContent>
+          </Select>
+          <Select
+            value={reviewRequested ? "requested" : ALL_REVIEW_REQUESTS}
+            onValueChange={(value) => resetPage(() => setReviewRequested(value === "requested"))}
+          >
+            <SelectTrigger
+              size="sm"
+              className="w-full min-w-0"
+              aria-label={t("workspace.repositories.pullRequestReviewRequestedFilter")}
+            >
+              <SelectValue placeholder={t("workspace.repositories.allPullRequestReviewRequests")} />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectGroup>
+                <SelectItem value={ALL_REVIEW_REQUESTS}>
+                  {t("workspace.repositories.allPullRequestReviewRequests")}
+                </SelectItem>
+                <SelectItem value="requested">
+                  {t("workspace.repositories.pullRequestReviewRequested")}
                 </SelectItem>
               </SelectGroup>
             </SelectContent>

--- a/src/features/github/github-queries.test.ts
+++ b/src/features/github/github-queries.test.ts
@@ -1135,6 +1135,7 @@ describe("GitHub repository queries", () => {
       review: "approved",
       merge: "merged",
       status: "success",
+      reviewRequested: true,
       sort: "comments",
       page: 2,
     });
@@ -1155,6 +1156,7 @@ describe("GitHub repository queries", () => {
       "success",
       null,
       false,
+      true,
       "comments",
       2,
     ]);
@@ -1167,6 +1169,7 @@ describe("GitHub repository queries", () => {
       review: "approved",
       merge: "merged",
       status: "success",
+      reviewRequested: true,
       sort: "comments",
       page: 2,
     });

--- a/src/features/github/github-queries.ts
+++ b/src/features/github/github-queries.ts
@@ -245,6 +245,7 @@ export type GitHubPullRequestsTarget = GitHubRepositoryTarget & {
   status?: GitHubPullRequestStatusFilter | null;
   draft?: GitHubPullRequestDraftFilter | null;
   linkedIssue?: boolean;
+  reviewRequested?: boolean;
   sort: GitHubPullRequestSort;
   page: number;
 };
@@ -758,6 +759,7 @@ export const githubQueryKeys = {
     status,
     draft,
     linkedIssue,
+    reviewRequested,
     sort,
     page,
   }: GitHubPullRequestsTarget) =>
@@ -775,6 +777,7 @@ export const githubQueryKeys = {
       status ?? null,
       draft ?? null,
       linkedIssue ?? false,
+      reviewRequested ?? false,
       sort,
       page,
     ] as const,
@@ -1866,6 +1869,7 @@ export function repositoryPullRequestsQueryOptions(target: GitHubPullRequestsTar
         ...(target.status ? { status: target.status } : {}),
         ...(target.draft ? { draft: target.draft } : {}),
         ...(target.linkedIssue ? { linkedIssue: true } : {}),
+        ...(target.reviewRequested ? { reviewRequested: true } : {}),
         sort: target.sort,
         page: target.page,
       }),

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1483,6 +1483,9 @@
         "approved": "Approved",
         "changesRequested": "Changes requested"
       },
+      "pullRequestReviewRequestedFilter": "Review requested",
+      "allPullRequestReviewRequests": "All review requests",
+      "pullRequestReviewRequested": "Requested from me",
       "pullRequestMergeFilter": "Merge status",
       "allPullRequestMerges": "All merge statuses",
       "pullRequestMergeFilters": {

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -1477,6 +1477,9 @@
         "approved": "已批准",
         "changesRequested": "要求修改"
       },
+      "pullRequestReviewRequestedFilter": "评审请求",
+      "allPullRequestReviewRequests": "全部评审请求",
+      "pullRequestReviewRequested": "请求我评审",
       "pullRequestMergeFilter": "合入状态",
       "allPullRequestMerges": "全部合入状态",
       "pullRequestMergeFilters": {


### PR DESCRIPTION
## Summary
- add a repository Pull Requests selector for GitHub's `user-review-requested:@me` qualifier
- preserve the existing review-status selector while isolating review-requested state in the query key and optional Tauri argument
- own conflicting review-requested qualifiers in free-form search and keep the layout responsive
- add localized UI and frontend/Rust regression coverage

## Verification
- `pnpm check`
- `cargo test --manifest-path src-tauri/Cargo.toml --lib`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets`

Follow-up to the personal GitHub Web parity audit; organization/enterprise administration remains out of scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a pull-request filter for review requests.
  * Users can view all review-requested pull requests or those specifically requesting their review.
  * Added English and Simplified Chinese translations for the new filter options.

* **Bug Fixes**
  * Review-request filtering now takes precedence over conflicting review qualifiers in search queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->