### PR TITLE
Add a native frosted glass workspace

### DIFF
--- a/.cairn/items/adaptive-main-window.md
+++ b/.cairn/items/adaptive-main-window.md
@@ -27,7 +27,7 @@ window edits were split into three commits and pushed to recovery branch
 
 ## Next action
 
-Monitor PR #79 checks and address any failures before merge review.
+Review and merge PR #79. All CodeQL and CodeRabbit checks passed on commit `cb16133`.
 
 ## Verification
 

--- a/.cairn/items/glass-workspace.md
+++ b/.cairn/items/glass-workspace.md
@@ -8,10 +8,10 @@ and interaction behavior, and remains readable with reduced-transparency and lig
 
 ## Current state
 
-Branch `feat/glass-workspace-20260904` is based on the adaptive-window PR branch. Harbor already has
-transparent Tauri windows and semantic glass utilities. The implementation now uses Tauri's native
-macOS `underWindowBackground` material for main and child windows, synchronizes the native material
-with Harbor's resolved theme, and makes the shared `WindowFrame` glass by default. Existing
+Commit `d12cde0` is pushed on branch `feat/glass-workspace-20260904`. Stacked PR #80 targets the
+adaptive-window branch at `https://github.com/Excelius-Wang/harbor/pull/80`. The implementation uses
+Tauri's native macOS `underWindowBackground` material for main and child windows, synchronizes the
+native material with Harbor's resolved theme, and makes the shared `WindowFrame` glass by default. Existing
 `harbor-glass`, popover, command, and sheet utilities now share calibrated translucent tokens, while
 the new `harbor-content` surface gives code and content areas a deeper tint for readability. Major
 GitHub views and Settings use these shared surfaces without changing information architecture,
@@ -19,7 +19,7 @@ components, icon family, copy, or behavior.
 
 ## Next action
 
-Commit and push the verified implementation, then open a stacked pull request for review.
+Collect visual feedback on the first glass pass and adjust the shared opacity tokens if requested.
 
 ## Verification
 

--- a/.cairn/items/glass-workspace.md
+++ b/.cairn/items/glass-workspace.md
@@ -8,7 +8,8 @@ and interaction behavior, and remains readable with reduced-transparency and lig
 
 ## Current state
 
-Commit `d12cde0` is pushed on branch `feat/glass-workspace-20260904`. Stacked PR #80 targets the
+The glass workspace and follow-up fixes are committed through `fe23e8e` on branch
+`feat/glass-workspace-20260904`. Stacked PR #80 targets the
 adaptive-window branch at `https://github.com/Excelius-Wang/harbor/pull/80`. The implementation uses
 Tauri's native macOS `underWindowBackground` material for main and child windows, synchronizes the
 native material with Harbor's resolved theme, and makes the shared `WindowFrame` glass by default. Existing
@@ -23,19 +24,27 @@ came from compositing the original blue-gray dark tokens over a bright source. D
 the native `hudWindow` effect after theme resolution and uses deeper smoke-black window, chrome,
 content, and overlay tokens. Light mode is unchanged.
 
+The primary-navigation separator is also contained within the sidebar. Its shadcn base class applies
+an orientation-scoped `w-full`, so the earlier plain `w-auto` did not win and its horizontal margins
+made the line cross the sidebar border. The call site now overrides width in the same orientation
+variant, preserving the shared Separator component and both compact and expanded layouts.
+
 ## Next action
 
-Collect visual feedback on the first glass pass and adjust the shared opacity tokens if requested.
+Collect further visual feedback on the glass workspace and address any remaining layout details.
 
 ## Verification
 
-`pnpm check` passes 94 frontend files and 430 tests plus the production build. `cargo check
+`pnpm check` passes 95 frontend files and 431 tests plus the production build. `cargo check
 --manifest-path src-tauri/Cargo.toml` passes. Focused glass, theme synchronization, and Discovery
 tests pass 3/3. The macOS runtime was reviewed over both dark and light desktop content at the
 adaptive default size, and the browser-rendered light theme was reviewed separately. The too-light
 dark-mode reproduction was rerun against the same white desktop background after the correction;
 the content now stays deep gray while retaining the native frosted material. The native-effect test
-failed before the correction and passes afterward.
+failed before the correction and passes afterward. The sidebar-separator regression test also failed
+before its fix and passes afterward. Browser layout measurements confirm that the separator ends at
+204px inside the expanded sidebar's 217px right edge and at 46px inside the compact sidebar's 55px
+right edge.
 
 Success: the desktop background reads through every major workspace region without compromising
 text, list, focus, or light-theme readability; code and diff surfaces inherit the same deeper

--- a/.cairn/items/glass-workspace.md
+++ b/.cairn/items/glass-workspace.md
@@ -1,0 +1,33 @@
+# Frosted glass workspace
+
+## Goal
+
+Create a reviewable macOS-first frosted-glass version of Harbor that includes the code and content
+areas, reuses the existing theme and shadcn/Tauri infrastructure, preserves information architecture
+and interaction behavior, and remains readable with reduced-transparency and light-theme fallbacks.
+
+## Current state
+
+Branch `feat/glass-workspace-20260904` is based on the adaptive-window PR branch. Harbor already has
+transparent Tauri windows and semantic glass utilities. The implementation now uses Tauri's native
+macOS `underWindowBackground` material for main and child windows, synchronizes the native material
+with Harbor's resolved theme, and makes the shared `WindowFrame` glass by default. Existing
+`harbor-glass`, popover, command, and sheet utilities now share calibrated translucent tokens, while
+the new `harbor-content` surface gives code and content areas a deeper tint for readability. Major
+GitHub views and Settings use these shared surfaces without changing information architecture,
+components, icon family, copy, or behavior.
+
+## Next action
+
+Commit and push the verified implementation, then open a stacked pull request for review.
+
+## Verification
+
+`pnpm check` passes 94 frontend files and 430 tests plus the production build. `cargo check
+--manifest-path src-tauri/Cargo.toml` passes. Focused glass, theme synchronization, and Discovery
+tests pass 3/3. The macOS runtime was reviewed over both dark and light desktop content at the
+adaptive default size, and the browser-rendered light theme was reviewed separately.
+
+Success: the desktop background reads through every major workspace region without compromising
+text, list, focus, or light-theme readability; code and diff surfaces inherit the same deeper
+content material, and reduced transparency falls back to the solid semantic background.

--- a/.cairn/items/glass-workspace.md
+++ b/.cairn/items/glass-workspace.md
@@ -8,7 +8,7 @@ and interaction behavior, and remains readable with reduced-transparency and lig
 
 ## Current state
 
-The glass workspace and follow-up fixes are committed through `fe23e8e` on branch
+The glass workspace and follow-up fixes are committed through `4f24d5b` on branch
 `feat/glass-workspace-20260904`. Stacked PR #80 targets the
 adaptive-window branch at `https://github.com/Excelius-Wang/harbor/pull/80`. The implementation uses
 Tauri's native macOS `underWindowBackground` material for main and child windows, synchronizes the
@@ -21,8 +21,11 @@ components, icon family, copy, or behavior.
 The first pass looked too light over white desktop content. Reproducing it against the same white
 browser background showed that `underWindowBackground` was only a secondary factor: the main lift
 came from compositing the original blue-gray dark tokens over a bright source. Dark mode now reapplies
-the native `hudWindow` effect after theme resolution and uses deeper smoke-black window, chrome,
-content, and overlay tokens. Light mode is unchanged.
+the native `hudWindow` effect after theme resolution and uses smoke-black window, chrome, content,
+and overlay tokens. The window and pane layers previously composed to roughly 92% opacity, which
+made the native material look solid; the current deep-color/lower-alpha calibration composes the
+content surface to roughly 80% so the material reads again without returning to the washed-out first
+pass. Light mode is unchanged.
 
 The primary-navigation separator is also contained within the sidebar. Its shadcn base class applies
 an orientation-scoped `w-full`, so the earlier plain `w-auto` did not win and its horizontal margins
@@ -31,7 +34,7 @@ variant, preserving the shared Separator component and both compact and expanded
 
 ## Next action
 
-Collect further visual feedback on the glass workspace and address any remaining layout details.
+Review PR #80 and collect final visual feedback on the balanced dark glass calibration.
 
 ## Verification
 
@@ -40,7 +43,9 @@ Collect further visual feedback on the glass workspace and address any remaining
 tests pass 3/3. The macOS runtime was reviewed over both dark and light desktop content at the
 adaptive default size, and the browser-rendered light theme was reviewed separately. The too-light
 dark-mode reproduction was rerun against the same white desktop background after the correction;
-the content now stays deep gray while retaining the native frosted material. The native-effect test
+the content now stays deep gray while retaining the native frosted material. A high-contrast gradient
+backdrop stress test confirms distinct translucent title, navigation, content, and rail layers after
+the final alpha correction. The native-effect test
 failed before the correction and passes afterward. The sidebar-separator regression test also failed
 before its fix and passes afterward. Browser layout measurements confirm that the separator ends at
 204px inside the expanded sidebar's 217px right edge and at 46px inside the compact sidebar's 55px

--- a/.cairn/items/glass-workspace.md
+++ b/.cairn/items/glass-workspace.md
@@ -17,6 +17,12 @@ the new `harbor-content` surface gives code and content areas a deeper tint for 
 GitHub views and Settings use these shared surfaces without changing information architecture,
 components, icon family, copy, or behavior.
 
+The first pass looked too light over white desktop content. Reproducing it against the same white
+browser background showed that `underWindowBackground` was only a secondary factor: the main lift
+came from compositing the original blue-gray dark tokens over a bright source. Dark mode now reapplies
+the native `hudWindow` effect after theme resolution and uses deeper smoke-black window, chrome,
+content, and overlay tokens. Light mode is unchanged.
+
 ## Next action
 
 Collect visual feedback on the first glass pass and adjust the shared opacity tokens if requested.
@@ -26,7 +32,10 @@ Collect visual feedback on the first glass pass and adjust the shared opacity to
 `pnpm check` passes 94 frontend files and 430 tests plus the production build. `cargo check
 --manifest-path src-tauri/Cargo.toml` passes. Focused glass, theme synchronization, and Discovery
 tests pass 3/3. The macOS runtime was reviewed over both dark and light desktop content at the
-adaptive default size, and the browser-rendered light theme was reviewed separately.
+adaptive default size, and the browser-rendered light theme was reviewed separately. The too-light
+dark-mode reproduction was rerun against the same white desktop background after the correction;
+the content now stays deep gray while retaining the native frosted material. The native-effect test
+failed before the correction and passes afterward.
 
 Success: the desktop background reads through every major workspace region without compromising
 text, list, focus, or light-theme readability; code and diff surfaces inherit the same deeper

--- a/CAIRN.md
+++ b/CAIRN.md
@@ -4,4 +4,4 @@
 
 ## Current item
 
-`.cairn/items/adaptive-main-window.md`
+`.cairn/items/glass-workspace.md`

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -28,8 +28,13 @@
         "minHeight": 620,
         "decorations": false,
         "transparent": true,
+        "windowEffects": {
+          "effects": ["underWindowBackground"],
+          "state": "followsWindowActiveState",
+          "radius": 10
+        },
         "center": true,
-        "shadow": false,
+        "shadow": true,
         "visible": false
       }
     ],

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -29,7 +29,7 @@
         "decorations": false,
         "transparent": true,
         "windowEffects": {
-          "effects": ["underWindowBackground"],
+          "effects": ["hudWindow"],
           "state": "followsWindowActiveState",
           "radius": 10
         },

--- a/src/components/main-title-bar.tsx
+++ b/src/components/main-title-bar.tsx
@@ -67,7 +67,7 @@ export function MainTitleBar({ onOpenCommand }: MainTitleBarProps) {
       minimizable: false,
       decorations: false,
       transparent: true,
-      shadow: false,
+      shadow: true,
       alwaysOnTop: true,
       parent: "main",
     });

--- a/src/components/theme-provider.interaction.test.tsx
+++ b/src/components/theme-provider.interaction.test.tsx
@@ -1,0 +1,44 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ThemeProvider } from "./theme-provider";
+
+const nativeWindow = vi.hoisted(() => ({
+  setTheme: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({ isTauri: () => true }));
+vi.mock("@tauri-apps/api/window", () => ({ getCurrentWindow: () => nativeWindow }));
+
+beforeEach(() => {
+  localStorage.clear();
+  document.documentElement.classList.remove("light", "dark");
+  vi.stubGlobal(
+    "matchMedia",
+    vi.fn().mockReturnValue({
+      matches: false,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    })
+  );
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+describe("ThemeProvider", () => {
+  it("keeps the native vibrancy appearance in sync with the app theme", async () => {
+    render(
+      <ThemeProvider defaultTheme="dark" storageKey="test-theme">
+        <span>Harbor</span>
+      </ThemeProvider>
+    );
+
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+    await waitFor(() => expect(nativeWindow.setTheme).toHaveBeenCalledWith("dark"));
+  });
+});

--- a/src/components/theme-provider.interaction.test.tsx
+++ b/src/components/theme-provider.interaction.test.tsx
@@ -5,11 +5,19 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ThemeProvider } from "./theme-provider";
 
 const nativeWindow = vi.hoisted(() => ({
+  setEffects: vi.fn().mockResolvedValue(undefined),
   setTheme: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock("@tauri-apps/api/core", () => ({ isTauri: () => true }));
-vi.mock("@tauri-apps/api/window", () => ({ getCurrentWindow: () => nativeWindow }));
+vi.mock("@tauri-apps/api/window", () => ({
+  Effect: {
+    HudWindow: "hudWindow",
+    UnderWindowBackground: "underWindowBackground",
+  },
+  EffectState: { FollowsWindowActiveState: "followsWindowActiveState" },
+  getCurrentWindow: () => nativeWindow,
+}));
 
 beforeEach(() => {
   localStorage.clear();
@@ -40,5 +48,10 @@ describe("ThemeProvider", () => {
 
     expect(document.documentElement.classList.contains("dark")).toBe(true);
     await waitFor(() => expect(nativeWindow.setTheme).toHaveBeenCalledWith("dark"));
+    expect(nativeWindow.setEffects).toHaveBeenCalledWith({
+      effects: ["hudWindow"],
+      state: "followsWindowActiveState",
+      radius: 10,
+    });
   });
 });

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -1,4 +1,6 @@
 import { createContext, useContext, useEffect, useState } from "react";
+import { isTauri } from "@tauri-apps/api/core";
+import { getCurrentWindow } from "@tauri-apps/api/window";
 
 type Theme = "dark" | "light" | "system";
 
@@ -32,17 +34,28 @@ export function ThemeProvider({
 
   useEffect(() => {
     const root = window.document.documentElement;
-    root.classList.remove("light", "dark");
+    const colorScheme = window.matchMedia("(prefers-color-scheme: dark)");
 
-    if (theme === "system") {
-      const systemTheme = window.matchMedia("(prefers-color-scheme: dark)").matches
-        ? "dark"
-        : "light";
-      root.classList.add(systemTheme);
-      return;
-    }
+    const applyTheme = () => {
+      const resolvedTheme = theme === "system" ? (colorScheme.matches ? "dark" : "light") : theme;
 
-    root.classList.add(theme);
+      root.classList.remove("light", "dark");
+      root.classList.add(resolvedTheme);
+
+      if (isTauri()) {
+        void getCurrentWindow()
+          .setTheme(resolvedTheme)
+          .catch((error) => {
+            console.warn("Failed to synchronize the native window theme:", error);
+          });
+      }
+    };
+
+    applyTheme();
+    if (theme !== "system") return;
+
+    colorScheme.addEventListener("change", applyTheme);
+    return () => colorScheme.removeEventListener("change", applyTheme);
   }, [theme]);
 
   // Listen for localStorage changes to sync theme across windows

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext, useEffect, useState } from "react";
 import { isTauri } from "@tauri-apps/api/core";
-import { getCurrentWindow } from "@tauri-apps/api/window";
+import { Effect, EffectState, getCurrentWindow } from "@tauri-apps/api/window";
 
 type Theme = "dark" | "light" | "system";
 
@@ -43,10 +43,21 @@ export function ThemeProvider({
       root.classList.add(resolvedTheme);
 
       if (isTauri()) {
-        void getCurrentWindow()
+        const appWindow = getCurrentWindow();
+        const glassEffect =
+          resolvedTheme === "dark" ? Effect.HudWindow : Effect.UnderWindowBackground;
+
+        void appWindow
           .setTheme(resolvedTheme)
+          .then(() =>
+            appWindow.setEffects({
+              effects: [glassEffect],
+              state: EffectState.FollowsWindowActiveState,
+              radius: 10,
+            })
+          )
           .catch((error) => {
-            console.warn("Failed to synchronize the native window theme:", error);
+            console.warn("Failed to synchronize the native window appearance:", error);
           });
       }
     };

--- a/src/components/window-frame.interaction.test.tsx
+++ b/src/components/window-frame.interaction.test.tsx
@@ -1,0 +1,24 @@
+// @vitest-environment jsdom
+
+import type { ReactNode } from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { WindowFrame } from "./window-frame";
+
+vi.mock("@tauri-apps/api/core", () => ({ isTauri: () => false }));
+vi.mock("@/components/theme-provider", () => ({
+  ThemeProvider: ({ children }: { children: ReactNode }) => children,
+}));
+
+afterEach(() => cleanup());
+
+describe("WindowFrame", () => {
+  it("uses the shared glass window surface by default", () => {
+    render(<WindowFrame titleBar={<header>Title</header>}>Content</WindowFrame>);
+
+    const frame = screen.getByRole("main").parentElement;
+
+    expect(frame?.className).toContain("harbor-window");
+    expect(frame?.className).not.toContain("bg-background");
+  });
+});

--- a/src/components/window-frame.tsx
+++ b/src/components/window-frame.tsx
@@ -35,7 +35,7 @@ export function WindowFrame({ titleBar, children, className, contentClassName }:
     <ThemeProvider defaultTheme="dark" storageKey="tauri-ui-theme">
       <div
         className={cn(
-          "bg-background flex h-screen w-screen flex-col overflow-hidden",
+          "harbor-window flex h-screen w-screen flex-col overflow-hidden",
           isMaximized ? "" : "border-border rounded-lg border",
           className
         )}

--- a/src/features/github/github-discovery-view.interaction.test.tsx
+++ b/src/features/github/github-discovery-view.interaction.test.tsx
@@ -36,6 +36,7 @@ describe("GitHub discovery navigation", () => {
     const activeTab = screen.getByRole("tab", { name: "workspace.discovery.tabs.feed" });
     const feedWindow = screen.getByText("workspace.discovery.feedWindow");
 
+    expect(tabList.closest("section")?.className).toContain("harbor-content");
     expect(tabList.className).toContain("scrollbar-none");
     expect(tabList.className).toContain("overflow-x-auto");
     expect(tabList.className).toContain("overflow-y-hidden");

--- a/src/features/github/github-discovery-view.tsx
+++ b/src/features/github/github-discovery-view.tsx
@@ -678,7 +678,7 @@ export function GitHubDiscoveryView({
   };
 
   return (
-    <section className="flex min-w-0 flex-1 flex-col bg-[color-mix(in_srgb,var(--background)_95%,transparent)]">
+    <section className="harbor-content flex min-w-0 flex-1 flex-col">
       <header className="shrink-0 border-b border-white/[0.075] px-5 pt-4">
         <div className="mx-auto flex w-full max-w-[1180px] flex-col gap-3">
           <div className="flex items-end justify-between gap-5 max-[760px]:items-start">

--- a/src/features/github/github-gist-view.tsx
+++ b/src/features/github/github-gist-view.tsx
@@ -167,7 +167,7 @@ export function GitHubGists() {
   }, [gists, selectedId, wideLayout]);
 
   return (
-    <section className="@container/gists flex min-w-0 flex-1 flex-col bg-[color-mix(in_srgb,var(--background)_95%,transparent)]">
+    <section className="harbor-content @container/gists flex min-w-0 flex-1 flex-col">
       <header className="flex h-[74px] shrink-0 items-center justify-between gap-4 border-b px-5">
         <div>
           <p className="text-primary/80 text-[10px] font-medium tracking-[0.14em] uppercase">

--- a/src/features/github/github-issue-inbox.tsx
+++ b/src/features/github/github-issue-inbox.tsx
@@ -137,7 +137,7 @@ export function GitHubIssueInbox({
   };
 
   return (
-    <section className="flex min-w-0 flex-1 flex-col bg-[color-mix(in_srgb,var(--background)_95%,transparent)]">
+    <section className="harbor-content flex min-w-0 flex-1 flex-col">
       <header className="h-[74px] shrink-0 border-b border-white/[0.075] px-5">
         <div className="mx-auto flex h-full w-full max-w-[1120px] items-center justify-between gap-4">
           <div>

--- a/src/features/github/github-notifications.tsx
+++ b/src/features/github/github-notifications.tsx
@@ -496,7 +496,7 @@ export function GitHubNotifications({
   const pendingTarget = updateMutation.isPending ? updateMutation.variables : null;
 
   return (
-    <section className="flex min-w-0 flex-1 flex-col bg-[color-mix(in_srgb,var(--background)_95%,transparent)]">
+    <section className="harbor-content flex min-w-0 flex-1 flex-col">
       <header className="h-[74px] shrink-0 border-b border-white/[0.075] px-5">
         <div className="mx-auto flex h-full w-full max-w-[1120px] items-center justify-between gap-4">
           <div>

--- a/src/features/github/github-packages-view.tsx
+++ b/src/features/github/github-packages-view.tsx
@@ -738,7 +738,7 @@ export function GitHubPackagesView() {
   };
 
   return (
-    <section className="@container/packages flex min-w-0 flex-1 flex-col bg-[color-mix(in_srgb,var(--background)_95%,transparent)]">
+    <section className="harbor-content @container/packages flex min-w-0 flex-1 flex-col">
       <header className="flex min-h-[74px] shrink-0 items-center justify-between gap-4 border-b px-5 py-3">
         <div>
           <p className="text-primary/80 text-[10px] font-medium tracking-[0.14em] uppercase">

--- a/src/features/github/github-profile-view.tsx
+++ b/src/features/github/github-profile-view.tsx
@@ -487,7 +487,7 @@ export function GitHubProfileView({
   };
 
   return (
-    <section className="flex min-w-0 flex-1 flex-col bg-[color-mix(in_srgb,var(--background)_95%,transparent)]">
+    <section className="harbor-content flex min-w-0 flex-1 flex-col">
       <header className="flex h-[74px] shrink-0 items-center justify-between gap-4 border-b px-5">
         <div className="flex min-w-0 items-center gap-3">
           {selectedUsername || onBack ? (

--- a/src/features/github/github-project-view.tsx
+++ b/src/features/github/github-project-view.tsx
@@ -264,7 +264,7 @@ export function GitHubProjects() {
   const submitSearch = () => setQuery(draftQuery.trim());
 
   return (
-    <section className="@container/projects flex min-w-0 flex-1 flex-col bg-[color-mix(in_srgb,var(--background)_95%,transparent)]">
+    <section className="harbor-content @container/projects flex min-w-0 flex-1 flex-col">
       <header className="flex h-[74px] shrink-0 items-center justify-between gap-4 border-b px-5">
         <div>
           <p className="text-primary/80 text-[10px] font-medium tracking-[0.14em] uppercase">

--- a/src/features/github/github-pull-request-inbox.tsx
+++ b/src/features/github/github-pull-request-inbox.tsx
@@ -140,7 +140,7 @@ export function GitHubPullRequestInbox({
   };
 
   return (
-    <section className="flex min-w-0 flex-1 flex-col bg-[color-mix(in_srgb,var(--background)_95%,transparent)]">
+    <section className="harbor-content flex min-w-0 flex-1 flex-col">
       <header className="h-[74px] shrink-0 border-b border-white/[0.075] px-5">
         <div className="mx-auto flex h-full w-full max-w-[1120px] items-center justify-between gap-4">
           <div>

--- a/src/features/github/github-repository-browser.tsx
+++ b/src/features/github/github-repository-browser.tsx
@@ -296,7 +296,7 @@ export function GitHubRepositoryBrowser({ onSelectRepository }: GitHubRepository
   if (repositoryError && !repositoriesLoaded) {
     const disconnected = repositoryError.code === "githubNotConnected";
     return (
-      <section className="grid min-w-0 flex-1 place-items-center bg-[color-mix(in_srgb,var(--background)_95%,transparent)] p-6">
+      <section className="harbor-content grid min-w-0 flex-1 place-items-center p-6">
         <Empty className="max-w-lg border border-white/[0.075] bg-white/[0.02]">
           <EmptyHeader>
             <EmptyMedia variant="icon">
@@ -327,7 +327,7 @@ export function GitHubRepositoryBrowser({ onSelectRepository }: GitHubRepository
   }
 
   return (
-    <section className="flex min-w-0 flex-1 flex-col bg-[color-mix(in_srgb,var(--background)_95%,transparent)]">
+    <section className="harbor-content flex min-w-0 flex-1 flex-col">
       <header className="flex h-[74px] shrink-0 items-center justify-between gap-4 border-b border-white/[0.075] px-5">
         <div>
           <p className="text-primary/80 text-[10px] font-medium tracking-[0.14em] uppercase">

--- a/src/features/github/github-repository-invitations-view.tsx
+++ b/src/features/github/github-repository-invitations-view.tsx
@@ -172,7 +172,7 @@ export function GitHubRepositoryInvitations({
   };
 
   return (
-    <section className="flex min-w-0 flex-1 flex-col bg-[color-mix(in_srgb,var(--background)_95%,transparent)]">
+    <section className="harbor-content flex min-w-0 flex-1 flex-col">
       <header className="h-[74px] shrink-0 border-b px-4 sm:px-5">
         <div className="mx-auto flex h-full w-full max-w-[960px] items-center justify-between gap-3">
           <div className="flex min-w-0 items-center gap-3">

--- a/src/features/workspace/harbor-workspace.interaction.test.tsx
+++ b/src/features/workspace/harbor-workspace.interaction.test.tsx
@@ -1,0 +1,63 @@
+// @vitest-environment jsdom
+
+import type { ReactNode } from "react";
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { TooltipProvider } from "@/components/ui/tooltip";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+vi.mock("@/components/main-title-bar", () => ({
+  MainTitleBar: () => null,
+}));
+vi.mock("@/components/window-frame", () => ({
+  WindowFrame: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+vi.mock("@/features/github/github-discovery-view", () => ({
+  GitHubDiscoveryView: () => null,
+}));
+vi.mock("@/features/github/github-gist-view", () => ({
+  GitHubGists: () => null,
+}));
+vi.mock("@/features/github/github-issue-inbox", () => ({
+  GitHubIssueInbox: () => null,
+}));
+vi.mock("@/features/github/github-notifications", () => ({
+  GitHubNotifications: () => null,
+}));
+vi.mock("@/features/github/github-packages-view", () => ({
+  GitHubPackagesView: () => null,
+}));
+vi.mock("@/features/github/github-profile-view", () => ({
+  GitHubProfileView: () => null,
+}));
+vi.mock("@/features/github/github-project-view", () => ({
+  GitHubProjects: () => null,
+}));
+vi.mock("@/features/github/github-pull-request-inbox", () => ({
+  GitHubPullRequestInbox: () => null,
+}));
+vi.mock("@/features/github/github-repository-browser", () => ({
+  GitHubRepositoryBrowser: () => null,
+}));
+vi.mock("./harbor-rail", () => ({
+  HarborRail: () => null,
+}));
+
+import { HarborWorkspace } from "./harbor-workspace";
+
+afterEach(cleanup);
+
+describe("HarborWorkspace navigation", () => {
+  it("keeps the inset separator inside the primary navigation", () => {
+    const { container } = render(
+      <TooltipProvider>
+        <HarborWorkspace />
+      </TooltipProvider>
+    );
+    const separator = container.querySelector('[data-slot="separator"]');
+
+    expect(separator?.className.split(" ")).toContain("data-[orientation=horizontal]:w-auto!");
+  });
+});

--- a/src/features/workspace/harbor-workspace.tsx
+++ b/src/features/workspace/harbor-workspace.tsx
@@ -148,7 +148,7 @@ function PrimaryNavigation({
         })}
       </nav>
 
-      <Separator className="workspace-wide:mx-3 mx-2 w-auto bg-white/8" />
+      <Separator className="workspace-wide:mx-3 mx-2 bg-white/8 data-[orientation=horizontal]:w-auto!" />
       <div className="flex-1" />
 
       <div className="flex flex-col gap-0.5 p-2">

--- a/src/features/workspace/harbor-workspace.tsx
+++ b/src/features/workspace/harbor-workspace.tsx
@@ -261,7 +261,6 @@ export function HarborWorkspace() {
   return (
     <WindowFrame
       titleBar={<MainTitleBar onOpenCommand={() => setCommandOpen(true)} />}
-      className="harbor-window"
       contentClassName="flex min-h-0 flex-1 overflow-hidden"
     >
       <PrimaryNavigation activeSection={activeSection} onSectionChange={setActiveSection} />

--- a/src/index.css
+++ b/src/index.css
@@ -91,12 +91,13 @@
   --ring: #528bff;
   --harbor-chrome: #1e2227;
   --harbor-canvas-edge: #181a1f;
-  --harbor-window-fill: rgb(5 9 15 / 62%);
-  --harbor-glass-fill: rgb(13 18 25 / 68%);
-  --harbor-content-fill: rgb(17 22 30 / 78%);
-  --harbor-elevated-fill: rgb(14 18 25 / 92%);
-  --harbor-glass-edge: rgb(255 255 255 / 10%);
-  --harbor-glass-shadow: rgb(2 6 12 / 58%);
+  /* Window and pane fills stack, so keep the base translucent enough for native vibrancy to read. */
+  --harbor-window-fill: rgb(3 7 12 / 40%);
+  --harbor-glass-fill: rgb(10 15 22 / 52%);
+  --harbor-content-fill: rgb(12 17 25 / 66%);
+  --harbor-elevated-fill: rgb(12 16 23 / 90%);
+  --harbor-glass-edge: rgb(255 255 255 / 12%);
+  --harbor-glass-shadow: rgb(2 6 12 / 52%);
   color-scheme: dark;
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -91,12 +91,12 @@
   --ring: #528bff;
   --harbor-chrome: #1e2227;
   --harbor-canvas-edge: #181a1f;
-  --harbor-window-fill: rgb(14 18 24 / 56%);
-  --harbor-glass-fill: rgb(26 30 39 / 60%);
-  --harbor-content-fill: rgb(31 36 45 / 82%);
-  --harbor-elevated-fill: rgb(25 29 37 / 90%);
-  --harbor-glass-edge: rgb(255 255 255 / 12%);
-  --harbor-glass-shadow: rgb(4 9 16 / 48%);
+  --harbor-window-fill: rgb(5 9 15 / 62%);
+  --harbor-glass-fill: rgb(13 18 25 / 68%);
+  --harbor-content-fill: rgb(17 22 30 / 78%);
+  --harbor-elevated-fill: rgb(14 18 25 / 92%);
+  --harbor-glass-edge: rgb(255 255 255 / 10%);
+  --harbor-glass-shadow: rgb(2 6 12 / 58%);
   color-scheme: dark;
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -117,6 +117,7 @@
 
   body {
     @apply text-foreground bg-transparent;
+
     font-family:
       -apple-system, BlinkMacSystemFont, "SF Pro Text", "SF Pro Display", Inter, ui-sans-serif,
       "Segoe UI", sans-serif;

--- a/src/index.css
+++ b/src/index.css
@@ -57,6 +57,12 @@
   --chart-4: var(--destructive);
   --harbor-chrome: oklch(0.985 0.013 236);
   --harbor-canvas-edge: oklch(0.965 0.014 238);
+  --harbor-window-fill: rgb(238 245 250 / 68%);
+  --harbor-glass-fill: rgb(250 252 255 / 58%);
+  --harbor-content-fill: rgb(247 250 253 / 80%);
+  --harbor-elevated-fill: rgb(250 252 255 / 90%);
+  --harbor-glass-edge: rgb(255 255 255 / 66%);
+  --harbor-glass-shadow: rgb(36 58 78 / 20%);
   --radius: 0.55rem;
   color-scheme: light;
 }
@@ -85,6 +91,12 @@
   --ring: #528bff;
   --harbor-chrome: #1e2227;
   --harbor-canvas-edge: #181a1f;
+  --harbor-window-fill: rgb(14 18 24 / 56%);
+  --harbor-glass-fill: rgb(26 30 39 / 60%);
+  --harbor-content-fill: rgb(31 36 45 / 82%);
+  --harbor-elevated-fill: rgb(25 29 37 / 90%);
+  --harbor-glass-edge: rgb(255 255 255 / 12%);
+  --harbor-glass-shadow: rgb(4 9 16 / 48%);
   color-scheme: dark;
 }
 
@@ -105,12 +117,8 @@
   body {
     @apply text-foreground bg-transparent;
     font-family:
-      Inter,
-      ui-sans-serif,
-      -apple-system,
-      BlinkMacSystemFont,
-      "Segoe UI",
-      sans-serif;
+      -apple-system, BlinkMacSystemFont, "SF Pro Text", "SF Pro Display", Inter, ui-sans-serif,
+      "Segoe UI", sans-serif;
     font-feature-settings: "cv02", "cv03", "cv04", "cv11";
     text-rendering: optimizeLegibility;
   }
@@ -146,22 +154,30 @@
   }
 
   .harbor-glass {
-    border-color: color-mix(in oklch, var(--foreground) 10%, transparent);
-    background: color-mix(in srgb, var(--harbor-chrome) 90%, transparent);
-    box-shadow: inset 0 1px 0 color-mix(in srgb, white 5%, transparent);
-    backdrop-filter: saturate(112%) blur(22px);
-    -webkit-backdrop-filter: saturate(112%) blur(22px);
+    border-color: color-mix(in srgb, var(--harbor-glass-edge) 72%, transparent);
+    background: var(--harbor-glass-fill);
+    box-shadow:
+      inset 0 1px 0 color-mix(in srgb, white 10%, transparent),
+      inset 0 -1px 0 color-mix(in srgb, black 7%, transparent);
+    backdrop-filter: saturate(145%) blur(30px);
+    -webkit-backdrop-filter: saturate(145%) blur(30px);
+  }
+
+  .harbor-content {
+    background: var(--harbor-content-fill);
+    box-shadow: inset 0 1px 0 color-mix(in srgb, white 4%, transparent);
   }
 
   .harbor-popover,
   .harbor-command,
   .harbor-sheet {
-    background: color-mix(in srgb, var(--popover) 96%, transparent);
+    border-color: color-mix(in srgb, var(--harbor-glass-edge) 84%, transparent);
+    background: var(--harbor-elevated-fill);
     box-shadow:
-      0 24px 70px color-mix(in srgb, black 38%, transparent),
-      inset 0 1px 0 color-mix(in srgb, white 6%, transparent);
-    backdrop-filter: saturate(125%) blur(24px);
-    -webkit-backdrop-filter: saturate(125%) blur(24px);
+      0 24px 70px var(--harbor-glass-shadow),
+      inset 0 1px 0 color-mix(in srgb, white 12%, transparent);
+    backdrop-filter: saturate(150%) blur(36px);
+    -webkit-backdrop-filter: saturate(150%) blur(36px);
   }
 }
 
@@ -170,29 +186,29 @@
   isolation: isolate;
   background:
     radial-gradient(
-      900px 560px at 9% -16%,
-      color-mix(in srgb, var(--primary) 8%, transparent),
-      transparent 62%
+      880px 520px at 7% -14%,
+      color-mix(in srgb, var(--primary) 12%, transparent),
+      transparent 60%
     ),
-    linear-gradient(
-      145deg,
-      color-mix(in srgb, var(--background) 92%, var(--harbor-chrome)),
-      var(--background) 54%,
-      color-mix(in srgb, var(--background) 92%, var(--harbor-canvas-edge))
+    radial-gradient(
+      760px 520px at 104% 112%,
+      color-mix(in srgb, var(--primary) 5%, transparent),
+      transparent 68%
     );
+  background-color: var(--harbor-window-fill);
   box-shadow:
-    0 34px 90px rgb(0 0 0 / 34%),
-    inset 0 1px 0 rgb(255 255 255 / 5%);
+    0 34px 90px var(--harbor-glass-shadow),
+    inset 0 1px 0 color-mix(in srgb, white 12%, transparent),
+    inset 0 0 0 1px color-mix(in srgb, var(--harbor-glass-edge) 64%, transparent);
 }
 
 .light .harbor-window {
-  background:
-    radial-gradient(
-      900px 560px at 9% -16%,
-      color-mix(in srgb, var(--primary) 9%, transparent),
-      transparent 62%
-    ),
-    linear-gradient(145deg, var(--harbor-chrome), var(--background));
+  background: radial-gradient(
+    880px 520px at 7% -14%,
+    color-mix(in srgb, var(--primary) 10%, transparent),
+    transparent 60%
+  );
+  background-color: var(--harbor-window-fill);
 }
 
 .harbor-diff {
@@ -437,7 +453,9 @@ button {
 }
 
 @media (prefers-reduced-transparency: reduce) {
+  .harbor-window,
   .harbor-glass,
+  .harbor-content,
   .harbor-popover,
   .harbor-command,
   .harbor-sheet {

--- a/src/lib/window.ts
+++ b/src/lib/window.ts
@@ -11,7 +11,7 @@ const destroyTimers: Record<string, number> = {};
 const destroyVersions: Record<string, number> = {};
 
 const DEFAULT_GLASS_WINDOW_EFFECTS: Effects = {
-  effects: [Effect.UnderWindowBackground],
+  effects: [Effect.HudWindow],
   state: EffectState.FollowsWindowActiveState,
   radius: 10,
 };

--- a/src/lib/window.ts
+++ b/src/lib/window.ts
@@ -1,6 +1,7 @@
 import { isTauri } from "@tauri-apps/api/core";
 import { WebviewWindow } from "@tauri-apps/api/webviewWindow";
 import { LogicalPosition } from "@tauri-apps/api/dpi";
+import { Effect, EffectState, type Effects } from "@tauri-apps/api/window";
 import { emit, once } from "@tauri-apps/api/event";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { isSafeExternalUrl } from "./url-policy";
@@ -8,6 +9,12 @@ import { isSafeExternalUrl } from "./url-policy";
 const createWindowLoading: Record<string, boolean> = {};
 const destroyTimers: Record<string, number> = {};
 const destroyVersions: Record<string, number> = {};
+
+const DEFAULT_GLASS_WINDOW_EFFECTS: Effects = {
+  effects: [Effect.UnderWindowBackground],
+  state: EffectState.FollowsWindowActiveState,
+  radius: 10,
+};
 
 export async function openExternalUrl(url: string) {
   if (!isSafeExternalUrl(url)) return;
@@ -195,6 +202,7 @@ export async function createWindow(
     y?: number;
     decorations?: boolean;
     transparent?: boolean;
+    windowEffects?: Effects;
     alwaysOnTop?: boolean;
     skipTaskbar?: boolean;
     shadow?: boolean;
@@ -244,7 +252,10 @@ export async function createWindow(
     }
 
     // Create new window with centered position
-    const finalOptions = { ...options };
+    const finalOptions = {
+      windowEffects: DEFAULT_GLASS_WINDOW_EFFECTS,
+      ...options,
+    };
     if (options.parent && !options.x && !options.y) {
       const width = options.width || 500;
       const height = options.height || 400;
@@ -292,7 +303,7 @@ export async function openSettingsWindow(title: string) {
     minimizable: false,
     decorations: false,
     transparent: true,
-    shadow: false,
+    shadow: true,
     parent: "main",
   });
 }

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -77,7 +77,7 @@ export default function SettingsPage() {
       contentClassName="flex flex-1 overflow-hidden"
     >
       <Toaster />
-      <aside className="border-border flex w-40 flex-col border-r p-4">
+      <aside className="harbor-glass flex w-40 flex-col border-r p-4">
         <nav className="flex-1 space-y-1">
           {menuItems.map((item) => {
             const Icon = item.icon;
@@ -100,7 +100,7 @@ export default function SettingsPage() {
         </nav>
       </aside>
 
-      <div className="flex-1 overflow-auto">
+      <div className="harbor-content flex-1 overflow-auto">
         <div className="max-w-3xl p-4">
           {activeSection === "appearance" && (
             <div className="space-y-4">


### PR DESCRIPTION
## Summary
- enable Tauri native macOS under-window material for the main and child windows
- reuse Harbor semantic theme and glass utilities for window chrome, content, code, and overlays
- synchronize native material appearance with the resolved Harbor theme
- preserve solid fallbacks for reduced transparency
- keep the existing information architecture and shadcn component foundation

## Design direction
- dark macOS developer tool with restrained Zed-like frosted material
- deeper content tint for code and long-form reading
- lighter chrome tint for title bar and side rails
- existing Harbor blue remains the only interaction accent

## Verification
- `pnpm check` (94 test files, 430 tests, production build)
- `cargo check --manifest-path src-tauri/Cargo.toml`
- focused glass, theme synchronization, and Discovery tests (3/3)
- macOS runtime review over dark and light desktop content
- browser-rendered light-theme review

## Dependency
This is a stacked PR based on #79 so the adaptive window and navigation overflow fixes remain separate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added frosted-glass Harbor workspace styling with improved translucency, blur, borders, shadows, and gradients.
  * Added adaptive light and dark theme behavior, including native window appearance synchronization.
  * Enabled HUD-style window effects and shadows for supported windows.

* **Style**
  * Standardized GitHub views, settings, and workspace surfaces with consistent Harbor content and glass styling.
  * Improved system-font presentation and reduced-transparency accessibility handling.
  * Refined navigation separator spacing and window surface appearance.

* **Documentation**
  * Added documentation covering the Harbor workspace design, status, accessibility, and verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->