### PR TITLE
Fit the main window and clean up discovery navigation overflow

### DIFF
--- a/.cairn/items/adaptive-main-window.md
+++ b/.cairn/items/adaptive-main-window.md
@@ -9,12 +9,17 @@ through a clean pull request.
 
 ## Current state
 
-Commit `a3ddfb99c9cbf3b51f4df0fd0308854d55f928f2` is pushed on branch
+Commits `a3ddfb99c9cbf3b51f4df0fd0308854d55f928f2` and `136e610` are on branch
 `fix/adaptive-main-window-size-20260904`. Ready PR #79 is open at
 `https://github.com/Excelius-Wang/harbor/pull/79`. The Rust startup hook sizes and centers the hidden
 main window from the monitor work area, lowers the configured minimum on unusually small displays,
 and treats sizing failures as non-fatal. A macOS runtime check produced a `1285 x 758` window at
 position `(113, 100)` inside a `1512 x 893` usable area.
+
+The Discovery tab bar follow-up hides native scrollbars while retaining horizontal navigation on
+very narrow windows. It clips vertical overflow, keeps the active underline inside the tab list,
+and defers the optional feed hint until 1240px so it does not crowd the tabs. This fixes the
+scrollbars exposed when the adaptive window opened at a narrower width.
 
 The primary worktree is checked out on the PR branch. Earlier README, Cairn, and duplicate local
 window edits were split into three commits and pushed to recovery branch
@@ -26,8 +31,10 @@ Monitor PR #79 checks and address any failures before merge review.
 
 ## Verification
 
-`pnpm check` passed 91 frontend files and 427 tests plus the production build. Rust format and check
+`pnpm check` passed 92 frontend files and 428 tests plus the production build. Rust format and check
 passed; 586 Rust tests passed with 2 intentional external-service ignores. Focused window-layout
-tests passed 2/2, `git diff --check` passed, and the macOS runtime size matched the expected 85%.
+tests passed 2/2. The Discovery interaction regression test passed, `git diff --check` passed, and
+runtime visual verification confirmed the top navigation no longer shows horizontal or vertical
+native scrollbars. The macOS runtime size matched the expected 85%.
 
 Success: implementation verified; PR review and merge remain pending.

--- a/.cairn/items/adaptive-main-window.md
+++ b/.cairn/items/adaptive-main-window.md
@@ -1,0 +1,33 @@
+# Adaptive main window
+
+## Goal
+
+Size Harbor's main window to 85% of the current monitor work area before it becomes visible, while
+remaining usable on small displays and across Retina or multi-monitor setups. Done means the window
+stays inside the usable desktop area, the calculation has focused tests, and the change is delivered
+through a clean pull request.
+
+## Current state
+
+Commit `a3ddfb99c9cbf3b51f4df0fd0308854d55f928f2` is pushed on branch
+`fix/adaptive-main-window-size-20260904`. Ready PR #79 is open at
+`https://github.com/Excelius-Wang/harbor/pull/79`. The Rust startup hook sizes and centers the hidden
+main window from the monitor work area, lowers the configured minimum on unusually small displays,
+and treats sizing failures as non-fatal. A macOS runtime check produced a `1285 x 758` window at
+position `(113, 100)` inside a `1512 x 893` usable area.
+
+The primary worktree is checked out on the PR branch. Earlier README, Cairn, and duplicate local
+window edits were split into three commits and pushed to recovery branch
+`checkpoint/github-actions-administration-20260830`; they are not part of PR #79.
+
+## Next action
+
+Monitor PR #79 checks and address any failures before merge review.
+
+## Verification
+
+`pnpm check` passed 91 frontend files and 427 tests plus the production build. Rust format and check
+passed; 586 Rust tests passed with 2 intentional external-service ignores. Focused window-layout
+tests passed 2/2, `git diff --check` passed, and the macOS runtime size matched the expected 85%.
+
+Success: implementation verified; PR review and merge remain pending.

--- a/CAIRN.md
+++ b/CAIRN.md
@@ -4,4 +4,4 @@
 
 ## Current item
 
-`.cairn/items/github-web-parity.md`
+`.cairn/items/adaptive-main-window.md`

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,6 +5,7 @@ mod github;
 mod github_oauth;
 mod plugins;
 mod repository_context;
+mod window_layout;
 
 use tauri::Manager;
 
@@ -21,6 +22,15 @@ fn update_tray_menu(
 pub fn run() {
     let builder = tauri::Builder::default()
         .manage(app_state::AppState::default())
+        .setup(|app| {
+            if let Some(window) = app.get_webview_window("main") {
+                if let Err(error) = window_layout::fit_to_current_monitor(&window) {
+                    eprintln!("failed to fit main window to monitor: {error}");
+                }
+            }
+
+            Ok(())
+        })
         .plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
             // When attempting to start a second instance, focus the existing main window
             if let Some(window) = app.get_webview_window("main") {

--- a/src-tauri/src/window_layout.rs
+++ b/src-tauri/src/window_layout.rs
@@ -1,0 +1,83 @@
+use tauri::{PhysicalPosition, PhysicalRect, PhysicalSize, Runtime, WebviewWindow};
+
+const SCREEN_USAGE: f64 = 0.85;
+const MIN_WINDOW_WIDTH: f64 = 900.0;
+const MIN_WINDOW_HEIGHT: f64 = 620.0;
+
+#[derive(Debug, PartialEq)]
+struct WindowGeometry {
+    size: PhysicalSize<u32>,
+    min_size: PhysicalSize<u32>,
+    position: PhysicalPosition<i32>,
+}
+
+fn calculate_window_geometry(
+    work_area: &PhysicalRect<i32, u32>,
+    scale_factor: f64,
+) -> WindowGeometry {
+    let width = (f64::from(work_area.size.width) * SCREEN_USAGE).round() as u32;
+    let height = (f64::from(work_area.size.height) * SCREEN_USAGE).round() as u32;
+    let min_width = ((MIN_WINDOW_WIDTH * scale_factor).round() as u32).min(width);
+    let min_height = ((MIN_WINDOW_HEIGHT * scale_factor).round() as u32).min(height);
+
+    WindowGeometry {
+        size: PhysicalSize::new(width, height),
+        min_size: PhysicalSize::new(min_width, min_height),
+        position: PhysicalPosition::new(
+            work_area.position.x + ((work_area.size.width - width) / 2) as i32,
+            work_area.position.y + ((work_area.size.height - height) / 2) as i32,
+        ),
+    }
+}
+
+pub fn fit_to_current_monitor<R: Runtime>(window: &WebviewWindow<R>) -> tauri::Result<()> {
+    let monitor = match window.current_monitor()? {
+        Some(monitor) => Some(monitor),
+        None => window.primary_monitor()?,
+    };
+    let Some(monitor) = monitor else {
+        return Ok(());
+    };
+
+    let geometry = calculate_window_geometry(monitor.work_area(), monitor.scale_factor());
+
+    // Lower the configured minimum first when the display itself is unusually small.
+    window.set_min_size(Some(geometry.min_size))?;
+    window.set_size(geometry.size)?;
+    window.set_position(geometry.position)?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn uses_eighty_five_percent_of_the_monitor_work_area() {
+        let work_area = PhysicalRect {
+            position: PhysicalPosition::new(0, 112),
+            size: PhysicalSize::new(3024, 1786),
+        };
+
+        let geometry = calculate_window_geometry(&work_area, 2.0);
+
+        assert_eq!(geometry.size, PhysicalSize::new(2570, 1518));
+        assert_eq!(geometry.min_size, PhysicalSize::new(1800, 1240));
+        assert_eq!(geometry.position, PhysicalPosition::new(227, 246));
+    }
+
+    #[test]
+    fn keeps_the_window_within_an_unusually_small_work_area() {
+        let work_area = PhysicalRect {
+            position: PhysicalPosition::new(-800, 0),
+            size: PhysicalSize::new(800, 560),
+        };
+
+        let geometry = calculate_window_geometry(&work_area, 1.0);
+
+        assert_eq!(geometry.size, PhysicalSize::new(680, 476));
+        assert_eq!(geometry.min_size, geometry.size);
+        assert_eq!(geometry.position, PhysicalPosition::new(-740, 42));
+    }
+}

--- a/src/features/github/github-discovery-view.interaction.test.tsx
+++ b/src/features/github/github-discovery-view.interaction.test.tsx
@@ -1,0 +1,46 @@
+// @vitest-environment jsdom
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { GitHubDiscoveryView } from "./github-discovery-view";
+
+vi.mock("@tauri-apps/api/core", () => ({ isTauri: () => false }));
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: "en" } }),
+}));
+
+beforeAll(() => {
+  class ResizeObserverMock implements ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+
+  vi.stubGlobal("ResizeObserver", ResizeObserverMock);
+});
+
+afterEach(() => cleanup());
+
+describe("GitHub discovery navigation", () => {
+  it("keeps overflow available without showing native scrollbars", () => {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+    render(
+      <QueryClientProvider client={client}>
+        <GitHubDiscoveryView onSelectRepository={() => {}} />
+      </QueryClientProvider>
+    );
+
+    const tabList = screen.getByRole("tablist");
+    const activeTab = screen.getByRole("tab", { name: "workspace.discovery.tabs.feed" });
+    const feedWindow = screen.getByText("workspace.discovery.feedWindow");
+
+    expect(tabList.className).toContain("scrollbar-none");
+    expect(tabList.className).toContain("overflow-x-auto");
+    expect(tabList.className).toContain("overflow-y-hidden");
+    expect(activeTab.className).toContain("after:bottom-0!");
+    expect(feedWindow.className).toContain("min-[1240px]:block");
+    expect(feedWindow.className).not.toContain("min-[900px]:block");
+  });
+});

--- a/src/features/github/github-discovery-view.tsx
+++ b/src/features/github/github-discovery-view.tsx
@@ -715,9 +715,9 @@ export function GitHubDiscoveryView({
             <Tabs value={tab} onValueChange={changeTab} className="min-w-0 gap-0">
               <TabsList
                 variant="line"
-                className="h-9 max-w-full justify-start gap-4 overflow-x-auto p-0"
+                className="scrollbar-none h-9 max-w-full justify-start gap-4 overflow-x-auto overflow-y-hidden p-0"
               >
-                <TabsTrigger value="feed" className="px-1.5 text-xs">
+                <TabsTrigger value="feed" className="px-1.5 text-xs after:bottom-0!">
                   <UsersRound /> {t("workspace.discovery.tabs.feed")}
                 </TabsTrigger>
                 {SEARCH_TABS.map((searchKind) => {
@@ -732,7 +732,11 @@ export function GitHubDiscoveryView({
                             ? GitPullRequest
                             : UserRound;
                   return (
-                    <TabsTrigger key={searchKind} value={searchKind} className="px-1.5 text-xs">
+                    <TabsTrigger
+                      key={searchKind}
+                      value={searchKind}
+                      className="px-1.5 text-xs after:bottom-0!"
+                    >
                       <Icon /> {t(`workspace.discovery.tabs.${searchKind}`)}
                     </TabsTrigger>
                   );
@@ -740,7 +744,7 @@ export function GitHubDiscoveryView({
               </TabsList>
             </Tabs>
             {tab === "feed" ? (
-              <span className="text-muted-foreground hidden pb-2 text-[10px] min-[900px]:block">
+              <span className="text-muted-foreground hidden pb-2 text-[10px] min-[1240px]:block">
                 {t("workspace.discovery.feedWindow")}
               </span>
             ) : (


### PR DESCRIPTION
## Summary
- size the main window to 85% of the current monitor work area before it becomes visible
- center the window using physical monitor coordinates for Retina and multi-monitor setups
- lower the minimum size on unusually small displays and keep sizing failures non-fatal
- hide native scrollbars in the Discovery tab navigation while retaining horizontal overflow for very narrow windows
- keep the active-tab underline inside the tab bar and defer the optional feed hint at narrower widths

## Verification
- `pnpm check` (92 test files, 428 tests, production build)
- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `cargo test --manifest-path src-tauri/Cargo.toml` (586 passed, 2 ignored)
- focused Discovery navigation regression test
- Retina geometry check: a 3024 x 1786 physical work area produces a 2570 x 1518 physical window (1285 x 759 logical at 2x)
- macOS visual check: no horizontal or vertical native scrollbar in the Discovery tab navigation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Main windows now automatically fit the current monitor with a centered layout sized to approximately 85% of the available work area.
  * Window sizing adapts to display scaling and constrained screen dimensions.
  * If the current monitor cannot be detected, the primary monitor is used when available.
  * Window setup continues normally if automatic sizing cannot be applied.
  * GitHub Discovery tabs now support horizontal overflow, improved active-tab indicators, and more responsive feed navigation across window sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->