### PR TITLE
feat: add pull request authored filter

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2598,6 +2598,7 @@ pub async fn github_list_repository_pull_requests(
     draft: Option<GitHubPullRequestDraftFilter>,
     linked_issue: Option<bool>,
     review_requested: Option<bool>,
+    created_by_me: Option<bool>,
     sort: GitHubPullRequestSort,
     page: u32,
     state: State<'_, AppState>,
@@ -2613,6 +2614,7 @@ pub async fn github_list_repository_pull_requests(
         draft,
         linked_issue: linked_issue.unwrap_or(false),
         review_requested: review_requested.unwrap_or(false),
+        created_by_me: created_by_me.unwrap_or(false),
         sort,
         page: validate_issue_page(page)?,
     };

--- a/src-tauri/src/github.rs
+++ b/src-tauri/src/github.rs
@@ -378,6 +378,7 @@ pub struct GitHubPullRequestFilters {
     pub draft: Option<GitHubPullRequestDraftFilter>,
     pub linked_issue: bool,
     pub review_requested: bool,
+    pub created_by_me: bool,
     pub sort: GitHubPullRequestSort,
     pub page: u32,
 }
@@ -1900,6 +1901,7 @@ fn pull_request_search_query(
             filters.draft,
             filters.linked_issue,
             filters.review_requested,
+            filters.created_by_me,
         ),
         format!("repo:{owner}/{repository}"),
         "is:pr".to_string(),
@@ -1926,6 +1928,9 @@ fn pull_request_search_query(
     }
     if filters.review_requested {
         query.push("user-review-requested:@me".to_string());
+    }
+    if filters.created_by_me {
+        query.push("author:@me".to_string());
     }
     query
         .into_iter()
@@ -1992,6 +1997,7 @@ fn pull_request_search_terms(
     selected_draft: Option<GitHubPullRequestDraftFilter>,
     selected_linked_issue: bool,
     selected_review_requested: bool,
+    selected_created_by_me: bool,
 ) -> String {
     query
         .split_whitespace()
@@ -2010,7 +2016,8 @@ fn pull_request_search_terms(
                         "team-review-requested:",
                     ]
                     .iter()
-                    .any(|prefix| term.starts_with(prefix)))
+                    .any(|prefix| term.starts_with(prefix))
+                || selected_created_by_me && term.starts_with("author:"))
         })
         .collect::<Vec<_>>()
         .join(" ")
@@ -4321,6 +4328,7 @@ mod tests {
             draft: None,
             linked_issue: false,
             review_requested: false,
+            created_by_me: false,
             sort: GitHubPullRequestSort::Updated,
             page: 1,
         };
@@ -4334,7 +4342,7 @@ mod tests {
     #[test]
     fn pull_request_review_filters_use_github_search_values() {
         assert_eq!(
-            pull_request_search_terms("review:approved crash", None, None, false, false),
+            pull_request_search_terms("review:approved crash", None, None, false, false, false),
             "review:approved crash"
         );
         assert_eq!(
@@ -4370,7 +4378,7 @@ mod tests {
             "is:draft"
         );
         assert_eq!(
-            pull_request_search_terms("is:draft -is:draft crash", None, None, false, false),
+            pull_request_search_terms("is:draft -is:draft crash", None, None, false, false, false),
             "crash"
         );
         assert_eq!(
@@ -4378,6 +4386,7 @@ mod tests {
                 "is:draft -is:draft crash",
                 None,
                 Some(GitHubPullRequestDraftFilter::Draft),
+                false,
                 false,
                 false,
             ),
@@ -4397,6 +4406,7 @@ mod tests {
             draft: Some(GitHubPullRequestDraftFilter::Draft),
             linked_issue: false,
             review_requested: false,
+            created_by_me: false,
             sort: GitHubPullRequestSort::Updated,
             page: 1,
         };
@@ -4419,6 +4429,7 @@ mod tests {
             draft: None,
             linked_issue: true,
             review_requested: false,
+            created_by_me: false,
             sort: GitHubPullRequestSort::Updated,
             page: 1,
         };
@@ -4441,6 +4452,7 @@ mod tests {
             draft: None,
             linked_issue: false,
             review_requested: true,
+            created_by_me: false,
             sort: GitHubPullRequestSort::Updated,
             page: 1,
         };
@@ -4448,6 +4460,29 @@ mod tests {
         assert_eq!(
             pull_request_search_query("octocat", "hello-world", &filters),
             "crash repo:octocat/hello-world is:pr is:open user-review-requested:@me"
+        );
+    }
+
+    #[test]
+    fn selected_pull_request_created_by_me_filter_owns_author_qualifiers() {
+        let filters = GitHubPullRequestFilters {
+            state: GitHubPullRequestState::Open,
+            query: "author:someone -(author:another) crash".to_string(),
+            label: String::new(),
+            review: None,
+            merge: None,
+            status: None,
+            draft: None,
+            linked_issue: false,
+            review_requested: false,
+            created_by_me: true,
+            sort: GitHubPullRequestSort::Updated,
+            page: 1,
+        };
+
+        assert_eq!(
+            pull_request_search_query("octocat", "hello-world", &filters),
+            "crash repo:octocat/hello-world is:pr is:open author:@me"
         );
     }
 
@@ -4495,6 +4530,7 @@ mod tests {
             draft: None,
             linked_issue: false,
             review_requested: false,
+            created_by_me: false,
             sort: GitHubPullRequestSort::Updated,
             page: 1,
         };

--- a/src/features/github/github-pull-request-view.interaction.test.tsx
+++ b/src/features/github/github-pull-request-view.interaction.test.tsx
@@ -95,6 +95,39 @@ describe("GitHub Pull Request list filters", () => {
     });
   });
 
+  it("sends the created-by-me filter", async () => {
+    const user = userEvent.setup();
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    render(
+      <QueryClientProvider client={client}>
+        <GitHubPullRequestView repository={repository} />
+      </QueryClientProvider>
+    );
+
+    const authorTrigger = await screen.findByRole("combobox", {
+      name: "workspace.repositories.pullRequestAuthorFilter",
+    });
+    await user.click(authorTrigger);
+    await user.click(
+      await screen.findByRole("option", {
+        name: "workspace.repositories.createdByMePullRequests",
+      })
+    );
+
+    await waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith("github_list_repository_pull_requests", {
+        owner: "octocat",
+        repository: "hello-world",
+        pullRequestState: "open",
+        query: "",
+        label: "",
+        createdByMe: true,
+        sort: "updated",
+        page: 1,
+      });
+    });
+  });
+
   it("sends the linked-to-Issue filter", async () => {
     const user = userEvent.setup();
     const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });

--- a/src/features/github/github-pull-request-view.tsx
+++ b/src/features/github/github-pull-request-view.tsx
@@ -49,6 +49,7 @@ const ALL_LABELS = "__all__";
 const ALL_DRAFTS = "__all_drafts__";
 const ALL_LINKED_ISSUES = "__all_linked_issues__";
 const ALL_REVIEW_REQUESTS = "__all_review_requests__";
+const ALL_CREATED_BY_ME = "__all_created_by_me__";
 const ALL_REVIEWS = "__all_reviews__";
 const ALL_MERGES = "__all_merges__";
 const ALL_STATUSES = "__all_statuses__";
@@ -86,6 +87,7 @@ export function GitHubPullRequestView({ repository }: { repository: GitHubReposi
   const [draft, setDraft] = useState<GitHubPullRequestDraftFilter | null>(null);
   const [linkedIssue, setLinkedIssue] = useState(false);
   const [reviewRequested, setReviewRequested] = useState(false);
+  const [createdByMe, setCreatedByMe] = useState(false);
   const [review, setReview] = useState<GitHubPullRequestReviewFilter | null>(null);
   const [merge, setMerge] = useState<GitHubPullRequestMergeFilter | null>(null);
   const [status, setStatus] = useState<GitHubPullRequestStatusFilter | null>(null);
@@ -103,6 +105,7 @@ export function GitHubPullRequestView({ repository }: { repository: GitHubReposi
       draft,
       linkedIssue,
       reviewRequested,
+      createdByMe,
       review,
       merge,
       status,
@@ -132,6 +135,7 @@ export function GitHubPullRequestView({ repository }: { repository: GitHubReposi
     setDraft(null);
     setLinkedIssue(false);
     setReviewRequested(false);
+    setCreatedByMe(false);
     setReview(null);
     setMerge(null);
     setStatus(null);
@@ -210,13 +214,13 @@ export function GitHubPullRequestView({ repository }: { repository: GitHubReposi
           </div>
         </div>
         <form
-          className="grid min-w-0 grid-cols-1 gap-2 @min-[480px]/pulls:grid-cols-3 @min-[1440px]/pulls:grid-cols-[minmax(180px,1fr)_repeat(8,minmax(128px,144px))]"
+          className="grid min-w-0 grid-cols-1 gap-2 @min-[480px]/pulls:grid-cols-3 @min-[1600px]/pulls:grid-cols-[minmax(180px,1fr)_repeat(9,minmax(128px,144px))]"
           onSubmit={(event) => {
             event.preventDefault();
             resetPage(() => setQuery(draftQuery.trim()));
           }}
         >
-          <div className="relative min-w-0 @min-[480px]/pulls:col-span-3 @min-[1440px]/pulls:col-span-1">
+          <div className="relative min-w-0 @min-[480px]/pulls:col-span-3 @min-[1600px]/pulls:col-span-1">
             <Search className="text-muted-foreground pointer-events-none absolute top-1/2 left-2.5 size-3.5 -translate-y-1/2" />
             <Input
               value={draftQuery}
@@ -419,6 +423,28 @@ export function GitHubPullRequestView({ repository }: { repository: GitHubReposi
                 </SelectItem>
                 <SelectItem value="requested">
                   {t("workspace.repositories.pullRequestReviewRequested")}
+                </SelectItem>
+              </SelectGroup>
+            </SelectContent>
+          </Select>
+          <Select
+            value={createdByMe ? "created" : ALL_CREATED_BY_ME}
+            onValueChange={(value) => resetPage(() => setCreatedByMe(value === "created"))}
+          >
+            <SelectTrigger
+              size="sm"
+              className="w-full min-w-0"
+              aria-label={t("workspace.repositories.pullRequestAuthorFilter")}
+            >
+              <SelectValue placeholder={t("workspace.repositories.allPullRequestAuthors")} />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectGroup>
+                <SelectItem value={ALL_CREATED_BY_ME}>
+                  {t("workspace.repositories.allPullRequestAuthors")}
+                </SelectItem>
+                <SelectItem value="created">
+                  {t("workspace.repositories.createdByMePullRequests")}
                 </SelectItem>
               </SelectGroup>
             </SelectContent>

--- a/src/features/github/github-queries.test.ts
+++ b/src/features/github/github-queries.test.ts
@@ -1139,6 +1139,7 @@ describe("GitHub repository queries", () => {
       merge: "merged",
       status: "success",
       reviewRequested: true,
+      createdByMe: true,
       sort: "comments",
       page: 2,
     });
@@ -1160,6 +1161,7 @@ describe("GitHub repository queries", () => {
       null,
       false,
       true,
+      true,
       "comments",
       2,
     ]);
@@ -1173,6 +1175,7 @@ describe("GitHub repository queries", () => {
       merge: "merged",
       status: "success",
       reviewRequested: true,
+      createdByMe: true,
       sort: "comments",
       page: 2,
     });

--- a/src/features/github/github-queries.ts
+++ b/src/features/github/github-queries.ts
@@ -247,6 +247,7 @@ export type GitHubPullRequestsTarget = GitHubRepositoryTarget & {
   draft?: GitHubPullRequestDraftFilter | null;
   linkedIssue?: boolean;
   reviewRequested?: boolean;
+  createdByMe?: boolean;
   sort: GitHubPullRequestSort;
   page: number;
 };
@@ -763,6 +764,7 @@ export const githubQueryKeys = {
     draft,
     linkedIssue,
     reviewRequested,
+    createdByMe,
     sort,
     page,
   }: GitHubPullRequestsTarget) =>
@@ -781,6 +783,7 @@ export const githubQueryKeys = {
       draft ?? null,
       linkedIssue ?? false,
       reviewRequested ?? false,
+      createdByMe ?? false,
       sort,
       page,
     ] as const,
@@ -1874,6 +1877,7 @@ export function repositoryPullRequestsQueryOptions(target: GitHubPullRequestsTar
         ...(target.draft ? { draft: target.draft } : {}),
         ...(target.linkedIssue ? { linkedIssue: true } : {}),
         ...(target.reviewRequested ? { reviewRequested: true } : {}),
+        ...(target.createdByMe ? { createdByMe: true } : {}),
         sort: target.sort,
         page: target.page,
       }),

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1486,6 +1486,9 @@
       "pullRequestReviewRequestedFilter": "Review requested",
       "allPullRequestReviewRequests": "All review requests",
       "pullRequestReviewRequested": "Requested from me",
+      "pullRequestAuthorFilter": "Author",
+      "allPullRequestAuthors": "All authors",
+      "createdByMePullRequests": "Created by me",
       "pullRequestMergeFilter": "Merge status",
       "allPullRequestMerges": "All merge statuses",
       "pullRequestMergeFilters": {

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -1480,6 +1480,9 @@
       "pullRequestReviewRequestedFilter": "评审请求",
       "allPullRequestReviewRequests": "全部评审请求",
       "pullRequestReviewRequested": "请求我评审",
+      "pullRequestAuthorFilter": "作者",
+      "allPullRequestAuthors": "全部作者",
+      "createdByMePullRequests": "我创建的",
       "pullRequestMergeFilter": "合入状态",
       "allPullRequestMerges": "全部合入状态",
       "pullRequestMergeFilters": {


### PR DESCRIPTION
## Summary
- add a repository Pull Requests “Created by me” filter backed by author:@me
- keep author qualifiers owned and isolated through optional Tauri IPC and TanStack Query keys
- add responsive layout, English/Simplified Chinese labels, and interaction/Rust coverage

## Verification
- pnpm check
- cargo test --manifest-path src-tauri/Cargo.toml --lib
- cargo check --manifest-path src-tauri/Cargo.toml
- cargo fmt --manifest-path src-tauri/Cargo.toml -- --check
- cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets
- git diff --check
- exact-head Standards and Spec reviews: no findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a “Created by me” filter for repository pull requests.
  - Added author filtering options, including “All authors” and “Created by me.”
  - Pull-request searches now support the selected author filter across supported languages.
  - Filter selections reset when switching repositories.
- **Localization**
  - Added English and Chinese translations for the new author-filter options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->