### PR TITLE
fix: complete Tauri updater runtime contract

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1903,6 +1903,7 @@ dependencies = [
  "tauri-plugin-dialog",
  "tauri-plugin-global-shortcut",
  "tauri-plugin-opener",
+ "tauri-plugin-process",
  "tauri-plugin-single-instance",
  "tauri-plugin-updater",
  "tempfile",
@@ -5339,6 +5340,16 @@ dependencies = [
  "url",
  "windows",
  "zbus",
+]
+
+[[package]]
+name = "tauri-plugin-process"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55511a7bf6cd70c8767b02c97bf8134fa434daf3926cfc1be0a0f94132d165a"
+dependencies = [
+ "tauri",
+ "tauri-plugin",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -48,6 +48,7 @@ percent-encoding = "2"
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-single-instance = "2"
 tauri-plugin-updater = "2"
+tauri-plugin-process = "2"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -31,8 +31,6 @@
     "core:webview:allow-webview-position",
     "core:webview:allow-webview-size",
     "opener:default",
-    "updater:default",
-    "updater:allow-check",
     "global-shortcut:default",
     "global-shortcut:allow-is-registered",
     "global-shortcut:allow-register",

--- a/src-tauri/capabilities/updater-about.json
+++ b/src-tauri/capabilities/updater-about.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "updater-about",
+  "description": "Update check permission for the about window",
+  "windows": ["about"],
+  "permissions": ["updater:allow-check"]
+}

--- a/src-tauri/capabilities/updater-main.json
+++ b/src-tauri/capabilities/updater-main.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "updater-main",
+  "description": "Update installation and relaunch permissions for the main window",
+  "windows": ["main"],
+  "permissions": [
+    "updater:allow-check",
+    "updater:allow-download-and-install",
+    "process:allow-restart"
+  ]
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -266,8 +266,10 @@ pub fn run() {
         ]);
 
     // Only enable updater in release mode
-    #[cfg(not(debug_assertions))]
-    let builder = builder.plugin(tauri_plugin_updater::Builder::new().build());
+    #[cfg(all(desktop, not(debug_assertions)))]
+    let builder = builder
+        .plugin(tauri_plugin_updater::Builder::new().build())
+        .plugin(tauri_plugin_process::init());
 
     builder
         .run(tauri::generate_context!())

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -13,10 +13,7 @@
   "plugins": {
     "updater": {
       "pubkey": "__TAURI_UPDATER_PUBKEY__",
-      "endpoints": ["__TAURI_UPDATER_ENDPOINT__"],
-      "windows": {
-        "installMode": "passive"
-      }
+      "endpoints": ["__TAURI_UPDATER_ENDPOINT__"]
     }
   },
   "app": {
@@ -55,14 +52,8 @@
   },
   "bundle": {
     "active": true,
-    "targets": "all",
+    "targets": ["dmg"],
     "createUpdaterArtifacts": true,
-    "windows": {
-      "nsis": {
-        "installerIcon": "icons/icon.ico",
-        "languages": ["SimpChinese", "English"]
-      }
-    },
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/src/tauri-updater-contract.test.ts
+++ b/src/tauri-updater-contract.test.ts
@@ -1,0 +1,80 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import packageJson from "../package.json";
+
+const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const cargoToml = readFileSync(path.join(projectRoot, "src-tauri", "Cargo.toml"), "utf8");
+const cargoLock = readFileSync(path.join(projectRoot, "src-tauri", "Cargo.lock"), "utf8");
+const tauriLib = readFileSync(path.join(projectRoot, "src-tauri", "src", "lib.rs"), "utf8");
+const defaultCapability = JSON.parse(
+  readFileSync(path.join(projectRoot, "src-tauri", "capabilities", "default.json"), "utf8")
+);
+const tauriConfig = JSON.parse(
+  readFileSync(path.join(projectRoot, "src-tauri", "tauri.conf.json"), "utf8")
+);
+
+describe("Tauri updater contract", () => {
+  it("keeps matching frontend and Rust plugins for update installation and relaunch", () => {
+    expect(packageJson.dependencies["@tauri-apps/plugin-updater"]).toBeDefined();
+    expect(packageJson.dependencies["@tauri-apps/plugin-process"]).toBeDefined();
+    expect(cargoToml).toContain('tauri-plugin-updater = "2"');
+    expect(cargoToml).toContain('tauri-plugin-process = "2"');
+    expect(cargoLock).toContain('name = "tauri-plugin-updater"');
+    expect(cargoLock).toContain('name = "tauri-plugin-process"');
+  });
+
+  it("registers updater and process together for release builds", () => {
+    const releasePluginBlock = tauriLib.match(
+      /#\[cfg\(all\(desktop,\s*not\(debug_assertions\)\)\)\]\s*let\s+builder\s*=\s*builder(?<plugins>[\s\S]*?);/
+    );
+    const releasePlugins = releasePluginBlock?.groups?.plugins ?? "";
+
+    expect(releasePluginBlock).not.toBeNull();
+    expect(releasePlugins).toContain("tauri_plugin_updater::Builder::new().build()");
+    expect(releasePlugins).toContain("tauri_plugin_process::init()");
+  });
+
+  it("grants only the process capability needed to relaunch after installation", () => {
+    expect(defaultCapability.windows).toEqual(["main", "about", "settings"]);
+    expect(
+      defaultCapability.permissions.some(
+        (permission: string) =>
+          permission.startsWith("updater:") || permission.startsWith("process:")
+      )
+    ).toBe(false);
+
+    const mainCapability = JSON.parse(
+      readFileSync(path.join(projectRoot, "src-tauri", "capabilities", "updater-main.json"), "utf8")
+    );
+    expect(mainCapability.windows).toEqual(["main"]);
+    expect(mainCapability.permissions).toEqual([
+      "updater:allow-check",
+      "updater:allow-download-and-install",
+      "process:allow-restart",
+    ]);
+
+    const aboutCapability = JSON.parse(
+      readFileSync(
+        path.join(projectRoot, "src-tauri", "capabilities", "updater-about.json"),
+        "utf8"
+      )
+    );
+    expect(aboutCapability.windows).toEqual(["about"]);
+    expect(aboutCapability.permissions).toEqual(["updater:allow-check"]);
+  });
+
+  it("keeps the updater placeholders while limiting bundle configuration to macOS DMG", () => {
+    expect(tauriConfig.plugins.updater).toEqual({
+      pubkey: "__TAURI_UPDATER_PUBKEY__",
+      endpoints: ["__TAURI_UPDATER_ENDPOINT__"],
+    });
+    expect(tauriConfig.bundle.active).toBe(true);
+    expect(tauriConfig.bundle.createUpdaterArtifacts).toBe(true);
+    expect(tauriConfig.bundle.targets).toEqual(["dmg"]);
+    expect(tauriConfig.bundle.windows).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- add the missing Rust process plugin dependency and register it beside the updater plugin in desktop release builds
- split updater capabilities by window: main can check, download/install, and relaunch; about can only check; settings receives neither updater nor process access
- limit the default Tauri bundle target to macOS DMG while preserving updater artifacts and release-time endpoint/public-key placeholders
- add a focused contract test covering frontend/Rust dependencies, release registration, least-privilege capabilities, and macOS bundle configuration

This PR does not create a tag or a GitHub Release.

## TDD evidence

- initial contract run: 4/4 tests failed for the missing Rust dependency, process registration, minimum capabilities, and macOS-only configuration
- capability-split regression: failed while updater/process access still applied to all windows
- final focused run: 4/4 passed

## Verification

- `pnpm check` — 90 files / 428 tests passed; lint, formatting, TypeScript, and Vite build passed
- `cargo check --locked --manifest-path src-tauri/Cargo.toml` — passed
- `cargo test --locked --manifest-path src-tauri/Cargo.toml` — 584 passed / 2 ignored; doctests passed
- `cargo clippy --locked --manifest-path src-tauri/Cargo.toml --all-targets` — passed with 16 unchanged baseline warnings
- `pnpm tauri build --no-bundle -- --locked` — release-mode build passed
- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check` — passed
- `git diff --check` — passed
- independent Standards review — PASS
- independent Spec review — PASS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Update checks and installation are now available in the main desktop window.
  - The About window can check for available updates.
  - Update and restart access is limited to the appropriate app windows.

- **Platform Support**
  - Release update functionality is restricted to desktop builds.
  - macOS releases are packaged as DMG files.
  - The Windows NSIS installer and passive installation mode are no longer included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->