### PR TITLE
feat: add personal pull request filters

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2601,6 +2601,8 @@ pub async fn github_list_repository_pull_requests(
     linked_issue: Option<bool>,
     review_requested: Option<bool>,
     created_by_me: Option<bool>,
+    assigned_to_me: Option<bool>,
+    mentioned_to_me: Option<bool>,
     sort: GitHubPullRequestSort,
     page: u32,
     state: State<'_, AppState>,
@@ -2617,6 +2619,8 @@ pub async fn github_list_repository_pull_requests(
         linked_issue: linked_issue.unwrap_or(false),
         review_requested: review_requested.unwrap_or(false),
         created_by_me: created_by_me.unwrap_or(false),
+        assigned_to_me: assigned_to_me.unwrap_or(false),
+        mentioned_to_me: mentioned_to_me.unwrap_or(false),
         sort,
         page: validate_issue_page(page)?,
     };

--- a/src-tauri/src/github.rs
+++ b/src-tauri/src/github.rs
@@ -379,6 +379,8 @@ pub struct GitHubPullRequestFilters {
     pub linked_issue: bool,
     pub review_requested: bool,
     pub created_by_me: bool,
+    pub assigned_to_me: bool,
+    pub mentioned_to_me: bool,
     pub sort: GitHubPullRequestSort,
     pub page: u32,
 }
@@ -1895,14 +1897,7 @@ fn pull_request_search_query(
         GitHubPullRequestState::Closed => "closed",
     };
     let mut query = vec![
-        pull_request_search_terms(
-            &filters.query,
-            filters.review,
-            filters.draft,
-            filters.linked_issue,
-            filters.review_requested,
-            filters.created_by_me,
-        ),
+        pull_request_search_terms(filters),
         format!("repo:{owner}/{repository}"),
         "is:pr".to_string(),
         format!("is:{state}"),
@@ -1931,6 +1926,12 @@ fn pull_request_search_query(
     }
     if filters.created_by_me {
         query.push("author:@me".to_string());
+    }
+    if filters.assigned_to_me {
+        query.push("assignee:@me".to_string());
+    }
+    if filters.mentioned_to_me {
+        query.push("mentions:@me".to_string());
     }
     query
         .into_iter()
@@ -1991,25 +1992,19 @@ fn pull_request_inbox_search_terms(query: &str) -> String {
         .join(" ")
 }
 
-fn pull_request_search_terms(
-    query: &str,
-    selected_review: Option<GitHubPullRequestReviewFilter>,
-    selected_draft: Option<GitHubPullRequestDraftFilter>,
-    selected_linked_issue: bool,
-    selected_review_requested: bool,
-    selected_created_by_me: bool,
-) -> String {
-    query
+fn pull_request_search_terms(filters: &GitHubPullRequestFilters) -> String {
+    filters
+        .query
         .split_whitespace()
         .filter(|term| {
             let term = term.trim_matches(['-', '(', ')']).to_ascii_lowercase();
             !(["repo:", "org:", "user:", "is:", "type:", "state:"]
                 .iter()
                 .any(|prefix| term.starts_with(prefix))
-                || selected_review.is_some() && term.starts_with("review:")
-                || selected_draft.is_some() && term.starts_with("is:draft")
-                || selected_linked_issue && term.starts_with("linked:")
-                || selected_review_requested
+                || filters.review.is_some() && term.starts_with("review:")
+                || filters.draft.is_some() && term.starts_with("is:draft")
+                || filters.linked_issue && term.starts_with("linked:")
+                || filters.review_requested
                     && [
                         "review-requested:",
                         "user-review-requested:",
@@ -2017,7 +2012,10 @@ fn pull_request_search_terms(
                     ]
                     .iter()
                     .any(|prefix| term.starts_with(prefix))
-                || selected_created_by_me && term.starts_with("author:"))
+                || filters.created_by_me && term.starts_with("author:")
+                || filters.assigned_to_me
+                    && (term.starts_with("assignee:") || term == "no:assignee")
+                || filters.mentioned_to_me && term.starts_with("mentions:"))
         })
         .collect::<Vec<_>>()
         .join(" ")
@@ -4317,6 +4315,25 @@ mod tests {
         assert!(page.repositories[0].is_fork);
     }
 
+    fn pull_request_filters_with_query(query: &str) -> GitHubPullRequestFilters {
+        GitHubPullRequestFilters {
+            state: GitHubPullRequestState::Open,
+            query: query.to_string(),
+            label: String::new(),
+            review: None,
+            merge: None,
+            status: None,
+            draft: None,
+            linked_issue: false,
+            review_requested: false,
+            created_by_me: false,
+            assigned_to_me: false,
+            mentioned_to_me: false,
+            sort: GitHubPullRequestSort::Updated,
+            page: 1,
+        }
+    }
+
     #[test]
     fn selected_pull_request_review_filter_owns_the_review_qualifier() {
         let filters = GitHubPullRequestFilters {
@@ -4330,6 +4347,8 @@ mod tests {
             linked_issue: false,
             review_requested: false,
             created_by_me: false,
+            assigned_to_me: false,
+            mentioned_to_me: false,
             sort: GitHubPullRequestSort::Updated,
             page: 1,
         };
@@ -4342,10 +4361,8 @@ mod tests {
 
     #[test]
     fn pull_request_review_filters_use_github_search_values() {
-        assert_eq!(
-            pull_request_search_terms("review:approved crash", None, None, false, false, false),
-            "review:approved crash"
-        );
+        let filters = pull_request_filters_with_query("review:approved crash");
+        assert_eq!(pull_request_search_terms(&filters), "review:approved crash");
         assert_eq!(
             GitHubPullRequestReviewFilter::None.search_qualifier(),
             "review:none"
@@ -4374,25 +4391,17 @@ mod tests {
 
     #[test]
     fn pull_request_draft_filter_owns_the_draft_qualifier() {
+        let filters = pull_request_filters_with_query("is:draft -is:draft crash");
+        let selected_filters = GitHubPullRequestFilters {
+            draft: Some(GitHubPullRequestDraftFilter::Draft),
+            ..filters.clone()
+        };
         assert_eq!(
             GitHubPullRequestDraftFilter::Draft.search_qualifier(),
             "is:draft"
         );
-        assert_eq!(
-            pull_request_search_terms("is:draft -is:draft crash", None, None, false, false, false),
-            "crash"
-        );
-        assert_eq!(
-            pull_request_search_terms(
-                "is:draft -is:draft crash",
-                None,
-                Some(GitHubPullRequestDraftFilter::Draft),
-                false,
-                false,
-                false,
-            ),
-            "crash"
-        );
+        assert_eq!(pull_request_search_terms(&filters), "crash");
+        assert_eq!(pull_request_search_terms(&selected_filters), "crash");
     }
 
     #[test]
@@ -4408,6 +4417,8 @@ mod tests {
             linked_issue: false,
             review_requested: false,
             created_by_me: false,
+            assigned_to_me: false,
+            mentioned_to_me: false,
             sort: GitHubPullRequestSort::Updated,
             page: 1,
         };
@@ -4431,6 +4442,8 @@ mod tests {
             linked_issue: true,
             review_requested: false,
             created_by_me: false,
+            assigned_to_me: false,
+            mentioned_to_me: false,
             sort: GitHubPullRequestSort::Updated,
             page: 1,
         };
@@ -4454,6 +4467,8 @@ mod tests {
             linked_issue: false,
             review_requested: true,
             created_by_me: false,
+            assigned_to_me: false,
+            mentioned_to_me: false,
             sort: GitHubPullRequestSort::Updated,
             page: 1,
         };
@@ -4477,6 +4492,8 @@ mod tests {
             linked_issue: false,
             review_requested: false,
             created_by_me: true,
+            assigned_to_me: false,
+            mentioned_to_me: false,
             sort: GitHubPullRequestSort::Updated,
             page: 1,
         };
@@ -4484,6 +4501,57 @@ mod tests {
         assert_eq!(
             pull_request_search_query("octocat", "hello-world", &filters),
             "crash repo:octocat/hello-world is:pr is:open author:@me"
+        );
+    }
+
+    #[test]
+    fn selected_pull_request_assigned_to_me_filter_owns_assignee_qualifiers() {
+        let filters = GitHubPullRequestFilters {
+            state: GitHubPullRequestState::Open,
+            query: "assignee:someone -(assignee:another) no:assignee -(no:assignee) crash"
+                .to_string(),
+            label: String::new(),
+            review: None,
+            merge: None,
+            status: None,
+            draft: None,
+            linked_issue: false,
+            review_requested: false,
+            created_by_me: false,
+            assigned_to_me: true,
+            mentioned_to_me: false,
+            sort: GitHubPullRequestSort::Updated,
+            page: 1,
+        };
+
+        assert_eq!(
+            pull_request_search_query("octocat", "hello-world", &filters),
+            "crash repo:octocat/hello-world is:pr is:open assignee:@me"
+        );
+    }
+
+    #[test]
+    fn selected_pull_request_mentioned_to_me_filter_owns_mentions_qualifiers() {
+        let filters = GitHubPullRequestFilters {
+            state: GitHubPullRequestState::Open,
+            query: "mentions:someone -(mentions:another) crash".to_string(),
+            label: String::new(),
+            review: None,
+            merge: None,
+            status: None,
+            draft: None,
+            linked_issue: false,
+            review_requested: false,
+            created_by_me: false,
+            assigned_to_me: false,
+            mentioned_to_me: true,
+            sort: GitHubPullRequestSort::Updated,
+            page: 1,
+        };
+
+        assert_eq!(
+            pull_request_search_query("octocat", "hello-world", &filters),
+            "crash repo:octocat/hello-world is:pr is:open mentions:@me"
         );
     }
 
@@ -4532,6 +4600,8 @@ mod tests {
             linked_issue: false,
             review_requested: false,
             created_by_me: false,
+            assigned_to_me: false,
+            mentioned_to_me: false,
             sort: GitHubPullRequestSort::Updated,
             page: 1,
         };

--- a/src/features/github/github-pull-request-view.interaction.test.tsx
+++ b/src/features/github/github-pull-request-view.interaction.test.tsx
@@ -62,6 +62,24 @@ beforeEach(() => {
 afterEach(() => cleanup());
 
 describe("GitHub Pull Request list filters", () => {
+  it("keeps search full-width until the complete wide filter grid activates", async () => {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    render(
+      <QueryClientProvider client={client}>
+        <GitHubPullRequestView repository={repository} />
+      </QueryClientProvider>
+    );
+
+    const search = await screen.findByRole("textbox", {
+      name: "workspace.repositories.searchPullRequests",
+    });
+    const searchContainer = search.parentElement;
+    const filterForm = searchContainer?.parentElement;
+
+    expect(filterForm?.className).toContain("@min-[1640px]/pulls:grid-cols-");
+    expect(searchContainer?.className).toContain("@min-[1640px]/pulls:col-span-1");
+  });
+
   it("sends the direct review-requested filter", async () => {
     const user = userEvent.setup();
     const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -122,6 +140,72 @@ describe("GitHub Pull Request list filters", () => {
         query: "",
         label: "",
         createdByMe: true,
+        sort: "updated",
+        page: 1,
+      });
+    });
+  });
+
+  it("sends the assigned-to-me filter", async () => {
+    const user = userEvent.setup();
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    render(
+      <QueryClientProvider client={client}>
+        <GitHubPullRequestView repository={repository} />
+      </QueryClientProvider>
+    );
+
+    const assigneeTrigger = await screen.findByRole("combobox", {
+      name: "workspace.repositories.pullRequestAssigneeFilter",
+    });
+    await user.click(assigneeTrigger);
+    await user.click(
+      await screen.findByRole("option", {
+        name: "workspace.repositories.assignedToMePullRequests",
+      })
+    );
+
+    await waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith("github_list_repository_pull_requests", {
+        owner: "octocat",
+        repository: "hello-world",
+        pullRequestState: "open",
+        query: "",
+        label: "",
+        assignedToMe: true,
+        sort: "updated",
+        page: 1,
+      });
+    });
+  });
+
+  it("sends the mentioning-me filter", async () => {
+    const user = userEvent.setup();
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    render(
+      <QueryClientProvider client={client}>
+        <GitHubPullRequestView repository={repository} />
+      </QueryClientProvider>
+    );
+
+    const mentionedTrigger = await screen.findByRole("combobox", {
+      name: "workspace.repositories.pullRequestMentionedFilter",
+    });
+    await user.click(mentionedTrigger);
+    await user.click(
+      await screen.findByRole("option", {
+        name: "workspace.repositories.mentionedToMePullRequests",
+      })
+    );
+
+    await waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith("github_list_repository_pull_requests", {
+        owner: "octocat",
+        repository: "hello-world",
+        pullRequestState: "open",
+        query: "",
+        label: "",
+        mentionedToMe: true,
         sort: "updated",
         page: 1,
       });

--- a/src/features/github/github-pull-request-view.tsx
+++ b/src/features/github/github-pull-request-view.tsx
@@ -50,6 +50,8 @@ const ALL_DRAFTS = "__all_drafts__";
 const ALL_LINKED_ISSUES = "__all_linked_issues__";
 const ALL_REVIEW_REQUESTS = "__all_review_requests__";
 const ALL_CREATED_BY_ME = "__all_created_by_me__";
+const ALL_ASSIGNED_TO_ME = "__all_assigned_to_me__";
+const ALL_MENTIONED_TO_ME = "__all_mentioned_to_me__";
 const ALL_REVIEWS = "__all_reviews__";
 const ALL_MERGES = "__all_merges__";
 const ALL_STATUSES = "__all_statuses__";
@@ -88,6 +90,8 @@ export function GitHubPullRequestView({ repository }: { repository: GitHubReposi
   const [linkedIssue, setLinkedIssue] = useState(false);
   const [reviewRequested, setReviewRequested] = useState(false);
   const [createdByMe, setCreatedByMe] = useState(false);
+  const [assignedToMe, setAssignedToMe] = useState(false);
+  const [mentionedToMe, setMentionedToMe] = useState(false);
   const [review, setReview] = useState<GitHubPullRequestReviewFilter | null>(null);
   const [merge, setMerge] = useState<GitHubPullRequestMergeFilter | null>(null);
   const [status, setStatus] = useState<GitHubPullRequestStatusFilter | null>(null);
@@ -106,6 +110,8 @@ export function GitHubPullRequestView({ repository }: { repository: GitHubReposi
       linkedIssue,
       reviewRequested,
       createdByMe,
+      assignedToMe,
+      mentionedToMe,
       review,
       merge,
       status,
@@ -136,6 +142,8 @@ export function GitHubPullRequestView({ repository }: { repository: GitHubReposi
     setLinkedIssue(false);
     setReviewRequested(false);
     setCreatedByMe(false);
+    setAssignedToMe(false);
+    setMentionedToMe(false);
     setReview(null);
     setMerge(null);
     setStatus(null);
@@ -214,13 +222,13 @@ export function GitHubPullRequestView({ repository }: { repository: GitHubReposi
           </div>
         </div>
         <form
-          className="grid min-w-0 grid-cols-1 gap-2 @min-[480px]/pulls:grid-cols-3 @min-[1600px]/pulls:grid-cols-[minmax(180px,1fr)_repeat(9,minmax(128px,144px))]"
+          className="grid min-w-0 grid-cols-1 gap-2 @min-[480px]/pulls:grid-cols-3 @min-[1640px]/pulls:grid-cols-[minmax(180px,1fr)_repeat(11,minmax(120px,136px))]"
           onSubmit={(event) => {
             event.preventDefault();
             resetPage(() => setQuery(draftQuery.trim()));
           }}
         >
-          <div className="relative min-w-0 @min-[480px]/pulls:col-span-3 @min-[1600px]/pulls:col-span-1">
+          <div className="relative min-w-0 @min-[480px]/pulls:col-span-3 @min-[1640px]/pulls:col-span-1">
             <Search className="text-muted-foreground pointer-events-none absolute top-1/2 left-2.5 size-3.5 -translate-y-1/2" />
             <Input
               value={draftQuery}
@@ -445,6 +453,50 @@ export function GitHubPullRequestView({ repository }: { repository: GitHubReposi
                 </SelectItem>
                 <SelectItem value="created">
                   {t("workspace.repositories.createdByMePullRequests")}
+                </SelectItem>
+              </SelectGroup>
+            </SelectContent>
+          </Select>
+          <Select
+            value={assignedToMe ? "assigned" : ALL_ASSIGNED_TO_ME}
+            onValueChange={(value) => resetPage(() => setAssignedToMe(value === "assigned"))}
+          >
+            <SelectTrigger
+              size="sm"
+              className="w-full min-w-0"
+              aria-label={t("workspace.repositories.pullRequestAssigneeFilter")}
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectGroup>
+                <SelectItem value={ALL_ASSIGNED_TO_ME}>
+                  {t("workspace.repositories.allPullRequestAssignees")}
+                </SelectItem>
+                <SelectItem value="assigned">
+                  {t("workspace.repositories.assignedToMePullRequests")}
+                </SelectItem>
+              </SelectGroup>
+            </SelectContent>
+          </Select>
+          <Select
+            value={mentionedToMe ? "mentioned" : ALL_MENTIONED_TO_ME}
+            onValueChange={(value) => resetPage(() => setMentionedToMe(value === "mentioned"))}
+          >
+            <SelectTrigger
+              size="sm"
+              className="w-full min-w-0"
+              aria-label={t("workspace.repositories.pullRequestMentionedFilter")}
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectGroup>
+                <SelectItem value={ALL_MENTIONED_TO_ME}>
+                  {t("workspace.repositories.allPullRequestMentionStates")}
+                </SelectItem>
+                <SelectItem value="mentioned">
+                  {t("workspace.repositories.mentionedToMePullRequests")}
                 </SelectItem>
               </SelectGroup>
             </SelectContent>

--- a/src/features/github/github-queries.test.ts
+++ b/src/features/github/github-queries.test.ts
@@ -1143,6 +1143,8 @@ describe("GitHub repository queries", () => {
       status: "success",
       reviewRequested: true,
       createdByMe: true,
+      assignedToMe: true,
+      mentionedToMe: true,
       sort: "comments",
       page: 2,
     });
@@ -1165,6 +1167,8 @@ describe("GitHub repository queries", () => {
       false,
       true,
       true,
+      true,
+      true,
       "comments",
       2,
     ]);
@@ -1179,6 +1183,8 @@ describe("GitHub repository queries", () => {
       status: "success",
       reviewRequested: true,
       createdByMe: true,
+      assignedToMe: true,
+      mentionedToMe: true,
       sort: "comments",
       page: 2,
     });

--- a/src/features/github/github-queries.ts
+++ b/src/features/github/github-queries.ts
@@ -249,6 +249,8 @@ export type GitHubPullRequestsTarget = GitHubRepositoryTarget & {
   linkedIssue?: boolean;
   reviewRequested?: boolean;
   createdByMe?: boolean;
+  assignedToMe?: boolean;
+  mentionedToMe?: boolean;
   sort: GitHubPullRequestSort;
   page: number;
 };
@@ -768,6 +770,8 @@ export const githubQueryKeys = {
     linkedIssue,
     reviewRequested,
     createdByMe,
+    assignedToMe,
+    mentionedToMe,
     sort,
     page,
   }: GitHubPullRequestsTarget) =>
@@ -787,6 +791,8 @@ export const githubQueryKeys = {
       linkedIssue ?? false,
       reviewRequested ?? false,
       createdByMe ?? false,
+      assignedToMe ?? false,
+      mentionedToMe ?? false,
       sort,
       page,
     ] as const,
@@ -1882,6 +1888,8 @@ export function repositoryPullRequestsQueryOptions(target: GitHubPullRequestsTar
         ...(target.linkedIssue ? { linkedIssue: true } : {}),
         ...(target.reviewRequested ? { reviewRequested: true } : {}),
         ...(target.createdByMe ? { createdByMe: true } : {}),
+        ...(target.assignedToMe ? { assignedToMe: true } : {}),
+        ...(target.mentionedToMe ? { mentionedToMe: true } : {}),
         sort: target.sort,
         page: target.page,
       }),

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1489,6 +1489,12 @@
       "pullRequestAuthorFilter": "Author",
       "allPullRequestAuthors": "All authors",
       "createdByMePullRequests": "Created by me",
+      "pullRequestAssigneeFilter": "Assignee",
+      "allPullRequestAssignees": "All assignees",
+      "assignedToMePullRequests": "Assigned to me",
+      "pullRequestMentionedFilter": "Mentions",
+      "allPullRequestMentionStates": "All mention states",
+      "mentionedToMePullRequests": "Mentioning me",
       "pullRequestMergeFilter": "Merge status",
       "allPullRequestMerges": "All merge statuses",
       "pullRequestMergeFilters": {

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -1483,6 +1483,12 @@
       "pullRequestAuthorFilter": "作者",
       "allPullRequestAuthors": "全部作者",
       "createdByMePullRequests": "我创建的",
+      "pullRequestAssigneeFilter": "负责人",
+      "allPullRequestAssignees": "全部负责人",
+      "assignedToMePullRequests": "分配给我的",
+      "pullRequestMentionedFilter": "提及我",
+      "allPullRequestMentionStates": "全部提及状态",
+      "mentionedToMePullRequests": "提到我",
       "pullRequestMergeFilter": "合入状态",
       "allPullRequestMerges": "全部合入状态",
       "pullRequestMergeFilters": {


### PR DESCRIPTION
## Summary
- add repository Pull Request “Assigned to me” and “Mentioning me” filters backed by `assignee:@me` and `mentions:@me`
- preserve optional Tauri IPC compatibility, isolate query keys, and own conflicting free-form qualifiers including `no:assignee`
- add accessible English/Simplified Chinese Select controls and a synchronized 1640px responsive grid

## Evidence
- GitHub Docs lists created-by-me, assigned-to-me, and @mentioned as default Issue/Pull Request filters
- https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/filtering-and-searching-issues-and-pull-requests

## Verification
- `pnpm check` (85 files, 411 tests)
- `cargo test --manifest-path src-tauri/Cargo.toml --lib` (584 passed, 2 ignored)
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets`
- `git diff --check`
- exact-head Standards and Spec re-reviews: no P0-P3 findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added “Assigned to me” and “Mentioned to me” filters for GitHub pull requests.
  - Filter selections are preserved in searches and reset appropriately.
  - Expanded the filter layout for wider screens.
  - Added English and Chinese translations for the new filter options.

- **Tests**
  - Added coverage for personal pull-request filters and responsive filter layout behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->