### PR TITLE
feat: add involved pull request inbox scope

### DIFF
--- a/src-tauri/src/github.rs
+++ b/src-tauri/src/github.rs
@@ -364,6 +364,7 @@ impl GitHubPullRequestStatusFilter {
 pub enum GitHubPullRequestInboxScope {
     Authored,
     Assigned,
+    Involved,
     ReviewRequested,
 }
 
@@ -1948,6 +1949,7 @@ fn pull_request_inbox_search_query(filters: &GitHubPullRequestInboxFilters) -> S
     let scope = match filters.scope {
         GitHubPullRequestInboxScope::Authored => "author:@me",
         GitHubPullRequestInboxScope::Assigned => "assignee:@me",
+        GitHubPullRequestInboxScope::Involved => "involves:@me",
         GitHubPullRequestInboxScope::ReviewRequested => "review-requested:@me",
     };
     [
@@ -1967,10 +1969,7 @@ fn pull_request_inbox_search_terms(query: &str) -> String {
     query
         .split_whitespace()
         .filter(|term| {
-            let term = term
-                .trim_matches(['(', ')'])
-                .trim_start_matches('-')
-                .to_ascii_lowercase();
+            let term = term.trim_matches(['-', '(', ')']).to_ascii_lowercase();
             ![
                 "repo:",
                 "org:",
@@ -1980,6 +1979,7 @@ fn pull_request_inbox_search_terms(query: &str) -> String {
                 "state:",
                 "author:",
                 "assignee:",
+                "involves:",
                 "review-requested:",
                 "user-review-requested:",
                 "team-review-requested:",
@@ -4631,16 +4631,17 @@ mod tests {
     #[test]
     fn pull_request_inbox_enforces_the_selected_account_scope() {
         let filters = GitHubPullRequestInboxFilters {
-            scope: GitHubPullRequestInboxScope::ReviewRequested,
+            scope: GitHubPullRequestInboxScope::Involved,
             state: GitHubPullRequestState::Open,
-            query: "author:someone repo:other/project label:bug render".to_string(),
+            query: "author:someone -(involves:hubot) repo:other/project label:bug render"
+                .to_string(),
             sort: GitHubPullRequestSort::Updated,
             page: 2,
         };
 
         assert_eq!(
             pull_request_inbox_search_query(&filters),
-            "label:bug render is:pr is:open review-requested:@me archived:false"
+            "label:bug render is:pr is:open involves:@me archived:false"
         );
     }
 
@@ -4658,6 +4659,7 @@ mod tests {
 
         assert!(query_for(GitHubPullRequestInboxScope::Authored).contains("author:@me"));
         assert!(query_for(GitHubPullRequestInboxScope::Assigned).contains("assignee:@me"));
+        assert!(query_for(GitHubPullRequestInboxScope::Involved).contains("involves:@me"));
         assert!(query_for(GitHubPullRequestInboxScope::ReviewRequested)
             .contains("review-requested:@me"));
     }

--- a/src/features/github/github-data.ts
+++ b/src/features/github/github-data.ts
@@ -1703,7 +1703,7 @@ export type GitHubPullRequestReviewFilter = "none" | "required" | "approved" | "
 export type GitHubPullRequestMergeFilter = "merged" | "unmerged";
 export type GitHubPullRequestStatusFilter = "success" | "failure" | "pending";
 export type GitHubPullRequestDraftFilter = "draft";
-export type GitHubPullRequestInboxScope = "authored" | "assigned" | "reviewRequested";
+export type GitHubPullRequestInboxScope = "authored" | "assigned" | "involved" | "reviewRequested";
 export type GitHubPullRequestMergeMethod = "merge" | "squash" | "rebase";
 export type GitHubPullRequestAutoMergeState =
   | "enabled"

--- a/src/features/github/github-pull-request-inbox.interaction.test.tsx
+++ b/src/features/github/github-pull-request-inbox.interaction.test.tsx
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { invoke } from "@tauri-apps/api/core";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { GitHubPullRequestInbox } from "./github-pull-request-inbox";
+
+vi.mock("@tauri-apps/api/core", () => ({ invoke: vi.fn(), isTauri: () => true }));
+vi.mock("@tauri-apps/api/event", () => ({ listen: vi.fn().mockResolvedValue(() => {}) }));
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: "en" } }),
+}));
+
+beforeEach(() => {
+  vi.mocked(invoke).mockReset();
+  vi.mocked(invoke).mockResolvedValue({
+    pullRequests: [],
+    totalCount: 0,
+    page: 1,
+    hasPrevious: false,
+    hasMore: false,
+  });
+});
+
+afterEach(() => cleanup());
+
+describe("GitHub Pull Request inbox filters", () => {
+  it("requests pull requests involving the signed-in user", async () => {
+    const user = userEvent.setup();
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    render(
+      <QueryClientProvider client={client}>
+        <GitHubPullRequestInbox onSelectRepository={() => {}} />
+      </QueryClientProvider>
+    );
+
+    await user.click(await screen.findByRole("tab", { name: "workspace.pullRequests.involved" }));
+
+    await waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith("github_list_pull_request_inbox", {
+        scope: "involved",
+        pullRequestState: "open",
+        query: "",
+        sort: "updated",
+        page: 1,
+      });
+    });
+  });
+});

--- a/src/features/github/github-pull-request-inbox.tsx
+++ b/src/features/github/github-pull-request-inbox.tsx
@@ -10,6 +10,7 @@ import {
   ShieldCheck,
   TriangleAlert,
   UserCheck,
+  UsersRound,
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { Alert, AlertDescription } from "@/components/ui/alert";
@@ -179,6 +180,9 @@ export function GitHubPullRequestInbox({
               </TabsTrigger>
               <TabsTrigger value="assigned" className="px-1.5 text-xs">
                 <UserCheck /> {t("workspace.pullRequests.assigned")}
+              </TabsTrigger>
+              <TabsTrigger value="involved" className="px-1.5 text-xs">
+                <UsersRound /> {t("workspace.pullRequests.involved")}
               </TabsTrigger>
               <TabsTrigger value="reviewRequested" className="px-1.5 text-xs">
                 <ShieldCheck /> {t("workspace.pullRequests.reviewRequested")}

--- a/src/features/github/github-queries.test.ts
+++ b/src/features/github/github-queries.test.ts
@@ -1190,7 +1190,7 @@ describe("GitHub repository queries", () => {
     });
   });
 
-  it("keys and invokes account pull request inbox pages by scope", async () => {
+  it("keys and invokes involved account pull request inbox pages", async () => {
     const client = createTestQueryClient();
     vi.mocked(invoke).mockResolvedValueOnce({
       pullRequests: [],
@@ -1200,7 +1200,7 @@ describe("GitHub repository queries", () => {
       hasMore: false,
     });
     const options = pullRequestInboxQueryOptions({
-      scope: "reviewRequested",
+      scope: "involved",
       state: "open",
       query: "label:bug render",
       sort: "updated",
@@ -1212,14 +1212,14 @@ describe("GitHub repository queries", () => {
     expect(options.queryKey).toEqual([
       "github",
       "pull-request-inbox",
-      "reviewRequested",
+      "involved",
       "open",
       "label:bug render",
       "updated",
       3,
     ]);
     expect(invoke).toHaveBeenCalledWith("github_list_pull_request_inbox", {
-      scope: "reviewRequested",
+      scope: "involved",
       pullRequestState: "open",
       query: "label:bug render",
       sort: "updated",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -766,6 +766,7 @@
       "refresh": "Refresh",
       "authored": "Created",
       "assigned": "Assigned",
+      "involved": "Involves me",
       "reviewRequested": "Review requests",
       "count": "{{count}} pull requests",
       "search": "Search titles, repositories, or qualifiers…",
@@ -778,6 +779,7 @@
       "emptyDescriptions": {
         "authored": "You have not created a pull request matching these filters.",
         "assigned": "No pull request matching these filters is assigned to you.",
+        "involved": "No pull request involving you matches these filters.",
         "reviewRequested": "You have no review request matching these filters."
       },
       "pagination": "Pull request inbox pages"

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -760,6 +760,7 @@
       "refresh": "刷新",
       "authored": "我创建的",
       "assigned": "分配给我的",
+      "involved": "与我相关",
       "reviewRequested": "等待我评审",
       "count": "{{count}} 个拉取请求",
       "search": "搜索标题、仓库或 GitHub 限定词…",
@@ -772,6 +773,7 @@
       "emptyDescriptions": {
         "authored": "你创建的拉取请求里，没有符合当前条件的内容。",
         "assigned": "目前没有符合条件且分配给你的拉取请求。",
+        "involved": "与你相关的拉取请求里，没有符合当前条件的内容。",
         "reviewRequested": "目前没有需要你评审且符合当前条件的拉取请求。"
       },
       "pagination": "拉取请求收件箱分页"


### PR DESCRIPTION
## Summary

- add the current GitHub pull request dashboard Involves me scope to the personal inbox
- map the scope to involves:@me while removing conflicting free-form involves qualifiers
- add English and Simplified Chinese UI plus focused Rust, query-contract, and interaction coverage

## Evidence

GitHub documents Involves me as a built-in filter in the generally available pull request dashboard, and the Search API accepted the exact involves:@me query without additional permissions.

## Verification

- pnpm check (86 files, 412 tests)
- cargo test --manifest-path src-tauri/Cargo.toml --lib (584 passed, 2 ignored)
- cargo check --manifest-path src-tauri/Cargo.toml
- cargo fmt --manifest-path src-tauri/Cargo.toml -- --check
- cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets (existing warnings only)
- git diff --check
- independent Standards review: 0 P0-P3
- independent Spec review: 0 P0-P3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an **Involved** filter to the GitHub pull request inbox.
  - The filter shows pull requests involving the signed-in account and resets pagination when selected.
  - Added localized labels and empty-state messages in English and Chinese.

- **Bug Fixes**
  - Improved inbox query handling to consistently apply the selected account scope and clean up conflicting qualifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->