### PR TITLE
fix: install the reviewed desktop update

### DIFF
--- a/src/components/updater-dialog.interaction.test.tsx
+++ b/src/components/updater-dialog.interaction.test.tsx
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+
+import type { Update } from "@tauri-apps/plugin-updater";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const updaterPlugin = vi.hoisted(() => ({
+  check: vi.fn(),
+}));
+
+const processPlugin = vi.hoisted(() => ({
+  relaunch: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/plugin-updater", () => updaterPlugin);
+vi.mock("@tauri-apps/plugin-process", () => processPlugin);
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, values?: { version?: string }) =>
+      values?.version ? `${key} ${values.version}` : key,
+  }),
+}));
+
+import { UpdaterDialog } from "./updater-dialog";
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("UpdaterDialog", () => {
+  it("installs the update whose version and notes the user reviewed", async () => {
+    const user = userEvent.setup();
+    const reviewedUpdate = {
+      version: "0.2.0",
+      date: "2026-09-04",
+      body: "Reviewed release notes",
+      downloadAndInstall: vi.fn().mockResolvedValue(undefined),
+    } as unknown as Update;
+    updaterPlugin.check.mockResolvedValueOnce(reviewedUpdate).mockResolvedValue(null);
+
+    render(<UpdaterDialog />);
+
+    expect(await screen.findByText("updater.versionAvailable 0.2.0")).toBeTruthy();
+    expect(screen.getByText("Reviewed release notes")).toBeTruthy();
+    await user.click(screen.getByRole("button", { name: "updater.installNow" }));
+
+    await waitFor(() => {
+      expect(reviewedUpdate.downloadAndInstall).toHaveBeenCalledTimes(1);
+    });
+    expect(updaterPlugin.check).toHaveBeenCalledTimes(1);
+    expect(processPlugin.relaunch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/hooks/use-updater.ts
+++ b/src/hooks/use-updater.ts
@@ -25,16 +25,20 @@ export function useUpdater() {
   }, []);
 
   const installUpdate = useCallback(async () => {
+    if (!update) {
+      return;
+    }
+
     setDownloading(true);
     try {
-      await downloadAndInstall((progressEvent) => {
+      await downloadAndInstall(update, (progressEvent) => {
         setProgress(progressEvent);
       });
     } catch (error) {
       console.error("Failed to install update:", error);
       setDownloading(false);
     }
-  }, []);
+  }, [update]);
 
   return {
     update,

--- a/src/lib/updater.test.ts
+++ b/src/lib/updater.test.ts
@@ -1,0 +1,44 @@
+import type { Update } from "@tauri-apps/plugin-updater";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const updaterPlugin = vi.hoisted(() => ({
+  check: vi.fn(),
+}));
+
+const processPlugin = vi.hoisted(() => ({
+  relaunch: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/plugin-updater", () => updaterPlugin);
+vi.mock("@tauri-apps/plugin-process", () => processPlugin);
+
+import { checkForUpdates, downloadAndInstall } from "./updater";
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("desktop updater", () => {
+  it("installs the same update that was checked and reviewed", async () => {
+    const reviewedUpdate = {
+      version: "0.2.0",
+      date: "2026-09-04",
+      body: "Reviewed release notes",
+      downloadAndInstall: vi.fn().mockResolvedValue(undefined),
+    } as unknown as Update;
+    updaterPlugin.check.mockResolvedValueOnce(reviewedUpdate).mockResolvedValueOnce(null);
+
+    const result = await checkForUpdates();
+
+    expect(result.status).toBe("available");
+    if (result.status !== "available") {
+      throw new Error("Expected an available update");
+    }
+
+    await downloadAndInstall(result.update);
+
+    expect(updaterPlugin.check).toHaveBeenCalledTimes(1);
+    expect(reviewedUpdate.downloadAndInstall).toHaveBeenCalledTimes(1);
+    expect(processPlugin.relaunch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -30,13 +30,10 @@ export async function checkForUpdates(): Promise<UpdateCheckResult> {
   }
 }
 
-export async function downloadAndInstall(onProgress?: (progress: UpdateProgress) => void) {
-  const update = await check();
-
-  if (!update) {
-    return false;
-  }
-
+export async function downloadAndInstall(
+  update: Update,
+  onProgress?: (progress: UpdateProgress) => void
+) {
   console.log(`Found update ${update.version} from ${update.date} with notes: ${update.body}`);
 
   let downloaded = 0;


### PR DESCRIPTION
## Summary

- install the exact `Update` object returned by the check the user reviewed
- remove the second updater request from the installation path
- cover both the updater module contract and the rendered dialog interaction

The first-release platform is macOS only. This focused updater slice does not yet change the release workflow, create a tag, or publish a Release.

## Verification

- `pnpm vitest run src/lib/updater.test.ts src/components/updater-dialog.interaction.test.tsx` (2 tests passed)
- `pnpm check` (88 test files, 414 tests passed; production build passed)
- `cargo test --manifest-path src-tauri/Cargo.toml` (584 passed, 2 ignored)
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets` (passes with 16 pre-existing warnings in untouched Rust code)
- `pnpm tauri build --no-bundle`
- `git diff --check origin/main...HEAD`

Strict Clippy with `-D warnings` remains blocked by those 16 warnings already present on `origin/main`; this PR does not modify the affected files.

## Independent review

- Standards: no documented-standard violations. One judgment-call note found small duplicated updater mocks across the Node and jsdom tests; retained to keep the two environments isolated and avoid coupling through Vitest hoisting.
- Spec: pass. The dialog displays the checked object's version and notes, clicking install invokes that same object's `downloadAndInstall`, and `check()` is called exactly once.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved update installation to ensure the selected version is downloaded and installed correctly.
  * Prevented installation attempts when no update is available.
  * Avoided redundant update checks during the installation process.
  * Ensured the application relaunches after a successful update installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->