### PR TITLE
fix: surface desktop update install states

### DIFF
--- a/src/components/updater-dialog.interaction.test.tsx
+++ b/src/components/updater-dialog.interaction.test.tsx
@@ -24,21 +24,26 @@ vi.mock("react-i18next", () => ({
 
 import { UpdaterDialog } from "./updater-dialog";
 
+function reviewedUpdate(downloadAndInstall = vi.fn().mockResolvedValue(undefined)) {
+  return {
+    version: "0.2.0",
+    date: "2026-09-04",
+    body: "Reviewed release notes",
+    downloadAndInstall,
+  } as unknown as Update;
+}
+
 afterEach(() => {
   cleanup();
-  vi.clearAllMocks();
+  vi.restoreAllMocks();
+  vi.resetAllMocks();
 });
 
 describe("UpdaterDialog", () => {
   it("installs the update whose version and notes the user reviewed", async () => {
     const user = userEvent.setup();
-    const reviewedUpdate = {
-      version: "0.2.0",
-      date: "2026-09-04",
-      body: "Reviewed release notes",
-      downloadAndInstall: vi.fn().mockResolvedValue(undefined),
-    } as unknown as Update;
-    updaterPlugin.check.mockResolvedValueOnce(reviewedUpdate).mockResolvedValue(null);
+    const update = reviewedUpdate();
+    updaterPlugin.check.mockResolvedValueOnce(update).mockResolvedValue(null);
 
     render(<UpdaterDialog />);
 
@@ -47,9 +52,77 @@ describe("UpdaterDialog", () => {
     await user.click(screen.getByRole("button", { name: "updater.installNow" }));
 
     await waitFor(() => {
-      expect(reviewedUpdate.downloadAndInstall).toHaveBeenCalledTimes(1);
+      expect(update.downloadAndInstall).toHaveBeenCalledTimes(1);
     });
     expect(updaterPlugin.check).toHaveBeenCalledTimes(1);
     expect(processPlugin.relaunch).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows download failure, retries, and announces the restart", async () => {
+    const user = userEvent.setup();
+    let rejectFirstAttempt!: (reason: unknown) => void;
+    const firstAttempt = new Promise<void>((_resolve, reject) => {
+      rejectFirstAttempt = reject;
+    });
+    let finishRelaunch!: () => void;
+    const relaunchAttempt = new Promise<void>((resolve) => {
+      finishRelaunch = resolve;
+    });
+    type ProgressCallback = Parameters<Update["downloadAndInstall"]>[0];
+    const install = vi
+      .fn()
+      .mockImplementationOnce(async (onProgress: ProgressCallback) => {
+        onProgress?.({ event: "Started", data: { contentLength: 100 } });
+        await firstAttempt;
+      })
+      .mockImplementationOnce(async (onProgress: ProgressCallback) => {
+        onProgress?.({ event: "Started", data: { contentLength: 100 } });
+        onProgress?.({ event: "Progress", data: { chunkLength: 100 } });
+        onProgress?.({ event: "Finished" });
+      });
+    const update = reviewedUpdate(install);
+    updaterPlugin.check.mockResolvedValueOnce(update);
+    processPlugin.relaunch.mockReturnValue(relaunchAttempt);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    render(<UpdaterDialog />);
+    await screen.findByText("updater.versionAvailable 0.2.0");
+
+    await user.click(screen.getByRole("button", { name: "updater.installNow" }));
+    expect(await screen.findByText("updater.downloading")).toBeTruthy();
+
+    rejectFirstAttempt(new Error("download failed"));
+    expect(await screen.findByText("updater.installFailed")).toBeTruthy();
+
+    await user.click(screen.getByRole("button", { name: "updater.retry" }));
+    expect(await screen.findByText("updater.restarting")).toBeTruthy();
+    expect(update.downloadAndInstall).toHaveBeenCalledTimes(2);
+    expect(updaterPlugin.check).toHaveBeenCalledTimes(1);
+    finishRelaunch();
+  });
+
+  it("keeps the installed state and retries only relaunch after relaunch fails", async () => {
+    const user = userEvent.setup();
+    const update = reviewedUpdate();
+    updaterPlugin.check.mockResolvedValueOnce(update);
+    processPlugin.relaunch
+      .mockRejectedValueOnce(new Error("relaunch failed"))
+      .mockResolvedValueOnce(undefined);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    render(<UpdaterDialog />);
+    await screen.findByText("updater.versionAvailable 0.2.0");
+
+    await user.click(screen.getByRole("button", { name: "updater.installNow" }));
+    expect(await screen.findByText("updater.relaunchFailed")).toBeTruthy();
+    expect(update.downloadAndInstall).toHaveBeenCalledTimes(1);
+
+    await user.click(screen.getByRole("button", { name: "updater.retryRestart" }));
+    await waitFor(() => {
+      expect(processPlugin.relaunch).toHaveBeenCalledTimes(2);
+    });
+    expect(update.downloadAndInstall).toHaveBeenCalledTimes(1);
+    expect(updaterPlugin.check).toHaveBeenCalledTimes(1);
+    expect(screen.getByText("updater.restarting")).toBeTruthy();
   });
 });

--- a/src/components/updater-dialog.tsx
+++ b/src/components/updater-dialog.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState } from "react";
-import { useUpdater } from "@/hooks/use-updater";
+import { useEffect, useState, type ReactNode } from "react";
+import { useUpdater, type UpdateInstallStatus } from "@/hooks/use-updater";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -10,16 +10,36 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Progress } from "@/components/ui/progress";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Spinner } from "@/components/ui/spinner";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
+import { CircleAlert } from "lucide-react";
 
 interface UpdaterDialogProps {
   manualCheck?: boolean;
   onCheckComplete?: () => void;
 }
 
+interface InstallPresentation {
+  titleKey: string;
+  description: ReactNode;
+  action: {
+    labelKey: string;
+    run: () => void;
+  } | null;
+}
+
 export function UpdaterDialog({ manualCheck = false, onCheckComplete }: UpdaterDialogProps) {
-  const { update, checking, downloading, progress, checkUpdate, installUpdate } = useUpdater();
+  const {
+    update,
+    checking,
+    installStatus,
+    progress,
+    checkUpdate,
+    installUpdate,
+    relaunchAfterUpdate,
+  } = useUpdater();
   const [open, setOpen] = useState(false);
   const { t } = useTranslation();
 
@@ -38,10 +58,6 @@ export function UpdaterDialog({ manualCheck = false, onCheckComplete }: UpdaterD
     }
   }, [update, checking, manualCheck, onCheckComplete]);
 
-  const handleInstall = () => {
-    void installUpdate();
-  };
-
   const handleCancel = () => {
     setOpen(false);
   };
@@ -54,38 +70,93 @@ export function UpdaterDialog({ manualCheck = false, onCheckComplete }: UpdaterD
     return Math.round(((downloaded ?? 0) / contentLength) * 100);
   };
 
+  const presentations: Record<UpdateInstallStatus, InstallPresentation> = {
+    idle: {
+      titleKey: "updater.updateAvailable",
+      description: (
+        <div className="flex flex-col gap-2">
+          <p>{t("updater.versionAvailable", { version: update?.version })}</p>
+          {update?.body && (
+            <div className="bg-muted mt-2 rounded-md p-3 text-sm">
+              <p className="font-semibold">{t("updater.releaseNotes")}</p>
+              <p className="mt-1 whitespace-pre-wrap">{update.body}</p>
+            </div>
+          )}
+        </div>
+      ),
+      action: {
+        labelKey: "updater.installNow",
+        run: () => void installUpdate(),
+      },
+    },
+    downloading: {
+      titleKey: "updater.downloading",
+      description: (
+        <div className="flex flex-col gap-2">
+          <p>{t("updater.installingVersion", { version: update?.version })}</p>
+          <Progress value={getProgressPercentage()} />
+        </div>
+      ),
+      action: null,
+    },
+    failed: {
+      titleKey: "updater.installFailed",
+      description: (
+        <Alert variant="destructive">
+          <CircleAlert />
+          <AlertDescription>
+            {t("updater.installFailedDescription", { version: update?.version })}
+          </AlertDescription>
+        </Alert>
+      ),
+      action: {
+        labelKey: "updater.retry",
+        run: () => void installUpdate(),
+      },
+    },
+    restarting: {
+      titleKey: "updater.restarting",
+      description: (
+        <div className="flex items-center gap-2">
+          <Spinner />
+          <p>{t("updater.restartingDescription", { version: update?.version })}</p>
+        </div>
+      ),
+      action: null,
+    },
+    "relaunch-failed": {
+      titleKey: "updater.relaunchFailed",
+      description: (
+        <Alert variant="destructive">
+          <CircleAlert />
+          <AlertDescription>
+            {t("updater.relaunchFailedDescription", { version: update?.version })}
+          </AlertDescription>
+        </Alert>
+      ),
+      action: {
+        labelKey: "updater.retryRestart",
+        run: () => void relaunchAfterUpdate(),
+      },
+    },
+  };
+  const presentation = presentations[installStatus];
+
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>
-            {downloading ? t("updater.downloading") : t("updater.updateAvailable")}
-          </DialogTitle>
-          <DialogDescription>
-            {downloading ? (
-              <div className="space-y-2">
-                <p>{t("updater.installingVersion", { version: update?.version })}</p>
-                <Progress value={getProgressPercentage()} />
-              </div>
-            ) : (
-              <div className="space-y-2">
-                <p>{t("updater.versionAvailable", { version: update?.version })}</p>
-                {update?.body && (
-                  <div className="bg-muted mt-2 rounded-md p-3 text-sm">
-                    <p className="font-semibold">{t("updater.releaseNotes")}</p>
-                    <p className="mt-1 whitespace-pre-wrap">{update.body}</p>
-                  </div>
-                )}
-              </div>
-            )}
+          <DialogTitle>{t(presentation.titleKey)}</DialogTitle>
+          <DialogDescription asChild>
+            <div>{presentation.description}</div>
           </DialogDescription>
         </DialogHeader>
-        {!downloading && (
+        {presentation.action && (
           <DialogFooter>
             <Button variant="outline" onClick={handleCancel}>
               {t("updater.later")}
             </Button>
-            <Button onClick={handleInstall}>{t("updater.installNow")}</Button>
+            <Button onClick={presentation.action.run}>{t(presentation.action.labelKey)}</Button>
           </DialogFooter>
         )}
       </DialogContent>

--- a/src/hooks/use-updater.ts
+++ b/src/hooks/use-updater.ts
@@ -2,15 +2,23 @@ import { useCallback, useState } from "react";
 import {
   checkForUpdates,
   downloadAndInstall,
+  restartApplication,
   UpdateProgress,
   UpdateCheckResult,
 } from "@/lib/updater";
 import type { Update } from "@tauri-apps/plugin-updater";
 
+export type UpdateInstallStatus =
+  | "idle"
+  | "downloading"
+  | "failed"
+  | "restarting"
+  | "relaunch-failed";
+
 export function useUpdater() {
   const [update, setUpdate] = useState<Update | null>(null);
   const [checking, setChecking] = useState(false);
-  const [downloading, setDownloading] = useState(false);
+  const [installStatus, setInstallStatus] = useState<UpdateInstallStatus>("idle");
   const [progress, setProgress] = useState<UpdateProgress | null>(null);
 
   const checkUpdate = useCallback(async (): Promise<UpdateCheckResult> => {
@@ -24,28 +32,43 @@ export function useUpdater() {
     }
   }, []);
 
+  const relaunchAfterUpdate = useCallback(async () => {
+    setInstallStatus("restarting");
+    try {
+      await restartApplication();
+    } catch (error) {
+      console.error("Failed to relaunch after update:", error);
+      setInstallStatus("relaunch-failed");
+    }
+  }, []);
+
   const installUpdate = useCallback(async () => {
     if (!update) {
       return;
     }
 
-    setDownloading(true);
+    setInstallStatus("downloading");
+    setProgress(null);
     try {
       await downloadAndInstall(update, (progressEvent) => {
         setProgress(progressEvent);
       });
     } catch (error) {
       console.error("Failed to install update:", error);
-      setDownloading(false);
+      setInstallStatus("failed");
+      return;
     }
-  }, [update]);
+
+    await relaunchAfterUpdate();
+  }, [relaunchAfterUpdate, update]);
 
   return {
     update,
     checking,
-    downloading,
+    installStatus,
     progress,
     checkUpdate,
     installUpdate,
+    relaunchAfterUpdate,
   };
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2912,7 +2912,15 @@
     "versionAvailable": "Version {{version}} is available.",
     "releaseNotes": "Release Notes:",
     "later": "Later",
-    "installNow": "Install Now"
+    "installNow": "Install Now",
+    "installFailed": "Update Failed",
+    "installFailedDescription": "Harbor couldn't install version {{version}}. Check your connection and try again.",
+    "retry": "Retry",
+    "restarting": "Restarting Harbor",
+    "restartingDescription": "Version {{version}} is installed. Harbor is restarting...",
+    "relaunchFailed": "Restart Failed",
+    "relaunchFailedDescription": "Version {{version}} is installed, but Harbor couldn't restart. Try again or reopen Harbor manually.",
+    "retryRestart": "Restart Now"
   },
   "settings": {
     "title": "Settings",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -2905,7 +2905,15 @@
     "versionAvailable": "版本 {{version}} 可用。",
     "releaseNotes": "更新说明：",
     "later": "稍后",
-    "installNow": "立即安装"
+    "installNow": "立即安装",
+    "installFailed": "更新失败",
+    "installFailedDescription": "Harbor 无法安装版本 {{version}}。请检查网络连接后重试。",
+    "retry": "重试",
+    "restarting": "正在重启 Harbor",
+    "restartingDescription": "版本 {{version}} 已安装，Harbor 正在重启...",
+    "relaunchFailed": "重启失败",
+    "relaunchFailedDescription": "版本 {{version}} 已安装，但 Harbor 无法自动重启。请重试，或手动退出并重新打开 Harbor。",
+    "retryRestart": "立即重启"
   },
   "settings": {
     "title": "设置",

--- a/src/lib/updater.test.ts
+++ b/src/lib/updater.test.ts
@@ -12,7 +12,7 @@ const processPlugin = vi.hoisted(() => ({
 vi.mock("@tauri-apps/plugin-updater", () => updaterPlugin);
 vi.mock("@tauri-apps/plugin-process", () => processPlugin);
 
-import { checkForUpdates, downloadAndInstall } from "./updater";
+import { checkForUpdates, downloadAndInstall, restartApplication } from "./updater";
 
 afterEach(() => {
   vi.clearAllMocks();
@@ -39,6 +39,9 @@ describe("desktop updater", () => {
 
     expect(updaterPlugin.check).toHaveBeenCalledTimes(1);
     expect(reviewedUpdate.downloadAndInstall).toHaveBeenCalledTimes(1);
+
+    await restartApplication();
+
     expect(processPlugin.relaunch).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -62,6 +62,9 @@ export async function downloadAndInstall(
   });
 
   console.log("Update installed");
-  await relaunch();
   return true;
+}
+
+export async function restartApplication() {
+  await relaunch();
 }


### PR DESCRIPTION
## Summary

- model update installation as explicit idle, downloading, failed, and restarting states
- keep installation failures visible and let the user retry the same checked update
- announce restarting only after installation finishes and immediately before relaunch
- keep relaunch failures distinct so retrying restarts the installed app without reinstalling
- add English and Simplified Chinese state copy and interaction coverage

The first-release platform is macOS only. This focused updater slice does not change the release workflow, create a tag, or publish a Release.

## Verification

- `pnpm vitest run src/components/updater-dialog.interaction.test.tsx src/lib/updater.test.ts` (4 tests passed)
- `pnpm check` (88 test files, 416 tests passed; production build passed)
- `cargo test --manifest-path src-tauri/Cargo.toml` (584 passed, 2 ignored)
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets` (passes with the same 16 pre-existing warnings in untouched Rust code)
- `pnpm tauri build --no-bundle`
- `git diff --check origin/main...HEAD`

Strict Clippy with `-D warnings` remains blocked by warnings already present on `origin/main`; this PR does not modify the affected files.

## Independent review

- Standards: pass after centralizing status-dependent presentation and the repeated test fixture.
- Spec: pass. The interaction tests cover downloading, visible installation failure, retry, restarting, and relaunch failure recovery while preserving the original checked `Update` and a single `check()` call.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer update progress states, including installation and restart status.
  * Added retry options for failed downloads, installations, and application restarts.
  * Preserves the installed update when only the restart fails.
  * Added English and Chinese messages for update and restart outcomes.

* **Bug Fixes**
  * Separates installation failures from restart failures, preventing unnecessary reinstalls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->