### PR TITLE
Use a safe macOS update fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "@tauri-apps/api": "^2.11.1",
     "@tauri-apps/plugin-global-shortcut": "^2.3.1",
     "@tauri-apps/plugin-opener": "^2",
-    "@tauri-apps/plugin-process": "^2.3.1",
     "@tauri-apps/plugin-updater": "^2.10.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,9 +35,6 @@ importers:
       '@tauri-apps/plugin-opener':
         specifier: ^2
         version: 2.5.3
-      '@tauri-apps/plugin-process':
-        specifier: ^2.3.1
-        version: 2.3.1
       '@tauri-apps/plugin-updater':
         specifier: ^2.10.0
         version: 2.10.0
@@ -1623,9 +1620,6 @@ packages:
 
   '@tauri-apps/plugin-opener@2.5.3':
     resolution: {integrity: sha512-CCcUltXMOfUEArbf3db3kCE7Ggy1ExBEBl51Ko2ODJ6GDYHRp1nSNlQm5uNCFY5k7/ufaK5Ib3Du/Zir19IYQQ==}
-
-  '@tauri-apps/plugin-process@2.3.1':
-    resolution: {integrity: sha512-nCa4fGVaDL/B9ai03VyPOjfAHRHSBz5v6F/ObsB73r/dA3MHHhZtldaDMIc0V/pnUw9ehzr2iEG+XkSEyC0JJA==}
 
   '@tauri-apps/plugin-updater@2.10.0':
     resolution: {integrity: sha512-ljN8jPlnT0aSn8ecYhuBib84alxfMx6Hc8vJSKMJyzGbTPFZAC44T2I1QNFZssgWKrAlofvJqCC6Rr472JWfkQ==}
@@ -4714,10 +4708,6 @@ snapshots:
       '@tauri-apps/api': 2.11.1
 
   '@tauri-apps/plugin-opener@2.5.3':
-    dependencies:
-      '@tauri-apps/api': 2.11.1
-
-  '@tauri-apps/plugin-process@2.3.1':
     dependencies:
       '@tauri-apps/api': 2.11.1
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1903,7 +1903,6 @@ dependencies = [
  "tauri-plugin-dialog",
  "tauri-plugin-global-shortcut",
  "tauri-plugin-opener",
- "tauri-plugin-process",
  "tauri-plugin-single-instance",
  "tauri-plugin-updater",
  "tempfile",
@@ -5340,16 +5339,6 @@ dependencies = [
  "url",
  "windows",
  "zbus",
-]
-
-[[package]]
-name = "tauri-plugin-process"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d55511a7bf6cd70c8767b02c97bf8134fa434daf3926cfc1be0a0f94132d165a"
-dependencies = [
- "tauri",
- "tauri-plugin",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -48,7 +48,6 @@ percent-encoding = "2"
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-single-instance = "2"
 tauri-plugin-updater = "2"
-tauri-plugin-process = "2"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src-tauri/capabilities/updater-about.json
+++ b/src-tauri/capabilities/updater-about.json
@@ -1,11 +1,7 @@
 {
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "updater-about",
-  "description": "Update and relaunch permissions for the about window",
+  "description": "Update check permission for the about window",
   "windows": ["about"],
-  "permissions": [
-    "updater:allow-check",
-    "updater:allow-download-and-install",
-    "process:allow-restart"
-  ]
+  "permissions": ["updater:allow-check"]
 }

--- a/src-tauri/capabilities/updater-about.json
+++ b/src-tauri/capabilities/updater-about.json
@@ -1,7 +1,11 @@
 {
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "updater-about",
-  "description": "Update check permission for the about window",
+  "description": "Update and relaunch permissions for the about window",
   "windows": ["about"],
-  "permissions": ["updater:allow-check"]
+  "permissions": [
+    "updater:allow-check",
+    "updater:allow-download-and-install",
+    "process:allow-restart"
+  ]
 }

--- a/src-tauri/capabilities/updater-main.json
+++ b/src-tauri/capabilities/updater-main.json
@@ -1,11 +1,7 @@
 {
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "updater-main",
-  "description": "Update installation and relaunch permissions for the main window",
+  "description": "Update check permission for the main window",
   "windows": ["main"],
-  "permissions": [
-    "updater:allow-check",
-    "updater:allow-download-and-install",
-    "process:allow-restart"
-  ]
+  "permissions": ["updater:allow-check"]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -265,11 +265,9 @@ pub fn run() {
             commands::repository_context_ask,
         ]);
 
-    // Only enable updater in release mode
+    // Only enable update checks in release mode
     #[cfg(all(desktop, not(debug_assertions)))]
-    let builder = builder
-        .plugin(tauri_plugin_updater::Builder::new().build())
-        .plugin(tauri_plugin_process::init());
+    let builder = builder.plugin(tauri_plugin_updater::Builder::new().build());
 
     builder
         .run(tauri::generate_context!())

--- a/src/components/updater-dialog.interaction.test.tsx
+++ b/src/components/updater-dialog.interaction.test.tsx
@@ -29,6 +29,7 @@ function reviewedUpdate() {
     version: "0.2.0",
     date: "2026-09-04",
     body: "Reviewed release notes",
+    close: vi.fn().mockResolvedValue(undefined),
   } as unknown as Update;
 }
 
@@ -53,6 +54,7 @@ describe("UpdaterDialog", () => {
     expect(windowApi.openExternalUrl).toHaveBeenCalledWith(
       "https://github.com/Excelius-Wang/harbor/releases/tag/v0.2.0"
     );
+    expect(update.close).toHaveBeenCalledTimes(1);
     expect(updaterPlugin.check).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/updater-dialog.interaction.test.tsx
+++ b/src/components/updater-dialog.interaction.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import type { Update } from "@tauri-apps/plugin-updater";
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -9,12 +9,12 @@ const updaterPlugin = vi.hoisted(() => ({
   check: vi.fn(),
 }));
 
-const processPlugin = vi.hoisted(() => ({
-  relaunch: vi.fn(),
+const windowApi = vi.hoisted(() => ({
+  openExternalUrl: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock("@tauri-apps/plugin-updater", () => updaterPlugin);
-vi.mock("@tauri-apps/plugin-process", () => processPlugin);
+vi.mock("@/lib/window", () => windowApi);
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
     t: (key: string, values?: { version?: string }) =>
@@ -24,12 +24,11 @@ vi.mock("react-i18next", () => ({
 
 import { UpdaterDialog } from "./updater-dialog";
 
-function reviewedUpdate(downloadAndInstall = vi.fn().mockResolvedValue(undefined)) {
+function reviewedUpdate() {
   return {
     version: "0.2.0",
     date: "2026-09-04",
     body: "Reviewed release notes",
-    downloadAndInstall,
   } as unknown as Update;
 }
 
@@ -40,7 +39,7 @@ afterEach(() => {
 });
 
 describe("UpdaterDialog", () => {
-  it("installs the update whose version and notes the user reviewed", async () => {
+  it("opens the checked release on GitHub instead of installing in-app", async () => {
     const user = userEvent.setup();
     const update = reviewedUpdate();
     updaterPlugin.check.mockResolvedValueOnce(update).mockResolvedValue(null);
@@ -49,80 +48,11 @@ describe("UpdaterDialog", () => {
 
     expect(await screen.findByText("updater.versionAvailable 0.2.0")).toBeTruthy();
     expect(screen.getByText("Reviewed release notes")).toBeTruthy();
-    await user.click(screen.getByRole("button", { name: "updater.installNow" }));
+    await user.click(screen.getByRole("button", { name: "updater.viewRelease" }));
 
-    await waitFor(() => {
-      expect(update.downloadAndInstall).toHaveBeenCalledTimes(1);
-    });
+    expect(windowApi.openExternalUrl).toHaveBeenCalledWith(
+      "https://github.com/Excelius-Wang/harbor/releases/tag/v0.2.0"
+    );
     expect(updaterPlugin.check).toHaveBeenCalledTimes(1);
-    expect(processPlugin.relaunch).toHaveBeenCalledTimes(1);
-  });
-
-  it("shows download failure, retries, and announces the restart", async () => {
-    const user = userEvent.setup();
-    let rejectFirstAttempt!: (reason: unknown) => void;
-    const firstAttempt = new Promise<void>((_resolve, reject) => {
-      rejectFirstAttempt = reject;
-    });
-    let finishRelaunch!: () => void;
-    const relaunchAttempt = new Promise<void>((resolve) => {
-      finishRelaunch = resolve;
-    });
-    type ProgressCallback = Parameters<Update["downloadAndInstall"]>[0];
-    const install = vi
-      .fn()
-      .mockImplementationOnce(async (onProgress: ProgressCallback) => {
-        onProgress?.({ event: "Started", data: { contentLength: 100 } });
-        await firstAttempt;
-      })
-      .mockImplementationOnce(async (onProgress: ProgressCallback) => {
-        onProgress?.({ event: "Started", data: { contentLength: 100 } });
-        onProgress?.({ event: "Progress", data: { chunkLength: 100 } });
-        onProgress?.({ event: "Finished" });
-      });
-    const update = reviewedUpdate(install);
-    updaterPlugin.check.mockResolvedValueOnce(update);
-    processPlugin.relaunch.mockReturnValue(relaunchAttempt);
-    vi.spyOn(console, "error").mockImplementation(() => {});
-
-    render(<UpdaterDialog />);
-    await screen.findByText("updater.versionAvailable 0.2.0");
-
-    await user.click(screen.getByRole("button", { name: "updater.installNow" }));
-    expect(await screen.findByText("updater.downloading")).toBeTruthy();
-
-    rejectFirstAttempt(new Error("download failed"));
-    expect(await screen.findByText("updater.installFailed")).toBeTruthy();
-
-    await user.click(screen.getByRole("button", { name: "updater.retry" }));
-    expect(await screen.findByText("updater.restarting")).toBeTruthy();
-    expect(update.downloadAndInstall).toHaveBeenCalledTimes(2);
-    expect(updaterPlugin.check).toHaveBeenCalledTimes(1);
-    finishRelaunch();
-  });
-
-  it("keeps the installed state and retries only relaunch after relaunch fails", async () => {
-    const user = userEvent.setup();
-    const update = reviewedUpdate();
-    updaterPlugin.check.mockResolvedValueOnce(update);
-    processPlugin.relaunch
-      .mockRejectedValueOnce(new Error("relaunch failed"))
-      .mockResolvedValueOnce(undefined);
-    vi.spyOn(console, "error").mockImplementation(() => {});
-
-    render(<UpdaterDialog />);
-    await screen.findByText("updater.versionAvailable 0.2.0");
-
-    await user.click(screen.getByRole("button", { name: "updater.installNow" }));
-    expect(await screen.findByText("updater.relaunchFailed")).toBeTruthy();
-    expect(update.downloadAndInstall).toHaveBeenCalledTimes(1);
-
-    await user.click(screen.getByRole("button", { name: "updater.retryRestart" }));
-    await waitFor(() => {
-      expect(processPlugin.relaunch).toHaveBeenCalledTimes(2);
-    });
-    expect(update.downloadAndInstall).toHaveBeenCalledTimes(1);
-    expect(updaterPlugin.check).toHaveBeenCalledTimes(1);
-    expect(screen.getByText("updater.restarting")).toBeTruthy();
   });
 });

--- a/src/components/updater-dialog.tsx
+++ b/src/components/updater-dialog.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState, type ReactNode } from "react";
-import { useUpdater, type UpdateInstallStatus } from "@/hooks/use-updater";
+import { useEffect, useState } from "react";
+import { useUpdater } from "@/hooks/use-updater";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -9,24 +9,20 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { Progress } from "@/components/ui/progress";
-import { Alert, AlertDescription } from "@/components/ui/alert";
-import { Spinner } from "@/components/ui/spinner";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
-import { CircleAlert } from "lucide-react";
+import { openExternalUrl } from "@/lib/window";
+import packageJson from "../../package.json";
+import type { Update } from "@tauri-apps/plugin-updater";
 
-interface UpdaterInstallDialogProps {
-  updater: ReturnType<typeof useUpdater>;
+interface UpdaterAvailableDialogProps {
+  update: Update | null;
 }
 
-interface InstallPresentation {
-  titleKey: string;
-  description: ReactNode;
-  action: {
-    labelKey: string;
-    run: () => void;
-  } | null;
+const projectSourceUrl = packageJson.repository.url.replace(/\.git$/, "");
+
+function getReleaseUrl(version: string) {
+  return `${projectSourceUrl}/releases/tag/v${encodeURIComponent(version)}`;
 }
 
 export function UpdaterDialog() {
@@ -37,11 +33,10 @@ export function UpdaterDialog() {
     void checkUpdate();
   }, [checkUpdate]);
 
-  return <UpdaterInstallDialog updater={updater} />;
+  return <UpdaterAvailableDialog update={updater.update} />;
 }
 
-export function UpdaterInstallDialog({ updater }: UpdaterInstallDialogProps) {
-  const { update, installStatus, progress, installUpdate, relaunchAfterUpdate } = updater;
+export function UpdaterAvailableDialog({ update }: UpdaterAvailableDialogProps) {
   const [open, setOpen] = useState(false);
   const { t } = useTranslation();
 
@@ -55,103 +50,35 @@ export function UpdaterInstallDialog({ updater }: UpdaterInstallDialogProps) {
     setOpen(false);
   };
 
-  const getProgressPercentage = () => {
-    if (!progress || progress.event === "Started") return 0;
-    const { downloaded, contentLength } = progress.data || {};
-    if (!contentLength) return 0;
-    if (progress.event === "Finished") return 100;
-    return Math.round(((downloaded ?? 0) / contentLength) * 100);
-  };
-
-  const presentations: Record<UpdateInstallStatus, InstallPresentation> = {
-    idle: {
-      titleKey: "updater.updateAvailable",
-      description: (
-        <div className="flex flex-col gap-2">
-          <p>{t("updater.versionAvailable", { version: update?.version })}</p>
-          {update?.body && (
-            <div className="bg-muted mt-2 rounded-md p-3 text-sm">
-              <p className="font-semibold">{t("updater.releaseNotes")}</p>
-              <p className="mt-1 whitespace-pre-wrap">{update.body}</p>
-            </div>
-          )}
-        </div>
-      ),
-      action: {
-        labelKey: "updater.installNow",
-        run: () => void installUpdate(),
-      },
-    },
-    downloading: {
-      titleKey: "updater.downloading",
-      description: (
-        <div className="flex flex-col gap-2">
-          <p>{t("updater.installingVersion", { version: update?.version })}</p>
-          <Progress value={getProgressPercentage()} />
-        </div>
-      ),
-      action: null,
-    },
-    failed: {
-      titleKey: "updater.installFailed",
-      description: (
-        <Alert variant="destructive">
-          <CircleAlert />
-          <AlertDescription>
-            {t("updater.installFailedDescription", { version: update?.version })}
-          </AlertDescription>
-        </Alert>
-      ),
-      action: {
-        labelKey: "updater.retry",
-        run: () => void installUpdate(),
-      },
-    },
-    restarting: {
-      titleKey: "updater.restarting",
-      description: (
-        <div className="flex items-center gap-2">
-          <Spinner />
-          <p>{t("updater.restartingDescription", { version: update?.version })}</p>
-        </div>
-      ),
-      action: null,
-    },
-    "relaunch-failed": {
-      titleKey: "updater.relaunchFailed",
-      description: (
-        <Alert variant="destructive">
-          <CircleAlert />
-          <AlertDescription>
-            {t("updater.relaunchFailedDescription", { version: update?.version })}
-          </AlertDescription>
-        </Alert>
-      ),
-      action: {
-        labelKey: "updater.retryRestart",
-        run: () => void relaunchAfterUpdate(),
-      },
-    },
-  };
-  const presentation = presentations[installStatus];
-
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>{t(presentation.titleKey)}</DialogTitle>
+          <DialogTitle>{t("updater.updateAvailable")}</DialogTitle>
           <DialogDescription asChild>
-            <div>{presentation.description}</div>
+            <div className="flex flex-col gap-2">
+              <p>{t("updater.versionAvailable", { version: update?.version })}</p>
+              {update?.body && (
+                <div className="bg-muted mt-2 rounded-md p-3 text-sm">
+                  <p className="font-semibold">{t("updater.releaseNotes")}</p>
+                  <p className="mt-1 whitespace-pre-wrap">{update.body}</p>
+                </div>
+              )}
+            </div>
           </DialogDescription>
         </DialogHeader>
-        {presentation.action && (
-          <DialogFooter>
-            <Button variant="outline" onClick={handleCancel}>
-              {t("updater.later")}
-            </Button>
-            <Button onClick={presentation.action.run}>{t(presentation.action.labelKey)}</Button>
-          </DialogFooter>
-        )}
+        <DialogFooter>
+          <Button variant="outline" onClick={handleCancel}>
+            {t("updater.later")}
+          </Button>
+          <Button
+            onClick={() => {
+              if (update) void openExternalUrl(getReleaseUrl(update.version));
+            }}
+          >
+            {t("updater.viewRelease")}
+          </Button>
+        </DialogFooter>
       </DialogContent>
     </Dialog>
   );
@@ -159,7 +86,7 @@ export function UpdaterInstallDialog({ updater }: UpdaterInstallDialogProps) {
 
 export function useManualUpdateCheck() {
   const updater = useUpdater();
-  const { checkUpdate, checking } = updater;
+  const { update, checkUpdate, checking } = updater;
   const [showNoUpdate, setShowNoUpdate] = useState(false);
   const { t } = useTranslation();
 
@@ -178,7 +105,7 @@ export function useManualUpdateCheck() {
   };
 
   return {
-    updater,
+    update,
     checkUpdate: handleCheckUpdate,
     checking,
     showNoUpdate,

--- a/src/components/updater-dialog.tsx
+++ b/src/components/updater-dialog.tsx
@@ -16,9 +16,8 @@ import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { CircleAlert } from "lucide-react";
 
-interface UpdaterDialogProps {
-  manualCheck?: boolean;
-  onCheckComplete?: () => void;
+interface UpdaterInstallDialogProps {
+  updater: ReturnType<typeof useUpdater>;
 }
 
 interface InstallPresentation {
@@ -30,33 +29,27 @@ interface InstallPresentation {
   } | null;
 }
 
-export function UpdaterDialog({ manualCheck = false, onCheckComplete }: UpdaterDialogProps) {
-  const {
-    update,
-    checking,
-    installStatus,
-    progress,
-    checkUpdate,
-    installUpdate,
-    relaunchAfterUpdate,
-  } = useUpdater();
+export function UpdaterDialog() {
+  const updater = useUpdater();
+  const { checkUpdate } = updater;
+
+  useEffect(() => {
+    void checkUpdate();
+  }, [checkUpdate]);
+
+  return <UpdaterInstallDialog updater={updater} />;
+}
+
+export function UpdaterInstallDialog({ updater }: UpdaterInstallDialogProps) {
+  const { update, installStatus, progress, installUpdate, relaunchAfterUpdate } = updater;
   const [open, setOpen] = useState(false);
   const { t } = useTranslation();
 
   useEffect(() => {
-    if (!manualCheck) {
-      void checkUpdate();
-    }
-  }, [manualCheck, checkUpdate]);
-
-  useEffect(() => {
     if (update) {
       setOpen(true);
-      onCheckComplete?.();
-    } else if (manualCheck && !checking) {
-      onCheckComplete?.();
     }
-  }, [update, checking, manualCheck, onCheckComplete]);
+  }, [update]);
 
   const handleCancel = () => {
     setOpen(false);
@@ -165,7 +158,8 @@ export function UpdaterDialog({ manualCheck = false, onCheckComplete }: UpdaterD
 }
 
 export function useManualUpdateCheck() {
-  const { checkUpdate, checking, update } = useUpdater();
+  const updater = useUpdater();
+  const { checkUpdate, checking } = updater;
   const [showNoUpdate, setShowNoUpdate] = useState(false);
   const { t } = useTranslation();
 
@@ -184,10 +178,9 @@ export function useManualUpdateCheck() {
   };
 
   return {
+    updater,
     checkUpdate: handleCheckUpdate,
     checking,
-    hasUpdate: !!update,
     showNoUpdate,
-    dismissNoUpdate: () => setShowNoUpdate(false),
   };
 }

--- a/src/components/updater-dialog.tsx
+++ b/src/components/updater-dialog.tsx
@@ -12,11 +12,11 @@ import {
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { openExternalUrl } from "@/lib/window";
+import type { AvailableUpdate } from "@/lib/updater";
 import packageJson from "../../package.json";
-import type { Update } from "@tauri-apps/plugin-updater";
 
 interface UpdaterAvailableDialogProps {
-  update: Update | null;
+  update: AvailableUpdate | null;
 }
 
 const projectSourceUrl = packageJson.repository.url.replace(/\.git$/, "");

--- a/src/hooks/use-updater.ts
+++ b/src/hooks/use-updater.ts
@@ -1,25 +1,10 @@
 import { useCallback, useState } from "react";
-import {
-  checkForUpdates,
-  downloadAndInstall,
-  restartApplication,
-  UpdateProgress,
-  UpdateCheckResult,
-} from "@/lib/updater";
+import { checkForUpdates, type UpdateCheckResult } from "@/lib/updater";
 import type { Update } from "@tauri-apps/plugin-updater";
-
-export type UpdateInstallStatus =
-  | "idle"
-  | "downloading"
-  | "failed"
-  | "restarting"
-  | "relaunch-failed";
 
 export function useUpdater() {
   const [update, setUpdate] = useState<Update | null>(null);
   const [checking, setChecking] = useState(false);
-  const [installStatus, setInstallStatus] = useState<UpdateInstallStatus>("idle");
-  const [progress, setProgress] = useState<UpdateProgress | null>(null);
 
   const checkUpdate = useCallback(async (): Promise<UpdateCheckResult> => {
     setChecking(true);
@@ -32,43 +17,9 @@ export function useUpdater() {
     }
   }, []);
 
-  const relaunchAfterUpdate = useCallback(async () => {
-    setInstallStatus("restarting");
-    try {
-      await restartApplication();
-    } catch (error) {
-      console.error("Failed to relaunch after update:", error);
-      setInstallStatus("relaunch-failed");
-    }
-  }, []);
-
-  const installUpdate = useCallback(async () => {
-    if (!update) {
-      return;
-    }
-
-    setInstallStatus("downloading");
-    setProgress(null);
-    try {
-      await downloadAndInstall(update, (progressEvent) => {
-        setProgress(progressEvent);
-      });
-    } catch (error) {
-      console.error("Failed to install update:", error);
-      setInstallStatus("failed");
-      return;
-    }
-
-    await relaunchAfterUpdate();
-  }, [relaunchAfterUpdate, update]);
-
   return {
     update,
     checking,
-    installStatus,
-    progress,
     checkUpdate,
-    installUpdate,
-    relaunchAfterUpdate,
   };
 }

--- a/src/hooks/use-updater.ts
+++ b/src/hooks/use-updater.ts
@@ -1,9 +1,8 @@
 import { useCallback, useState } from "react";
-import { checkForUpdates, type UpdateCheckResult } from "@/lib/updater";
-import type { Update } from "@tauri-apps/plugin-updater";
+import { checkForUpdates, type AvailableUpdate, type UpdateCheckResult } from "@/lib/updater";
 
 export function useUpdater() {
-  const [update, setUpdate] = useState<Update | null>(null);
+  const [update, setUpdate] = useState<AvailableUpdate | null>(null);
   const [checking, setChecking] = useState(false);
 
   const checkUpdate = useCallback(async (): Promise<UpdateCheckResult> => {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2907,20 +2907,10 @@
     "checkFailed": "Failed to check for updates.",
     "upToDate": "You're using the latest version!",
     "updateAvailable": "Update Available",
-    "downloading": "Downloading Update",
-    "installingVersion": "Installing version {{version}}...",
     "versionAvailable": "Version {{version}} is available.",
     "releaseNotes": "Release Notes:",
     "later": "Later",
-    "installNow": "Install Now",
-    "installFailed": "Update Failed",
-    "installFailedDescription": "Harbor couldn't install version {{version}}. Check your connection and try again.",
-    "retry": "Retry",
-    "restarting": "Restarting Harbor",
-    "restartingDescription": "Version {{version}} is installed. Harbor is restarting...",
-    "relaunchFailed": "Restart Failed",
-    "relaunchFailedDescription": "Version {{version}} is installed, but Harbor couldn't restart. Try again or reopen Harbor manually.",
-    "retryRestart": "Restart Now"
+    "viewRelease": "View Release"
   },
   "settings": {
     "title": "Settings",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -2900,20 +2900,10 @@
     "checkFailed": "检查更新失败。",
     "upToDate": "您正在使用最新版本！",
     "updateAvailable": "发现新版本",
-    "downloading": "正在下载更新",
-    "installingVersion": "正在安装版本 {{version}}...",
     "versionAvailable": "版本 {{version}} 可用。",
     "releaseNotes": "更新说明：",
     "later": "稍后",
-    "installNow": "立即安装",
-    "installFailed": "更新失败",
-    "installFailedDescription": "Harbor 无法安装版本 {{version}}。请检查网络连接后重试。",
-    "retry": "重试",
-    "restarting": "正在重启 Harbor",
-    "restartingDescription": "版本 {{version}} 已安装，Harbor 正在重启...",
-    "relaunchFailed": "重启失败",
-    "relaunchFailedDescription": "版本 {{version}} 已安装，但 Harbor 无法自动重启。请重试，或手动退出并重新打开 Harbor。",
-    "retryRestart": "立即重启"
+    "viewRelease": "查看发布页面"
   },
   "settings": {
     "title": "设置",

--- a/src/lib/updater.test.ts
+++ b/src/lib/updater.test.ts
@@ -5,26 +5,20 @@ const updaterPlugin = vi.hoisted(() => ({
   check: vi.fn(),
 }));
 
-const processPlugin = vi.hoisted(() => ({
-  relaunch: vi.fn(),
-}));
-
 vi.mock("@tauri-apps/plugin-updater", () => updaterPlugin);
-vi.mock("@tauri-apps/plugin-process", () => processPlugin);
 
-import { checkForUpdates, downloadAndInstall, restartApplication } from "./updater";
+import { checkForUpdates } from "./updater";
 
 afterEach(() => {
   vi.clearAllMocks();
 });
 
 describe("desktop updater", () => {
-  it("installs the same update that was checked and reviewed", async () => {
+  it("returns the exact update metadata that was checked", async () => {
     const reviewedUpdate = {
       version: "0.2.0",
       date: "2026-09-04",
       body: "Reviewed release notes",
-      downloadAndInstall: vi.fn().mockResolvedValue(undefined),
     } as unknown as Update;
     updaterPlugin.check.mockResolvedValueOnce(reviewedUpdate).mockResolvedValueOnce(null);
 
@@ -35,13 +29,7 @@ describe("desktop updater", () => {
       throw new Error("Expected an available update");
     }
 
-    await downloadAndInstall(result.update);
-
+    expect(result.update).toBe(reviewedUpdate);
     expect(updaterPlugin.check).toHaveBeenCalledTimes(1);
-    expect(reviewedUpdate.downloadAndInstall).toHaveBeenCalledTimes(1);
-
-    await restartApplication();
-
-    expect(processPlugin.relaunch).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/lib/updater.test.ts
+++ b/src/lib/updater.test.ts
@@ -19,6 +19,7 @@ describe("desktop updater", () => {
       version: "0.2.0",
       date: "2026-09-04",
       body: "Reviewed release notes",
+      close: vi.fn().mockResolvedValue(undefined),
     } as unknown as Update;
     updaterPlugin.check.mockResolvedValueOnce(reviewedUpdate).mockResolvedValueOnce(null);
 
@@ -29,7 +30,13 @@ describe("desktop updater", () => {
       throw new Error("Expected an available update");
     }
 
-    expect(result.update).toBe(reviewedUpdate);
+    expect(result.update).toEqual({
+      version: "0.2.0",
+      date: "2026-09-04",
+      body: "Reviewed release notes",
+    });
+    expect(result.update).not.toBe(reviewedUpdate);
+    expect(reviewedUpdate.close).toHaveBeenCalledTimes(1);
     expect(updaterPlugin.check).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -1,15 +1,5 @@
 import { check } from "@tauri-apps/plugin-updater";
 import type { Update } from "@tauri-apps/plugin-updater";
-import { relaunch } from "@tauri-apps/plugin-process";
-
-export interface UpdateProgress {
-  event: "Started" | "Progress" | "Finished";
-  data?: {
-    contentLength?: number;
-    chunkLength?: number;
-    downloaded?: number;
-  };
-}
 
 export type UpdateCheckResult =
   | { status: "available"; update: Update }
@@ -28,43 +18,4 @@ export async function checkForUpdates(): Promise<UpdateCheckResult> {
     console.error("Failed to check for updates:", error);
     return { status: "error", error };
   }
-}
-
-export async function downloadAndInstall(
-  update: Update,
-  onProgress?: (progress: UpdateProgress) => void
-) {
-  console.log(`Found update ${update.version} from ${update.date} with notes: ${update.body}`);
-
-  let downloaded = 0;
-  let contentLength = 0;
-
-  await update.downloadAndInstall((event) => {
-    switch (event.event) {
-      case "Started":
-        contentLength = event.data.contentLength!;
-        console.log(`Started downloading ${event.data.contentLength} bytes`);
-        onProgress?.({ event: "Started", data: { ...event.data, downloaded: 0 } });
-        break;
-      case "Progress":
-        downloaded += event.data.chunkLength;
-        console.log(`Downloaded ${downloaded} from ${contentLength}`);
-        onProgress?.({
-          event: "Progress",
-          data: { ...event.data, contentLength, downloaded },
-        });
-        break;
-      case "Finished":
-        console.log("Download finished");
-        onProgress?.({ event: "Finished", data: { contentLength, downloaded } });
-        break;
-    }
-  });
-
-  console.log("Update installed");
-  return true;
-}
-
-export async function restartApplication() {
-  await relaunch();
 }

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -1,15 +1,26 @@
 import { check } from "@tauri-apps/plugin-updater";
-import type { Update } from "@tauri-apps/plugin-updater";
+
+export interface AvailableUpdate {
+  version: string;
+  date?: string;
+  body?: string;
+}
 
 export type UpdateCheckResult =
-  | { status: "available"; update: Update }
+  | { status: "available"; update: AvailableUpdate }
   | { status: "up-to-date" }
   | { status: "error"; error: unknown };
 
 export async function checkForUpdates(): Promise<UpdateCheckResult> {
   try {
-    const update = await check();
-    if (update) {
+    const checkedUpdate = await check();
+    if (checkedUpdate) {
+      const update = {
+        version: checkedUpdate.version,
+        date: checkedUpdate.date,
+        body: checkedUpdate.body,
+      };
+      await checkedUpdate.close();
       return { status: "available", update };
     }
 

--- a/src/pages/about.interaction.test.tsx
+++ b/src/pages/about.interaction.test.tsx
@@ -56,6 +56,7 @@ function reviewedUpdate() {
     version: "0.2.0",
     date: "2026-09-04",
     body: "Manual release notes",
+    close: vi.fn().mockResolvedValue(undefined),
   } as unknown as Update;
 }
 
@@ -83,6 +84,7 @@ describe("AboutPage updater", () => {
         "https://github.com/Excelius-Wang/harbor/releases/tag/v0.2.0"
       );
     });
+    expect(update.close).toHaveBeenCalledTimes(1);
     expect(updaterPlugin.check).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/pages/about.interaction.test.tsx
+++ b/src/pages/about.interaction.test.tsx
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+
+import type { Update } from "@tauri-apps/plugin-updater";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const updaterPlugin = vi.hoisted(() => ({
+  check: vi.fn(),
+}));
+
+const processPlugin = vi.hoisted(() => ({
+  relaunch: vi.fn(),
+}));
+
+const aboutWindow = vi.hoisted(() => ({
+  label: "about",
+  onCloseRequested: vi.fn().mockResolvedValue(vi.fn()),
+  onFocusChanged: vi.fn().mockResolvedValue(vi.fn()),
+}));
+
+vi.mock("@tauri-apps/plugin-updater", () => updaterPlugin);
+vi.mock("@tauri-apps/plugin-process", () => processPlugin);
+vi.mock("@tauri-apps/api/app", () => ({
+  getVersion: vi.fn().mockResolvedValue("0.1.0"),
+}));
+vi.mock("@tauri-apps/api/webviewWindow", () => ({
+  getCurrentWebviewWindow: () => aboutWindow,
+}));
+vi.mock("@/lib/window", () => ({
+  cancelDestroyWindow: vi.fn(),
+  destroyWindow: vi.fn().mockResolvedValue(undefined),
+  openExternalUrl: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("@/components/title-bar", () => ({
+  TitleBar: () => null,
+}));
+vi.mock("@/components/window-frame", () => ({
+  WindowFrame: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+vi.mock("@/components/ui/sonner", () => ({
+  Toaster: () => null,
+}));
+vi.mock("@/hooks/use-app-translation", () => ({
+  useAppTranslation: () => ({ t: (key: string) => key }),
+}));
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, values?: { version?: string }) =>
+      values?.version ? `${key} ${values.version}` : key,
+  }),
+}));
+
+import AboutPage from "./about";
+
+function reviewedUpdate() {
+  return {
+    version: "0.2.0",
+    date: "2026-09-04",
+    body: "Manual release notes",
+    downloadAndInstall: vi.fn().mockResolvedValue(undefined),
+  } as unknown as Update;
+}
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  vi.resetAllMocks();
+});
+
+describe("AboutPage updater", () => {
+  it("installs and relaunches the exact update found by the manual check", async () => {
+    const user = userEvent.setup();
+    const update = reviewedUpdate();
+    updaterPlugin.check.mockResolvedValueOnce(update);
+    processPlugin.relaunch.mockResolvedValueOnce(undefined);
+
+    render(<AboutPage />);
+    await user.click(screen.getByRole("button", { name: "updater.checkForUpdates" }));
+
+    expect(await screen.findByText("updater.versionAvailable 0.2.0")).toBeTruthy();
+    expect(screen.getByText("Manual release notes")).toBeTruthy();
+    await user.click(screen.getByRole("button", { name: "updater.installNow" }));
+
+    await waitFor(() => {
+      expect(update.downloadAndInstall).toHaveBeenCalledTimes(1);
+      expect(processPlugin.relaunch).toHaveBeenCalledTimes(1);
+    });
+    expect(updaterPlugin.check).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/pages/about.interaction.test.tsx
+++ b/src/pages/about.interaction.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 
 import type { Update } from "@tauri-apps/plugin-updater";
+import type { ReactNode } from "react";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -9,34 +10,31 @@ const updaterPlugin = vi.hoisted(() => ({
   check: vi.fn(),
 }));
 
-const processPlugin = vi.hoisted(() => ({
-  relaunch: vi.fn(),
-}));
-
 const aboutWindow = vi.hoisted(() => ({
   label: "about",
   onCloseRequested: vi.fn().mockResolvedValue(vi.fn()),
   onFocusChanged: vi.fn().mockResolvedValue(vi.fn()),
 }));
 
+const windowApi = vi.hoisted(() => ({
+  cancelDestroyWindow: vi.fn(),
+  destroyWindow: vi.fn().mockResolvedValue(undefined),
+  openExternalUrl: vi.fn().mockResolvedValue(undefined),
+}));
+
 vi.mock("@tauri-apps/plugin-updater", () => updaterPlugin);
-vi.mock("@tauri-apps/plugin-process", () => processPlugin);
 vi.mock("@tauri-apps/api/app", () => ({
   getVersion: vi.fn().mockResolvedValue("0.1.0"),
 }));
 vi.mock("@tauri-apps/api/webviewWindow", () => ({
   getCurrentWebviewWindow: () => aboutWindow,
 }));
-vi.mock("@/lib/window", () => ({
-  cancelDestroyWindow: vi.fn(),
-  destroyWindow: vi.fn().mockResolvedValue(undefined),
-  openExternalUrl: vi.fn().mockResolvedValue(undefined),
-}));
+vi.mock("@/lib/window", () => windowApi);
 vi.mock("@/components/title-bar", () => ({
   TitleBar: () => null,
 }));
 vi.mock("@/components/window-frame", () => ({
-  WindowFrame: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  WindowFrame: ({ children }: { children: ReactNode }) => <>{children}</>,
 }));
 vi.mock("@/components/ui/sonner", () => ({
   Toaster: () => null,
@@ -58,7 +56,6 @@ function reviewedUpdate() {
     version: "0.2.0",
     date: "2026-09-04",
     body: "Manual release notes",
-    downloadAndInstall: vi.fn().mockResolvedValue(undefined),
   } as unknown as Update;
 }
 
@@ -69,22 +66,22 @@ afterEach(() => {
 });
 
 describe("AboutPage updater", () => {
-  it("installs and relaunches the exact update found by the manual check", async () => {
+  it("opens the exact checked version on GitHub instead of installing in-app", async () => {
     const user = userEvent.setup();
     const update = reviewedUpdate();
     updaterPlugin.check.mockResolvedValueOnce(update);
-    processPlugin.relaunch.mockResolvedValueOnce(undefined);
 
     render(<AboutPage />);
     await user.click(screen.getByRole("button", { name: "updater.checkForUpdates" }));
 
     expect(await screen.findByText("updater.versionAvailable 0.2.0")).toBeTruthy();
     expect(screen.getByText("Manual release notes")).toBeTruthy();
-    await user.click(screen.getByRole("button", { name: "updater.installNow" }));
+    await user.click(screen.getByRole("button", { name: "updater.viewRelease" }));
 
     await waitFor(() => {
-      expect(update.downloadAndInstall).toHaveBeenCalledTimes(1);
-      expect(processPlugin.relaunch).toHaveBeenCalledTimes(1);
+      expect(windowApi.openExternalUrl).toHaveBeenCalledWith(
+        "https://github.com/Excelius-Wang/harbor/releases/tag/v0.2.0"
+      );
     });
     expect(updaterPlugin.check).toHaveBeenCalledTimes(1);
   });

--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -9,7 +9,7 @@ import { WindowFrame } from "@/components/window-frame";
 import { Toaster } from "@/components/ui/sonner";
 import { useAppTranslation } from "@/hooks/use-app-translation";
 import { cancelDestroyWindow, destroyWindow, openExternalUrl } from "@/lib/window";
-import { UpdaterInstallDialog, useManualUpdateCheck } from "@/components/updater-dialog";
+import { UpdaterAvailableDialog, useManualUpdateCheck } from "@/components/updater-dialog";
 import packageJson from "../../package.json";
 
 const techVersions = {
@@ -23,7 +23,7 @@ const projectSourceUrl = packageJson.repository.url.replace(/\.git$/, "");
 export default function AboutPage() {
   const [appVersion, setAppVersion] = useState("");
   const { t } = useAppTranslation();
-  const { updater, checkUpdate, checking, showNoUpdate } = useManualUpdateCheck();
+  const { update, checkUpdate, checking, showNoUpdate } = useManualUpdateCheck();
 
   useEffect(() => {
     void getVersion().then(setAppVersion);
@@ -55,7 +55,7 @@ export default function AboutPage() {
       titleBar={<TitleBar title={t("about.title")} showMinimize={false} showMaximize={false} />}
       contentClassName="flex flex-1 items-center justify-center overflow-hidden"
     >
-      <UpdaterInstallDialog updater={updater} />
+      <UpdaterAvailableDialog update={update} />
       <Toaster />
       <div className="flex w-full max-w-xs flex-col gap-6">
         <div className="text-center">

--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -6,9 +6,10 @@ import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import { TitleBar } from "@/components/title-bar";
 import { WindowFrame } from "@/components/window-frame";
+import { Toaster } from "@/components/ui/sonner";
 import { useAppTranslation } from "@/hooks/use-app-translation";
 import { cancelDestroyWindow, destroyWindow, openExternalUrl } from "@/lib/window";
-import { useManualUpdateCheck } from "@/components/updater-dialog";
+import { UpdaterInstallDialog, useManualUpdateCheck } from "@/components/updater-dialog";
 import packageJson from "../../package.json";
 
 const techVersions = {
@@ -22,7 +23,7 @@ const projectSourceUrl = packageJson.repository.url.replace(/\.git$/, "");
 export default function AboutPage() {
   const [appVersion, setAppVersion] = useState("");
   const { t } = useAppTranslation();
-  const { checkUpdate, checking, showNoUpdate } = useManualUpdateCheck();
+  const { updater, checkUpdate, checking, showNoUpdate } = useManualUpdateCheck();
 
   useEffect(() => {
     void getVersion().then(setAppVersion);
@@ -54,6 +55,8 @@ export default function AboutPage() {
       titleBar={<TitleBar title={t("about.title")} showMinimize={false} showMaximize={false} />}
       contentClassName="flex flex-1 items-center justify-center overflow-hidden"
     >
+      <UpdaterInstallDialog updater={updater} />
+      <Toaster />
       <div className="flex w-full max-w-xs flex-col gap-6">
         <div className="text-center">
           <h2 className="text-2xl font-bold">{t("about.appName")}</h2>

--- a/src/tauri-updater-contract.test.ts
+++ b/src/tauri-updater-contract.test.ts
@@ -64,7 +64,11 @@ describe("Tauri updater contract", () => {
       )
     );
     expect(aboutCapability.windows).toEqual(["about"]);
-    expect(aboutCapability.permissions).toEqual(["updater:allow-check"]);
+    expect(aboutCapability.permissions).toEqual([
+      "updater:allow-check",
+      "updater:allow-download-and-install",
+      "process:allow-restart",
+    ]);
   });
 
   it("keeps the updater placeholders while limiting bundle configuration to macOS DMG", () => {

--- a/src/tauri-updater-contract.test.ts
+++ b/src/tauri-updater-contract.test.ts
@@ -18,16 +18,16 @@ const tauriConfig = JSON.parse(
 );
 
 describe("Tauri updater contract", () => {
-  it("keeps matching frontend and Rust plugins for update installation and relaunch", () => {
+  it("keeps the updater plugin without enabling in-app relaunch", () => {
     expect(packageJson.dependencies["@tauri-apps/plugin-updater"]).toBeDefined();
-    expect(packageJson.dependencies["@tauri-apps/plugin-process"]).toBeDefined();
+    expect("@tauri-apps/plugin-process" in packageJson.dependencies).toBe(false);
     expect(cargoToml).toContain('tauri-plugin-updater = "2"');
-    expect(cargoToml).toContain('tauri-plugin-process = "2"');
+    expect(cargoToml).not.toContain("tauri-plugin-process");
     expect(cargoLock).toContain('name = "tauri-plugin-updater"');
-    expect(cargoLock).toContain('name = "tauri-plugin-process"');
+    expect(cargoLock).not.toContain('name = "tauri-plugin-process"');
   });
 
-  it("registers updater and process together for release builds", () => {
+  it("registers only the updater plugin for release builds", () => {
     const releasePluginBlock = tauriLib.match(
       /#\[cfg\(all\(desktop,\s*not\(debug_assertions\)\)\)\]\s*let\s+builder\s*=\s*builder(?<plugins>[\s\S]*?);/
     );
@@ -35,10 +35,10 @@ describe("Tauri updater contract", () => {
 
     expect(releasePluginBlock).not.toBeNull();
     expect(releasePlugins).toContain("tauri_plugin_updater::Builder::new().build()");
-    expect(releasePlugins).toContain("tauri_plugin_process::init()");
+    expect(releasePlugins).not.toContain("tauri_plugin_process::init()");
   });
 
-  it("grants only the process capability needed to relaunch after installation", () => {
+  it("grants check-only updater access to main and about", () => {
     expect(defaultCapability.windows).toEqual(["main", "about", "settings"]);
     expect(
       defaultCapability.permissions.some(
@@ -51,11 +51,7 @@ describe("Tauri updater contract", () => {
       readFileSync(path.join(projectRoot, "src-tauri", "capabilities", "updater-main.json"), "utf8")
     );
     expect(mainCapability.windows).toEqual(["main"]);
-    expect(mainCapability.permissions).toEqual([
-      "updater:allow-check",
-      "updater:allow-download-and-install",
-      "process:allow-restart",
-    ]);
+    expect(mainCapability.permissions).toEqual(["updater:allow-check"]);
 
     const aboutCapability = JSON.parse(
       readFileSync(
@@ -64,11 +60,7 @@ describe("Tauri updater contract", () => {
       )
     );
     expect(aboutCapability.windows).toEqual(["about"]);
-    expect(aboutCapability.permissions).toEqual([
-      "updater:allow-check",
-      "updater:allow-download-and-install",
-      "process:allow-restart",
-    ]);
+    expect(aboutCapability.permissions).toEqual(["updater:allow-check"]);
   });
 
   it("keeps the updater placeholders while limiting bundle configuration to macOS DMG", () => {


### PR DESCRIPTION
## Summary
- keep automatic and manual update checks while sharing the checked metadata with the dialog
- open the exact `v{version}` GitHub Release page for signed DMG installation
- disable in-app `.app` replacement while upstream tauri-plugin-updater issue #3505 remains open
- remove process integration and limit main/about to check-only updater permissions
- cover both update entry points and the Tauri capability/runtime contract

## Verification
- pnpm check (91 files, 427 tests)
- cargo fmt --manifest-path src-tauri/Cargo.toml -- --check
- cargo check --manifest-path src-tauri/Cargo.toml --locked
- cargo test --manifest-path src-tauri/Cargo.toml --locked (584 passed, 2 ignored)
- pnpm tauri build --no-bundle -- --locked
- independent Standards review: PASS
- independent Spec review: PASS

## Upstream
- https://github.com/tauri-apps/plugins-workspace/issues/3505

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changed**
  * Update checks now show available version details and release notes.
  * Users can open the release page to review updates externally.
  * In-app downloading, installation, progress tracking, retry, and relaunch controls are no longer available.
  * About page update checks use the streamlined release-viewing experience.
  * Update permissions are limited to checking for available releases.
  * English and Chinese updater messages now reflect the release-page workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->